### PR TITLE
feat(P-62c1f8b5): reject 2-field cron expressions in scheduler.js

### DIFF
--- a/engine/scheduler.js
+++ b/engine/scheduler.js
@@ -61,11 +61,11 @@ function parseCronField(field, min, max) {
 function parseCronExpr(expr) {
   if (!expr || typeof expr !== 'string') return null;
   const parts = expr.trim().split(/\s+/);
-  if (parts.length < 2 || parts.length > 3) return null;
+  if (parts.length !== 3) return null;
 
   const minuteMatcher = parseCronField(parts[0], 0, 59);
   const hourMatcher = parseCronField(parts[1], 0, 23);
-  const dowMatcher = parts[2] ? parseCronField(parts[2], 0, 6) : () => true;
+  const dowMatcher = parseCronField(parts[2], 0, 6);
 
   return {
     matches(date) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -55,6 +55,7 @@ function skip(name, reason) {
 const MINIONS_DIR = path.resolve(__dirname, '..');
 const shared = require(path.join(MINIONS_DIR, 'engine', 'shared'));
 const queries = require(path.join(MINIONS_DIR, 'engine', 'queries'));
+const scheduler = require(path.join(MINIONS_DIR, 'engine', 'scheduler'));
 
 // ─── shared.js Tests ─────────────────────────────────────────────────────────
 
@@ -4712,6 +4713,70 @@ async function testMeetings() {
   });
 }
 
+// ─── scheduler.js Tests ─────────────────────────────────────────────────────
+
+async function testSchedulerCronParsing() {
+  console.log('\n── scheduler.js — Cron Parsing ──');
+
+  await test('parseCronExpr rejects 2-field cron expression', () => {
+    const result = scheduler.parseCronExpr('0 2');
+    assert.strictEqual(result, null, 'should return null for 2-field cron');
+  });
+
+  await test('parseCronExpr rejects 1-field cron expression', () => {
+    const result = scheduler.parseCronExpr('0');
+    assert.strictEqual(result, null, 'should return null for 1-field cron');
+  });
+
+  await test('parseCronExpr rejects 4-field cron expression', () => {
+    const result = scheduler.parseCronExpr('0 2 * *');
+    assert.strictEqual(result, null, 'should return null for 4-field cron');
+  });
+
+  await test('parseCronExpr accepts valid 3-field cron expression', () => {
+    const result = scheduler.parseCronExpr('0 2 *');
+    assert.ok(result !== null, 'should return a cron object');
+    assert.strictEqual(typeof result.matches, 'function', 'should have matches()');
+  });
+
+  await test('parseCronExpr 3-field matches correctly', () => {
+    const cron = scheduler.parseCronExpr('30 14 1');
+    // Monday at 14:30
+    const monday = new Date(2026, 2, 30, 14, 30); // March 30, 2026 is a Monday
+    assert.strictEqual(cron.matches(monday), true, 'should match Monday 14:30');
+    // Wrong hour
+    const wrongHour = new Date(2026, 2, 30, 15, 30);
+    assert.strictEqual(cron.matches(wrongHour), false, 'should not match wrong hour');
+  });
+
+  await test('parseCronExpr rejects null/undefined/empty', () => {
+    assert.strictEqual(scheduler.parseCronExpr(null), null);
+    assert.strictEqual(scheduler.parseCronExpr(undefined), null);
+    assert.strictEqual(scheduler.parseCronExpr(''), null);
+    assert.strictEqual(scheduler.parseCronExpr(42), null);
+  });
+
+  await test('parseCronField handles wildcard', () => {
+    const matcher = scheduler.parseCronField('*', 0, 59);
+    assert.strictEqual(matcher(0), true);
+    assert.strictEqual(matcher(59), true);
+  });
+
+  await test('parseCronField handles step syntax', () => {
+    const matcher = scheduler.parseCronField('*/15', 0, 59);
+    assert.strictEqual(matcher(0), true);
+    assert.strictEqual(matcher(15), true);
+    assert.strictEqual(matcher(7), false);
+  });
+
+  await test('parseCronField handles list syntax', () => {
+    const matcher = scheduler.parseCronField('1,3,5', 0, 6);
+    assert.strictEqual(matcher(1), true);
+    assert.strictEqual(matcher(3), true);
+    assert.strictEqual(matcher(2), false);
+  });
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -4846,6 +4911,9 @@ async function main() {
 
     // P-bf3a91c7: shared.js fixes
     await testSharedJsFixes();
+
+    // Scheduler tests
+    await testSchedulerCronParsing();
   } finally {
     cleanupTmpDirs();
   }


### PR DESCRIPTION
## What

`parseCronExpr()` silently accepted 2-field cron expressions (e.g. `'0 2'`) by defaulting `dayOfWeek` to `() => true`, which caused schedules to fire daily instead of erroring. The function comment documents 3-field format (`minute hour dayOfWeek`) but the code allowed 2 fields.

**Fix:** Changed `parts.length < 2 || parts.length > 3` to `parts.length !== 3` — now strictly requires exactly 3 fields and returns `null` for anything else.

## Files changed

- `engine/scheduler.js` — strict 3-field enforcement in `parseCronExpr()`
- `test/unit.test.js` — 9 new scheduler tests (cron field rejection, parsing, matching)

## Build & test

```bash
npm test   # 505 passed, 0 failed, 2 skipped
```

## Test plan

- [x] 2-field cron (`'0 2'`) returns `null`
- [x] 1-field cron returns `null`
- [x] 4-field cron returns `null`
- [x] null/undefined/empty/non-string returns `null`
- [x] Valid 3-field cron parses and matches correctly
- [x] `parseCronField` wildcard, step, and list syntax work
- [x] All 505 existing tests continue to pass

Built by Minions (Ripley — Lead / Explorer)