### PR TITLE
feat(P-d4b67a92): fix ado.js missing path import and document --mode flags

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -3,6 +3,7 @@
  * Extracted from engine.js: ADO token management, PR status polling, human comment polling.
  */
 
+const path = require('path');
 const shared = require('./shared');
 const { exec, getAdoOrgBase, addPrLink } = shared;
 const { getPrs } = require('./queries');
@@ -26,6 +27,8 @@ function getAdoToken() {
   // If recent fetch failed, don't retry until backoff expires (avoids repeated browser popups)
   if (Date.now() < _adoTokenFailedUntil) return null;
   try {
+    // azureauth supports multiple --mode flags as an ordered fallback chain:
+    // tries IWA (Integrated Windows Auth) first, falls back to broker if unavailable.
     const token = exec('azureauth ado token --mode iwa --mode broker --output token --timeout 1', {
       timeout: 15000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true    }).trim();
     if (token && token.startsWith('eyJ')) {
@@ -334,7 +337,7 @@ async function reconcilePrs(config) {
     // Load work items to match branches to work item IDs
     const wiPath = shared.projectWorkItemsPath(project);
     const workItems = shared.safeJson(wiPath) || [];
-    const centralWiPath = require('path').join(shared.MINIONS_DIR, 'work-items.json');
+    const centralWiPath = path.join(shared.MINIONS_DIR, 'work-items.json');
     const centralItems = shared.safeJson(centralWiPath) || [];
     const allItems = [...workItems, ...centralItems];
 


### PR DESCRIPTION
## Summary
- **What:** Fix two issues in `engine/ado.js`: add missing `path` module import and document the dual `--mode` flags on the `azureauth` command.
- **Why:** `path.join()` on line 157 would throw a `ReferenceError` at runtime because the `path` module was never imported. The dual `--mode iwa --mode broker` flags were undocumented, causing confusion about whether they were intentional.

## Files changed
- `engine/ado.js` — added `const path = require('path')` at top, replaced inline `require('path')` on line 337, added explanatory comment on line 31

## Build & test
- `node -e "require('./engine/ado.js')"` — loads without error ✅
- `npm test` — 496 passed, 0 failed, 2 skipped ✅

## Test plan
- [ ] Verify `engine/ado.js` loads without runtime errors
- [ ] Verify `path.join()` calls on lines 157 and 337 resolve correctly
- [ ] Verify `azureauth` token fetch still works with dual `--mode` flags
- [ ] All existing unit tests pass

Built by Minions (Lambert — Analyst)