### PR TITLE
fix(W-mnebz02cwhkh): meeting round timeout and output validation

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -2035,6 +2035,12 @@ async function tickInner() {
   checkSteering(config);
   checkIdleThreshold(config);
 
+  // 1b. Check for meeting round timeouts
+  try {
+    const { checkMeetingTimeouts } = require('./engine/meeting');
+    checkMeetingTimeouts(config);
+  } catch (e) { log('warn', 'check meeting timeouts: ' + e.message); }
+
   // In stopping state, only track agent completions — skip discovery and dispatch
   if (control.state === 'stopping') {
     log('info', `Engine stopping — ${activeProcesses.size} agent(s) still active, skipping discovery/dispatch`);

--- a/engine/meeting.js
+++ b/engine/meeting.js
@@ -6,10 +6,13 @@
 const fs = require('fs');
 const path = require('path');
 const shared = require('./shared');
-const { safeJson, safeWrite, safeRead, uid } = shared;
+const { safeJson, safeWrite, safeRead, uid, ENGINE_DEFAULTS } = shared;
 const queries = require('./queries');
-const { getDispatch } = queries;
+const { getDispatch, getConfig } = queries;
 const { renderPlaybook } = require('./playbook');
+
+/** Patterns that indicate an agent returned no meaningful output */
+const EMPTY_OUTPUT_PATTERNS = ['(no output)', '(no findings)', '(no response)'];
 
 let _engine = null;
 function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
@@ -43,6 +46,7 @@ function createMeeting({ title, agenda, participants }) {
     participants: participants || [],
     createdBy: 'human',
     createdAt: new Date().toISOString(),
+    roundStartedAt: new Date().toISOString(),
     findings: {},
     debate: {},
     conclusion: null,
@@ -180,7 +184,16 @@ function collectMeetingFindings(meetingId, agentId, roundName, output) {
   if (!meeting) return;
 
   const { text } = shared.parseStreamJsonOutput(output, { maxTextLength: 50000 });
-  const content = text || '(no output)';
+  const rawContent = (text || '').trim();
+
+  // Validate output — reject empty or placeholder responses
+  if (!rawContent || EMPTY_OUTPUT_PATTERNS.includes(rawContent)) {
+    e.log('warn', `Meeting ${meetingId}: agent ${agentId} returned empty output for ${roundName} — rejecting`);
+    // Don't record it — agent will be re-dispatched on next tick
+    saveMeeting(meeting);
+    return;
+  }
+  const content = rawContent;
 
   if (roundName === 'investigate') {
     meeting.findings[agentId] = { content, submittedAt: new Date().toISOString() };
@@ -221,10 +234,12 @@ function collectMeetingFindings(meetingId, agentId, roundName, output) {
     if (meeting.status === 'investigating') {
       meeting.status = 'debating';
       meeting.round = 2;
+      meeting.roundStartedAt = new Date().toISOString();
       e.log('info', `Meeting ${meetingId}: all findings in — advancing to debate`);
     } else if (meeting.status === 'debating') {
       meeting.status = 'concluding';
       meeting.round = 3;
+      meeting.roundStartedAt = new Date().toISOString();
       e.log('info', `Meeting ${meetingId}: all debate responses in — advancing to conclusion`);
     }
   }
@@ -246,6 +261,7 @@ function advanceMeetingRound(meetingId) {
   if (!meeting || meeting.status === 'completed') return null;
   if (meeting.status === 'investigating') { meeting.status = 'debating'; meeting.round = 2; }
   else if (meeting.status === 'debating') { meeting.status = 'concluding'; meeting.round = 3; }
+  meeting.roundStartedAt = new Date().toISOString();
   saveMeeting(meeting);
   return meeting;
 }
@@ -259,8 +275,58 @@ function endMeeting(meetingId) {
   return meeting;
 }
 
+/**
+ * Check for meeting rounds that have exceeded the timeout.
+ * Auto-advances to the next round with whatever responses were received.
+ * Called from engine.js tick cycle.
+ */
+function checkMeetingTimeouts(config) {
+  const e = engine();
+  const meetings = getMeetings();
+  const timeout = (config.engine || {}).meetingRoundTimeout
+    || ENGINE_DEFAULTS.meetingRoundTimeout;
+
+  for (const meeting of meetings) {
+    if (meeting.status === 'completed') continue;
+    if (!meeting.roundStartedAt) continue;
+
+    const elapsed = Date.now() - new Date(meeting.roundStartedAt).getTime();
+    if (elapsed < timeout) continue;
+
+    const respondedCount = meeting.status === 'investigating'
+      ? Object.keys(meeting.findings || {}).length
+      : meeting.status === 'debating'
+        ? Object.keys(meeting.debate || {}).length
+        : 0;
+    const totalCount = meeting.participants.length;
+
+    if (meeting.status === 'investigating') {
+      e.log('warn', `Meeting ${meeting.id}: round 1 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to debate`);
+      meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: `Round 1 timed out — ${respondedCount}/${totalCount} findings received`, at: new Date().toISOString() });
+      meeting.status = 'debating';
+      meeting.round = 2;
+      meeting.roundStartedAt = new Date().toISOString();
+      saveMeeting(meeting);
+    } else if (meeting.status === 'debating') {
+      e.log('warn', `Meeting ${meeting.id}: round 2 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to conclusion`);
+      meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: `Round 2 timed out — ${respondedCount}/${totalCount} debate responses received`, at: new Date().toISOString() });
+      meeting.status = 'concluding';
+      meeting.round = 3;
+      meeting.roundStartedAt = new Date().toISOString();
+      saveMeeting(meeting);
+    } else if (meeting.status === 'concluding') {
+      e.log('warn', `Meeting ${meeting.id}: conclusion round timed out after ${Math.round(elapsed / 60000)}min — ending meeting without conclusion`);
+      meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: 'Conclusion round timed out — meeting ended without conclusion', at: new Date().toISOString() });
+      meeting.status = 'completed';
+      meeting.completedAt = new Date().toISOString();
+      saveMeeting(meeting);
+    }
+  }
+}
+
 module.exports = {
   MEETINGS_DIR, getMeetings, getMeeting, saveMeeting, createMeeting,
-  discoverMeetingWork, collectMeetingFindings,
+  discoverMeetingWork, collectMeetingFindings, checkMeetingTimeouts,
   addMeetingNote, advanceMeetingRound, endMeeting,
+  EMPTY_OUTPUT_PATTERNS,
 };

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -245,6 +245,7 @@ const ENGINE_DEFAULTS = {
   shutdownTimeout: 300000, // 5min — max wait for active agents during graceful shutdown
   allowTempAgents: false, // opt-in: spawn ephemeral agents when all permanent agents are busy
   autoDecompose: true, // auto-decompose implement:large items into sub-tasks
+  meetingRoundTimeout: 600000, // 10min per meeting round before auto-advance
 };
 
 const DEFAULT_AGENTS = {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4123,6 +4123,46 @@ async function testMeetings() {
     assert.ok(routing.includes('meeting'), 'routing.md should have meeting work type');
   });
 
+  // Round timeout
+  await test('checkMeetingTimeouts exported and callable from engine tick', () => {
+    assert.ok(meetingSrc.includes('checkMeetingTimeouts') && meetingSrc.includes('module.exports'),
+      'checkMeetingTimeouts should be exported from meeting.js');
+    assert.ok(engineSrc.includes('checkMeetingTimeouts'),
+      'Engine tick should call checkMeetingTimeouts');
+  });
+
+  await test('meeting round timeout is configurable via meetingRoundTimeout', () => {
+    const sharedSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(sharedSrc.includes('meetingRoundTimeout') && sharedSrc.includes('600000'),
+      'ENGINE_DEFAULTS should include meetingRoundTimeout of 600000ms (10min)');
+    assert.ok(meetingSrc.includes('meetingRoundTimeout'),
+      'meeting.js should read meetingRoundTimeout from config');
+  });
+
+  await test('meetings track roundStartedAt timestamp', () => {
+    assert.ok(meetingSrc.includes('roundStartedAt'),
+      'Should track when each round started for timeout calculation');
+  });
+
+  await test('timeout auto-advances round with partial responses', () => {
+    assert.ok(meetingSrc.includes('timed out') && meetingSrc.includes('advancing'),
+      'Should log timeout and advance to next round');
+    assert.ok(meetingSrc.includes("type: 'timeout'"),
+      'Should record timeout events in meeting transcript');
+  });
+
+  await test('output validation rejects empty/placeholder responses', () => {
+    assert.ok(meetingSrc.includes('EMPTY_OUTPUT_PATTERNS'),
+      'Should define patterns for empty/placeholder output');
+    assert.ok(meetingSrc.includes("'(no output)'") && meetingSrc.includes('rejecting'),
+      'Should reject (no output) and log a warning');
+  });
+
+  await test('conclusion timeout ends meeting without conclusion', () => {
+    assert.ok(meetingSrc.includes('concluding') && meetingSrc.includes('ended without conclusion'),
+      'Should end meeting if conclusion round times out');
+  });
+
   // CC retry button
   await test('CC shows retry button on fetch failure', () => {
     const ccSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'command-center.js'), 'utf8');


### PR DESCRIPTION
## Summary
- Add configurable per-round timeout (10min default via `engine.meetingRoundTimeout`) to the meeting system
- Reject empty/placeholder agent responses (`(no output)`, `(no findings)`, `(no response)`) — agents returning these are not recorded and get re-dispatched
- Auto-advance rounds on timeout with whatever responses were received; timeout events recorded in meeting transcript
- Conclusion round timeout ends the meeting gracefully

## Files changed
- `engine/meeting.js` — output validation, `checkMeetingTimeouts()`, `roundStartedAt` tracking, `EMPTY_OUTPUT_PATTERNS`
- `engine/shared.js` — `meetingRoundTimeout: 600000` added to `ENGINE_DEFAULTS`
- `engine.js` — call `checkMeetingTimeouts(config)` in tick cycle
- `test/unit.test.js` — 6 new tests for timeout and validation behavior

## Build & test
```bash
npm test   # 496 passed, 0 failed, 2 skipped
```

## Test plan
- [ ] Verify `meetingRoundTimeout` is respected from config.json override
- [ ] Create a meeting, wait for round timeout, confirm auto-advance in transcript
- [ ] Confirm agent returning "(no output)" is not counted as submitted
- [ ] Confirm conclusion timeout ends meeting with `completed` status
- [ ] Verify existing meetings without `roundStartedAt` are skipped (no crash)

Built by Minions (Ralph — Engineer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)