### PR TITLE
fix(W-mnebz43b7sxo): Warn on unresolved playbook template variables

### DIFF
--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -291,6 +291,22 @@ function renderPlaybook(type, vars) {
     content = content.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), String(val));
   }
 
+  // Warn on variables that resolved to empty string
+  const emptyVars = Object.entries(allVars)
+    .filter(([, val]) => String(val) === '')
+    .map(([key]) => key);
+  if (emptyVars.length > 0) {
+    const msg = `Playbook "${type}": template variables resolved to empty string: ${emptyVars.join(', ')}`;
+    try { engine().log('warn', msg); } catch { /* engine not ready */ }
+  }
+
+  // Warn on any remaining unresolved {{variable}} placeholders
+  const unresolved = [...new Set((content.match(/\{\{(\w+)\}\}/g) || []).map(m => m.slice(2, -2)))];
+  if (unresolved.length > 0) {
+    const msg = `Playbook "${type}": unresolved template variables: ${unresolved.join(', ')}`;
+    try { engine().log('warn', msg); } catch { /* engine not ready */ }
+  }
+
   return content;
 }
 


### PR DESCRIPTION
## Summary
- Adds pre-spawn validation in `renderPlaybook()` (engine/playbook.js) that logs warnings when template variables resolve to empty string or remain unresolved
- Does **not** block agent spawning — warnings are informational only, visible in engine logs
- Addresses the issue where `{{typo_var}}` or `{{branch_name}}` on items without branches renders empty with no warning, causing agents to launch with incomplete context

## Files changed
- `engine/playbook.js` — Added empty-var and unresolved-var warning checks after template substitution (lines 294-307)

## Build & test
- `npm test` — 490 passed, 0 failed, 2 skipped

## Test plan
- [ ] Dispatch a work item with a missing/empty `branch_name` and verify warning appears in `engine/log.json`
- [ ] Add a `{{typo_var}}` to a playbook template and verify unresolved variable warning appears
- [ ] Confirm agent still spawns successfully (no blocking)

Built by Minions (Ralph — Engineer)