### PR TITLE
feat(P-8ca361f0): fix mutateDispatch returns, spawnAgent failure handling, log rotation

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -691,13 +691,14 @@ function spawnAgent(dispatchItem, config) {
   // Move pending -> active under a lock to avoid cross-process lost updates (engine/dashboard)
   mutateDispatch((dispatch) => {
     const idx = dispatch.pending.findIndex(d => d.id === id);
-    if (idx < 0) return;
+    if (idx < 0) return dispatch;
     const item = dispatch.pending.splice(idx, 1)[0];
     item.started_at = startedAt;
     delete item.skipReason;
     if (!dispatch.active.some(d => d.id === id)) {
       dispatch.active.push(item);
     }
+    return dispatch;
   });
 
   return proc;
@@ -1365,9 +1366,8 @@ function discoverFromWorkItems(config, project) {
     // This protects against persisted state drift from old runtime versions.
     try {
       mutateDispatch((dp) => {
-        const before = Array.isArray(dp.completed) ? dp.completed.length : 0;
         dp.completed = Array.isArray(dp.completed) ? dp.completed.filter(d => d.meta?.dispatchKey !== key) : [];
-        return dp.completed.length !== before ? dp : undefined;
+        return dp;
       });
       dispatchCooldowns.delete(key);
     } catch (e) { log('warn', 'self-heal dispatch state: ' + e.message); }
@@ -2128,9 +2128,8 @@ async function tickInner() {
                 try {
                     const key = `work-${project.name}-${item.id}`;
                     mutateDispatch((dp) => {
-                      const before = dp.completed.length;
                       dp.completed = dp.completed.filter(d => d.meta?.dispatchKey !== key);
-                      if (dp.completed.length !== before) return dp;
+                      return dp;
                     });
                   } catch (e) { log('warn', 'stall recovery clear dispatch: ' + e.message); }
 
@@ -2164,6 +2163,7 @@ async function tickInner() {
                       const key = `work-${project.name}-${dep.id}`;
                       mutateDispatch((dp) => {
                         dp.completed = dp.completed.filter(d => d.meta?.dispatchKey !== key);
+                        return dp;
                       });
                     } catch (e) { log('warn', 'stall recovery clear dependent dispatch: ' + e.message); }
                   }
@@ -2208,6 +2208,7 @@ async function tickInner() {
   mutateDispatch((dp) => {
     dp.pending = dispatch.pending;
     dp.active = dispatch.active || dp.active;
+    return dp;
   });
 
   // Only dispatch to agents that aren't already busy (one task per agent at a time).
@@ -2226,8 +2227,39 @@ async function tickInner() {
   const dispatched = new Set();
   for (const item of toDispatch) {
     if (!dispatched.has(item.id)) {
-      spawnAgent(item, config);
-      dispatched.add(item.id);
+      const proc = spawnAgent(item, config);
+      if (proc === null) {
+        // spawnAgent failed (e.g., worktree creation error). It already called
+        // completeDispatch internally which handles retry logic, but log at the
+        // dispatch-loop level for visibility and handle any edge cases where
+        // completeDispatch wasn't called.
+        log('error', `spawnAgent returned null for ${item.id} (${item.type} → ${item.agent}) — spawn failed`);
+        // Defensive: ensure the work item is re-queued if completeDispatch didn't fire
+        if (item.meta?.item?.id) {
+          try {
+            const wiPath = item.meta.source === 'central-work-item' || item.meta.source === 'central-work-item-fanout'
+              ? path.join(ENGINE_DIR, '..', 'work-items.json')
+              : item.meta.project?.name ? projectWorkItemsPath({ name: item.meta.project.name, localPath: item.meta.project.localPath }) : null;
+            if (wiPath) {
+              const items = safeJson(wiPath) || [];
+              const wi = items.find(i => i.id === item.meta.item.id);
+              if (wi && wi.status === 'dispatched') {
+                // completeDispatch didn't update the work item — re-queue manually
+                wi.status = 'pending';
+                wi._retryCount = (wi._retryCount || 0) + 1;
+                wi._lastRetryReason = 'spawnAgent returned null';
+                wi._lastRetryAt = ts();
+                delete wi.dispatched_at;
+                delete wi.dispatched_to;
+                safeWrite(wiPath, items);
+                log('info', `Re-queued ${item.meta.item.id} as pending (retry ${wi._retryCount})`);
+              }
+            }
+          } catch (e) { log('warn', `Failed to re-queue work item after spawn failure: ${e.message}`); }
+        }
+      } else {
+        dispatched.add(item.id);
+      }
     }
   }
 
@@ -2250,7 +2282,7 @@ async function tickInner() {
     }
   }
   if (skipReasonChanged) {
-    mutateDispatch((dp) => { dp.pending = postDispatch.pending; });
+    mutateDispatch((dp) => { dp.pending = postDispatch.pending; return dp; });
   }
 }
 

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -272,6 +272,7 @@ function runCleanup(config, verbose = false) {
             return allWiIds.has(itemId);
           });
         }
+        return dp;
       });
     }
   } catch (e) { log('warn', 'prune orphaned dispatches: ' + e.message); }

--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -38,6 +38,7 @@ function addToDispatch(item) {
   item.created_at = ts();
   mutateDispatch((dispatch) => {
     dispatch.pending.push(item);
+    return dispatch;
   });
   log('info', `Queued dispatch: ${item.id} (${item.type} → ${item.agent})`);
   return item.id;
@@ -79,7 +80,7 @@ function completeDispatch(id, result = 'success', reason = '', resultSummary = '
       if (idx >= 0) item = dispatch.pending.splice(idx, 1)[0];
     }
 
-    if (!item) return;
+    if (!item) return dispatch;
     item.completed_at = ts();
     item.result = result;
     if (reason) item.reason = reason;
@@ -89,6 +90,7 @@ function completeDispatch(id, result = 'success', reason = '', resultSummary = '
       dispatch.completed = dispatch.completed.slice(-99);
     }
     dispatch.completed.push(item);
+    return dispatch;
   });
 
   if (item) {

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -25,7 +25,7 @@ function log(level, msg, meta = {}) {
   let logData = safeJson(LOG_PATH) || [];
   if (!Array.isArray(logData)) logData = logData.entries || [];
   logData.push(entry);
-  if (logData.length > 2000) logData.splice(0, logData.length - 2000);
+  if (logData.length >= 2500) logData.splice(0, logData.length - 2000);
   safeWrite(LOG_PATH, logData);
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1857,6 +1857,61 @@ async function testStateIntegrity() {
       'engine dispatch writes should use lock-backed mutation');
   });
 
+  await test('All mutateDispatch callbacks return dispatch object on every path', () => {
+    const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    const dispatchSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');
+    const cleanupSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+
+    // Extract all mutateDispatch callback bodies from each file
+    for (const [name, src] of [['engine.js', engineSrc], ['dispatch.js', dispatchSrc], ['cleanup.js', cleanupSrc]]) {
+      // Find all mutateDispatch( occurrences (skip the definition itself)
+      const pattern = /mutateDispatch\(\((\w+)\)\s*=>\s*\{/g;
+      let match;
+      while ((match = pattern.exec(src)) !== null) {
+        const paramName = match[1];
+        // Walk forward from the match to find the closing brace of the callback
+        let depth = 1;
+        let i = match.index + match[0].length;
+        while (i < src.length && depth > 0) {
+          if (src[i] === '{') depth++;
+          else if (src[i] === '}') depth--;
+          i++;
+        }
+        const body = src.slice(match.index + match[0].length, i - 1);
+        // Every return statement should return the dispatch param, not undefined
+        const returnStatements = body.match(/return\b[^;]*/g) || [];
+        for (const ret of returnStatements) {
+          const trimmed = ret.replace(/^return\s*/, '').trim();
+          // Allow: return dp, return dispatch, return dp; — but not bare 'return' or 'return undefined'
+          assert.ok(
+            trimmed.length > 0 && trimmed !== 'undefined',
+            `${name}: mutateDispatch callback has bare/undefined return: "${ret.trim()}". Must return ${paramName}.`
+          );
+        }
+      }
+    }
+  });
+
+  await test('spawnAgent null return is handled in dispatch loop', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    assert.ok(src.includes('const proc = spawnAgent(item, config)'),
+      'dispatch loop must capture spawnAgent return value');
+    assert.ok(src.includes('proc === null'),
+      'dispatch loop must check for null return from spawnAgent');
+    assert.ok(src.includes('_retryCount') && src.includes("'pending'"),
+      'dispatch loop must re-queue work item with retry metadata on spawn failure');
+  });
+
+  await test('Log rotation uses batch threshold (>= 2500 → 2000)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(src.includes('logData.length >= 2500'),
+      'log rotation should trigger at >= 2500 for batch efficiency');
+    assert.ok(src.includes('logData.length - 2000'),
+      'log rotation should splice down to 2000 entries');
+    assert.ok(!src.includes('logData.length > 2000'),
+      'log rotation should NOT use tight > 2000 threshold');
+  });
+
   await test('Dashboard uses lock-backed dispatch mutations for API writes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     assert.ok(src.includes('mutateJsonFileLocked'),


### PR DESCRIPTION
## Summary
- **H-1**: All `mutateDispatch()` callbacks across `engine.js`, `engine/dispatch.js`, and `engine/cleanup.js` now explicitly return the dispatch object on every code path — prevents silent state drops when `mutateJsonFileLocked` treats `undefined` as no-change
- **H-2**: Dispatch loop now captures `spawnAgent()` return value and handles `null` (failure): logs error, defensively re-queues work item as pending with `_retryCount` increment and retry metadata
- **L-1**: Log rotation threshold changed from `> 2000` to `>= 2500`, splicing down to 2000 — eliminates tight 2001→2000 splice cycle for batch efficiency

## Files changed
- `engine.js` — mutateDispatch return fixes (6 callbacks), spawnAgent null-return handling in dispatch loop
- `engine/dispatch.js` — mutateDispatch return fixes (2 callbacks: addToDispatch, completeDispatch)
- `engine/cleanup.js` — mutateDispatch return fix (1 callback: orphaned dispatch pruning)
- `engine/shared.js` — log rotation threshold fix
- `test/unit.test.js` — 3 new tests verifying all three fixes

## Build & test
```
npm test   # 499 passed, 0 failed, 2 skipped
```

## Test plan
- [x] All existing unit tests pass (499/499)
- [x] New test: verify all mutateDispatch callbacks return dispatch object (source inspection)
- [x] New test: verify dispatch loop checks spawnAgent return value
- [x] New test: verify log rotation uses >= 2500 threshold
- [ ] Manual: confirm engine tick cycle works end-to-end with active agents

Built by Minions (Rebecca — Architect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)