### PR TITLE
fix(P-c2e84f1d): Fix github.js array spread and null guard

### DIFF
--- a/engine/github.js
+++ b/engine/github.js
@@ -234,7 +234,7 @@ async function pollPrHumanComments(config) {
     const reviewComments = ghApi(`/pulls/${prNum}/comments`, slug);
     const allComments = [
       ...(comments || []).map(c => ({ ...c, _type: 'issue' })),
-      ...((reviewComments || []).map(c => ({ ...c, _type: 'review' })))
+      ...(Array.isArray(reviewComments) ? reviewComments : []).map(c => ({ ...c, _type: 'review' }))
     ];
 
     // Filter out bot comments and minions's own comments


### PR DESCRIPTION
## What
Fix two issues in `engine/github.js`:

1. **Extra parenthesis in array spread (line 237):** `...((reviewComments || []).map(...))` had redundant double-wrapping parentheses. Fixed to clean spread syntax.
2. **Missing null guard on reviewComments:** `ghApi()` can return `null` or non-array responses on transient errors. Replaced `|| []` fallback with `Array.isArray()` guard which properly handles null, undefined, and non-array API responses.

## Files changed
- `engine/github.js` — 1 line changed (spread fix + Array.isArray guard)

## Build & test
```
node -e "require('./engine/github.js')" # OK - no syntax errors
node test/unit.test.js                   # 496 passed, 0 failed, 2 skipped
```

## Test plan
- [x] Module loads without syntax errors
- [x] All 496 unit tests pass
- [ ] PR comment polling works with null reviewComments response
- [ ] PR comment polling works with valid reviewComments array

Built by Minions (Ralph — Engineer)