### PR TITLE
feat: Add /api/schedules/parse-natural endpoint

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -2748,6 +2748,22 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     return jsonReply(res, 200, { ok: true });
   }
 
+  async function handleSchedulesParseNatural(req, res) {
+    const body = await readBody(req);
+    const { text } = body;
+    if (!text || !text.trim()) return jsonReply(res, 400, { error: 'text is required' });
+
+    const prompt = `Convert this schedule description to a 3-field cron expression (minute hour dayOfWeek, where dayOfWeek is 0=Sun..6=Sat or ranges like 1-5). Return JSON only: {"cron": "...", "description": "..."}. Input: ${text.trim()}`;
+    try {
+      const result = await llm.callLLM(prompt, '', { model: 'haiku', maxTurns: 1, timeout: 30000, label: 'schedule-parse' });
+      const parsed = JSON.parse(result.trim());
+      if (!parsed.cron) return jsonReply(res, 422, { error: 'Could not parse schedule' });
+      return jsonReply(res, 200, { cron: parsed.cron, description: parsed.description || '' });
+    } catch (e) {
+      return jsonReply(res, 422, { error: 'Parse failed: ' + e.message });
+    }
+  }
+
   async function handleEngineRestart(req, res) {
     try {
       const newPid = restartEngine();
@@ -3100,6 +3116,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     { method: 'POST', path: '/api/command-center', desc: 'Conversational command center with full minions context', params: 'message, sessionId?', handler: handleCommandCenter },
 
     // Schedules
+    { method: 'POST', path: '/api/schedules/parse-natural', desc: 'Parse natural language schedule text into cron expression', params: 'text', handler: handleSchedulesParseNatural },
     { method: 'GET', path: '/api/schedules', desc: 'Return schedules from config + last-run times', handler: handleSchedulesList },
     { method: 'POST', path: '/api/schedules', desc: 'Create a new schedule', params: 'id, cron, title, type?, project?, agent?, description?, priority?, enabled?', handler: handleSchedulesCreate },
     { method: 'POST', path: '/api/schedules/update', desc: 'Update an existing schedule', params: 'id, cron?, title?, type?, project?, agent?, description?, priority?, enabled?', handler: handleSchedulesUpdate },


### PR DESCRIPTION
## What

Adds a new `POST /api/schedules/parse-natural` endpoint to `dashboard.js` that converts natural language schedule descriptions into 3-field cron expressions using Haiku (fast, cheap).

**Request:** `{ "text": "every weekday at 9am" }`
**Response:** `{ "cron": "0 9 1-5", "description": "Every weekday at 9:00 AM" }`
**Errors:** 400 (missing text), 422 (parse failed)

## Files changed

- `dashboard.js` — new handler `handleSchedulesParseNatural` (after line 2749) + route registration (before generic `/api/schedules` routes)

## Build & test

```bash
npm test   # 490 passed, 0 failed, 2 skipped
```

## Test plan

- [ ] POST `/api/schedules/parse-natural` with `{"text": "every weekday at 9am"}` returns valid cron
- [ ] POST with empty/missing text returns 400
- [ ] POST with unparseable text returns 422
- [ ] Existing schedule CRUD endpoints still work
- [ ] `GET /api/routes` includes the new endpoint

## Notes

- Uses `llm.callLLM()` (already imported at line 12) with Haiku model for fast/cheap inference
- Route placed BEFORE generic `/api/schedules` to ensure specific path matches first
- No engine files modified

Built by Minions (Ralph — Engineer)