### PR TITLE
fix(W-mnebyxwoj1wo): Remove non-atomic write fallback in safeWrite

### DIFF
--- a/engine/shared.js
+++ b/engine/shared.js
@@ -41,16 +41,18 @@ function safeWrite(p, data) {
           try { const ab = new SharedArrayBuffer(4); Atomics.wait(new Int32Array(ab), 0, 0, delay); } catch { /* fallback busy-wait */ const start = Date.now(); while (Date.now() - start < delay) {} }
           continue;
         }
-        // Final attempt failed — fall through to direct write
+        // Final attempt failed — throw to let caller retry
+        try { fs.unlinkSync(tmp); } catch { /* cleanup */ }
+        throw e;
       }
     }
-    // All rename attempts failed — direct write as fallback (not atomic but won't lose data)
+    // All rename attempts exhausted without throw — should not happen, but clean up
     try { fs.unlinkSync(tmp); } catch { /* cleanup */ }
-    fs.writeFileSync(p, content);
+    throw new Error(`[safeWrite] All 5 rename attempts failed for ${p}`);
   } catch (err) {
-    // Even direct write failed — log and clean up tmp
-    console.error(`[safeWrite] FAILED to write ${p}: ${err.message}`);
+    // Clean up tmp if it still exists, then re-throw — never silently swallow
     try { fs.unlinkSync(tmp); } catch { /* cleanup */ }
+    throw err;
   }
 }
 
@@ -102,6 +104,9 @@ function mutateJsonFileLocked(filePath, mutateFn, {
   return withFileLock(lockPath, () => {
     let data = safeJson(filePath);
     if (data === null || typeof data !== 'object') data = Array.isArray(defaultValue) ? [...defaultValue] : { ...defaultValue };
+    // Back up last-known-good state before mutation (best-effort)
+    const backupPath = filePath + '.bak';
+    try { if (fs.existsSync(filePath)) fs.copyFileSync(filePath, backupPath); } catch { /* backup is best-effort */ }
     const next = mutateFn(data);
     const finalData = next === undefined ? data : next;
     safeWrite(filePath, finalData);


### PR DESCRIPTION
## Summary
- **Remove non-atomic `writeFileSync` fallback** in `safeWrite()` (was lines 47-49) — after 5 failed renames, the function now throws instead of silently falling back to a non-atomic write that can corrupt `dispatch.json`
- **Add `.bak` backup** in `mutateJsonFileLocked()` — copies the last-known-good state of the file before each mutation (best-effort, won't block on failure)
- **Fail-loud, not fail-corrupt** — callers (engine tick cycle) will catch the error and retry next tick, preserving data integrity

## Files changed
- `engine/shared.js` — `safeWrite()` and `mutateJsonFileLocked()`

## Build & test
```bash
node test/unit.test.js   # 490 passed, 0 failed, 2 skipped
```

## Test plan
- [ ] Verify `safeWrite` throws on persistent rename failure (mock `fs.renameSync` to always EPERM)
- [ ] Verify `.bak` file is created before mutation in `mutateJsonFileLocked`
- [ ] Verify engine tick cycle recovers gracefully when `safeWrite` throws
- [ ] Verify normal writes still work (atomic rename succeeds on first try)

Built by Minions (Dallas — Engineer)