### PR TITLE
feat(P-k7m2x9f4): make checkPlanCompletion idempotent with _completionNotified flag

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -6,8 +6,8 @@
 const fs = require('fs');
 const path = require('path');
 const shared = require('./shared');
-const { safeRead, safeJson, safeWrite, execSilent, projectPrPath, getPrLinks, addPrLink,
-  log, ts, dateStamp } = shared;
+const { safeRead, safeJson, safeWrite, safeReadDir, execSilent, projectPrPath, getPrLinks, addPrLink,
+  mutateJsonFileLocked, log, ts, dateStamp } = shared;
 const { trackEngineUsage } = require('./llm');
 const queries = require('./queries');
 const { getConfig, getInboxFiles, getNotes, getPrs, getDispatch,
@@ -21,7 +21,12 @@ function checkPlanCompletion(meta, config) {
   const planPath = path.join(PRD_DIR, planFile);
   const plan = safeJson(planPath);
   if (!plan?.missing_features) return;
-  if (plan.status === 'completed') return;
+  if (plan.status === 'completed') {
+    // Idempotency guard: if we already sent the completion notification, skip entirely.
+    // If _completionNotified is NOT set, fall through — crash recovery path:
+    // engine crashed after setting status=completed but before creating verify/PR items.
+    if (plan._completionNotified) return;
+  }
 
   const projects = shared.getProjects(config);
 
@@ -132,10 +137,26 @@ function checkPlanCompletion(meta, config) {
     ...uniquePrs.map(pr => `- ${pr.id}: ${pr.title || ''} ${pr.url || ''}`),
   ].filter(Boolean).join('\n');
 
-  // Write summary to notes/inbox
-  const summaryFile = `prd-completion-${planFile.replace('.json', '')}-${ts().slice(0, 10)}.md`;
-  shared.safeWrite(shared.uniquePath(path.join(MINIONS_DIR, 'notes', 'inbox', summaryFile)), summary);
-  log('info', `PRD completion summary written to notes/inbox/${summaryFile}`);
+  // Write summary to notes/inbox (slug+date dedup — same pattern as writeInboxAlert in dispatch.js)
+  const summarySlug = `prd-completion-${planFile.replace('.json', '')}`;
+  const summaryFile = `${summarySlug}-${dateStamp()}.md`;
+  const inboxDir = path.join(MINIONS_DIR, 'notes', 'inbox');
+  const existing = safeReadDir(inboxDir).find(f => f.startsWith(`${summarySlug}-${dateStamp()}`));
+  if (!existing) {
+    shared.safeWrite(path.join(inboxDir, summaryFile), summary);
+    log('info', `PRD completion summary written to notes/inbox/${summaryFile}`);
+  } else {
+    log('info', `PRD completion summary already exists for today: ${existing}, skipping inbox write`);
+  }
+
+  // Persist _completionNotified flag atomically BEFORE creating work items.
+  // This prevents duplicate inbox notes on re-entry. Work item creation below has its own
+  // existingPrItem/existingVerify guards, so the flag does NOT block crash recovery of those.
+  plan._completionNotified = true;
+  mutateJsonFileLocked(planPath, (data) => {
+    data._completionNotified = true;
+    return data;
+  });
 
   // Resolve the primary project for writing new work items (PR, verify)
   const projectName = plan.project;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2946,6 +2946,60 @@ async function testRunPostCompletionHooks() {
       'Should check plan completion when agent succeeds with sourcePlan');
   });
 
+  // ─── checkPlanCompletion idempotency tests ──────────────────────────────────
+
+  const lifecycleSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+
+  await test('checkPlanCompletion has _completionNotified idempotency guard', () => {
+    assert.ok(lifecycleSrc.includes('_completionNotified'),
+      'Should check _completionNotified flag for idempotency');
+    assert.ok(lifecycleSrc.includes('if (plan._completionNotified) return'),
+      'Should return early when _completionNotified is set');
+  });
+
+  await test('checkPlanCompletion persists _completionNotified via mutateJsonFileLocked', () => {
+    assert.ok(lifecycleSrc.includes('mutateJsonFileLocked(planPath'),
+      'Should use mutateJsonFileLocked to persist _completionNotified flag');
+    assert.ok(lifecycleSrc.includes("data._completionNotified = true"),
+      'Should set _completionNotified = true in the mutation');
+  });
+
+  await test('checkPlanCompletion does not use uniquePath for inbox summary', () => {
+    // uniquePath at the inbox summary line was replaced with slug+date dedup
+    const inboxSummarySection = lifecycleSrc.split('Write summary to notes/inbox')[1]?.split('Resolve the primary project')[0] || '';
+    assert.ok(!inboxSummarySection.includes('uniquePath'),
+      'Should not use uniquePath for plan completion inbox summary');
+    assert.ok(inboxSummarySection.includes('safeReadDir') || inboxSummarySection.includes('summarySlug'),
+      'Should use slug+date dedup pattern for inbox summary');
+  });
+
+  await test('checkPlanCompletion guards inbox write with slug+date dedup (not uniquePath)', () => {
+    // The inbox summary section should use safeReadDir + startsWith for dedup
+    const inboxSection = lifecycleSrc.split('Write summary to notes/inbox')[1]?.split('Resolve the primary project')[0] || '';
+    assert.ok(inboxSection.includes('safeReadDir'), 'Should use safeReadDir for inbox dedup check');
+    assert.ok(inboxSection.includes('dateStamp()'), 'Should include dateStamp in dedup slug');
+    assert.ok(inboxSection.includes('.startsWith('), 'Should use startsWith to check existing files');
+    assert.ok(!inboxSection.includes('uniquePath'), 'Should NOT use uniquePath for inbox summary');
+  });
+
+  await test('checkPlanCompletion sets _completionNotified on in-memory plan object', () => {
+    // The flag must be set on the local `plan` variable too so later safeWrite(planPath, plan)
+    // does not overwrite the persisted flag
+    assert.ok(lifecycleSrc.includes('plan._completionNotified = true'),
+      'Should set _completionNotified on in-memory plan object (not just in mutateJsonFileLocked)');
+  });
+
+  await test('checkPlanCompletion crash recovery: completed plan without _completionNotified falls through', () => {
+    // When plan.status === 'completed' but _completionNotified is NOT set, the function must
+    // NOT return early — it should fall through to create verify/PR items (crash recovery path)
+    const guardSection = lifecycleSrc.split("plan.status === 'completed'")[1]?.split('const projects')[0] || '';
+    assert.ok(guardSection.includes('if (plan._completionNotified) return'),
+      'Should only return early within the completed guard when _completionNotified is set');
+    // Verify the guard is INSIDE the status === completed block, not standalone
+    assert.ok(!lifecycleSrc.includes('if (plan._completionNotified) return;\n  if (plan.status'),
+      'The _completionNotified guard should be inside the completed status check, not before it');
+  });
+
   await test('runPostCompletionHooks calls updateMetrics', () => {
     assert.ok(src.includes('updateMetrics') || src.includes('trackEngineUsage'),
       'Should update agent metrics after completion');


### PR DESCRIPTION
## Summary
- Add `_completionNotified` flag to plan JSON, persisted atomically via `mutateJsonFileLocked()`, to prevent duplicate inbox notes when `checkPlanCompletion()` is called multiple times for the same completed plan
- Replace `uniquePath()` at lifecycle.js:137 with slug+date existence check dedup pattern (matching `writeInboxAlert` in dispatch.js)
- Crash recovery preserved: plans with `status=completed` but without `_completionNotified` still fall through to create verify/PR work items

## Changes
- **engine/lifecycle.js**: Added `_completionNotified` idempotency guard, replaced `uniquePath()` with `safeReadDir` dedup, added `mutateJsonFileLocked` import
- **test/unit.test.js**: Added 6 new tests verifying idempotency guard, flag persistence, dedup pattern, crash recovery behavior

## Root Cause
`checkPlanCompletion()` was called from 4+ sites with no idempotency guard, and used `uniquePath()` which guaranteed a new file on every call. A single 5-item PRD generated 2,700+ duplicate inbox notes.

## Test plan
- [x] All 502 unit tests pass (0 failures)
- [ ] Verify second call to `checkPlanCompletion` for same plan produces no duplicate inbox file
- [ ] Verify crash recovery: plan with `status=completed` but no `_completionNotified` still creates verify items
- [ ] Verify `uniquePath()` is only removed from plan completion inbox write, not elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)