### PR TITLE
fix(P-a7d20e53): eliminate command injection in preflight.js

### DIFF
--- a/engine/preflight.js
+++ b/engine/preflight.js
@@ -25,10 +25,11 @@ function findClaudeBinary() {
   // Fallback: parse the shell wrapper
   try {
     const which = execSync('bash -c "which claude"', { encoding: 'utf8', windowsHide: true, timeout: 5000 }).trim();
-    const wrapper = execSync(`bash -c "cat '${which}'"`, { encoding: 'utf8', windowsHide: true, timeout: 5000 });
+    const whichNative = which.replace(/^\/c\//, 'C:/').replace(/\//g, path.sep);
+    const wrapper = fs.readFileSync(whichNative, 'utf8');
     const m = wrapper.match(/node_modules\/@anthropic-ai\/claude-code\/cli\.js/);
     if (m) {
-      const basedir = path.dirname(which.replace(/^\/c\//, 'C:/').replace(/\//g, path.sep));
+      const basedir = path.dirname(whichNative);
       const resolved = path.join(basedir, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
       if (fs.existsSync(resolved)) return resolved;
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2235,6 +2235,30 @@ async function testPreflightModule() {
     // Wait for it to complete (don't leave dangling promises)
     return result.catch(() => {});
   });
+
+  await test('findClaudeBinary does not shell-interpolate paths (no command injection)', () => {
+    // Read the source of preflight.js and verify no shell interpolation of `which` variable
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'preflight.js'), 'utf8');
+    // Must NOT contain bash -c "cat '${which}'" or similar shell interpolation of file paths
+    assert.ok(!src.includes('cat \'${which}'), 'Source must not shell-interpolate which variable via cat');
+    assert.ok(!src.includes('cat "${which}'), 'Source must not shell-interpolate which variable via cat (double quotes)');
+    // Should use fs.readFileSync for reading the wrapper file
+    assert.ok(src.includes('fs.readFileSync('), 'Should use fs.readFileSync to read wrapper file');
+  });
+
+  await test('findClaudeBinary fallback handles paths with special chars safely', () => {
+    // This test verifies that the wrapper-reading fallback uses fs.readFileSync
+    // (not shell interpolation) by checking the source doesn't construct shell commands
+    // with user-controlled path variables
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'preflight.js'), 'utf8');
+    // The only execSync calls with string interpolation should NOT include file paths
+    const execSyncCalls = src.match(/execSync\(`[^`]*\$\{[^`]*`/g) || [];
+    for (const call of execSyncCalls) {
+      // Allowed: tasklist with control.pid (a number from our own JSON)
+      // Not allowed: any call interpolating 'which' or file path variables
+      assert.ok(!call.includes('${which'), `Found unsafe shell interpolation of path variable: ${call}`);
+    }
+  });
 }
 
 // ─── shared.js — cleanChildEnv & gitEnv Tests ──────────────────────────────


### PR DESCRIPTION
## What

Fixes a **command injection vulnerability** (C-3) in `engine/preflight.js` where the `which` variable was interpolated directly into a `bash -c "cat '${which}'"` shell command. A path containing shell metacharacters (single quotes, backticks, `$()`) could enable arbitrary command execution.

**Fix:** Replace the `execSync` + `cat` call with `fs.readFileSync()` — there's no reason to shell out when Node's fs module can read the file directly. Also DRYed up the duplicate path conversion logic by reusing the `whichNative` variable.

## Files changed

- `engine/preflight.js` — replaced shell interpolation with `fs.readFileSync`, DRYed path conversion
- `test/unit.test.js` — added 2 tests: source-level verification of no shell interpolation, and execSync audit for path variables

## Build & test

```bash
npm test   # 498 passed, 0 failed, 2 skipped
```

## Test plan

- [x] Unit tests pass (498/498)
- [x] Source no longer contains `cat '${which}'` shell interpolation
- [x] `fs.readFileSync` used instead for reading the claude wrapper script
- [x] Path conversion to native format done once and reused
- [ ] Manual: verify `findClaudeBinary()` still resolves on systems with claude CLI installed

Built by Minions (Ripley — Lead / Explorer)