### PR TITLE
feat(P-e5q3y8g1): throttle plan completion sweep to every 10 ticks

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1955,19 +1955,29 @@ function discoverWork(config) {
 
   // Periodic plan completion sweep — catch PRDs that completed while engine was down
   // or where checkPlanCompletion missed the completion event
-  try {
-    const lifecycle = require('./engine/lifecycle');
-    const prdDir = path.join(MINIONS_DIR, 'prd');
-    if (fs.existsSync(prdDir)) {
-      for (const f of fs.readdirSync(prdDir).filter(f => f.endsWith('.json'))) {
-        const plan = safeJson(path.join(prdDir, f));
-        if (!plan?.missing_features || plan.status === 'completed') continue;
-        if (plan.status !== 'approved' && plan.status !== 'active') continue;
-        // Simulate the meta object checkPlanCompletion expects
-        lifecycle.checkPlanCompletion({ item: { sourcePlan: f } }, config);
+  // Throttled to every 10 ticks (~5 min) to reduce call volume (P3 decision)
+  if (tickCount % 10 === 0) {
+    try {
+      const lifecycle = require('./engine/lifecycle');
+      const prdDir = path.join(MINIONS_DIR, 'prd');
+      if (fs.existsSync(prdDir)) {
+        for (const f of fs.readdirSync(prdDir).filter(f => f.endsWith('.json'))) {
+          if (completedPlanCache.has(f)) continue;
+          const plan = safeJson(path.join(prdDir, f));
+          if (!plan?.missing_features || plan.status === 'completed') {
+            if (plan?.status === 'completed') completedPlanCache.add(f);
+            continue;
+          }
+          if (plan.status !== 'approved' && plan.status !== 'active') continue;
+          // Simulate the meta object checkPlanCompletion expects
+          lifecycle.checkPlanCompletion({ item: { sourcePlan: f } }, config);
+          // If plan transitioned to completed, cache it
+          const after = safeJson(path.join(prdDir, f));
+          if (after?.status === 'completed') completedPlanCache.add(f);
+        }
       }
-    }
-  } catch (e) { log('warn', 'plan completion sweep: ' + e.message); }
+    } catch (e) { log('warn', 'plan completion sweep: ' + e.message); }
+  }
 
   // Gate reviews and fixes: do not dispatch until all implement items are complete
   const hasIncompleteImplements = projects.some(project => {
@@ -2004,6 +2014,10 @@ function discoverWork(config) {
 // ─── Main Tick ──────────────────────────────────────────────────────────────
 
 let tickCount = 0;
+
+// In-memory cache of plan filenames confirmed completed — avoids redundant
+// checkPlanCompletion calls.  Cleared automatically on engine restart.
+const completedPlanCache = new Set();
 
 let tickRunning = false;
 
@@ -2068,9 +2082,15 @@ async function tickInner() {
     try {
       const prdFiles = safeReadDir(PRD_DIR).filter(f => f.endsWith('.json'));
       for (const file of prdFiles) {
+        if (completedPlanCache.has(file)) continue;
         const plan = safeJson(path.join(PRD_DIR, file));
         if (plan && plan.missing_features && plan.status !== 'completed') {
           checkPlanCompletion({ item: { sourcePlan: file } }, config);
+          // If plan transitioned to completed, cache it
+          const after = safeJson(path.join(PRD_DIR, file));
+          if (after?.status === 'completed') completedPlanCache.add(file);
+        } else if (plan?.status === 'completed') {
+          completedPlanCache.add(file);
         }
       }
     } catch (err) { log('warn', `Plan completion check error: ${err?.message || err}`); }


### PR DESCRIPTION
## Summary
- Gates the `discoverWork` plan completion sweep to run every 10 ticks instead of every tick, reducing PRD file iteration volume by 10x (P3 decision from notes-deduplication meeting)
- Adds an in-memory `Set<string>` cache of confirmed-completed plan filenames, applied to both sweep call sites (`discoverWork` at line 1956 and `tickInner` at line 2067)
- Cache auto-clears on engine restart (in-memory only); plans that transition to completed are added to the cache immediately after `checkPlanCompletion` returns

## Test plan
- [x] `npm test` — 496 passed, 0 failed, 2 skipped
- [ ] Manual: start engine, verify plan completion sweep logs appear only every 10th tick
- [ ] Manual: complete all items in a PRD, verify plan transitions to completed and subsequent ticks skip it via cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)