### PR TITLE
feat(P-b2f7h9d5): shared writeToInbox helper with slug-based dedup

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -137,17 +137,10 @@ function checkPlanCompletion(meta, config) {
     ...uniquePrs.map(pr => `- ${pr.id}: ${pr.title || ''} ${pr.url || ''}`),
   ].filter(Boolean).join('\n');
 
-  // Write summary to notes/inbox (slug+date dedup — same pattern as writeInboxAlert in dispatch.js)
-  const summarySlug = `prd-completion-${planFile.replace('.json', '')}`;
-  const summaryFile = `${summarySlug}-${dateStamp()}.md`;
-  const inboxDir = path.join(MINIONS_DIR, 'notes', 'inbox');
-  const existing = safeReadDir(inboxDir).find(f => f.startsWith(`${summarySlug}-${dateStamp()}`));
-  if (!existing) {
-    shared.safeWrite(path.join(inboxDir, summaryFile), summary);
-    log('info', `PRD completion summary written to notes/inbox/${summaryFile}`);
-  } else {
-    log('info', `PRD completion summary already exists for today: ${existing}, skipping inbox write`);
-  }
+  // Write summary to notes/inbox (slug-based dedup prevents duplicates on same day)
+  const slug = `prd-completion-${planFile.replace('.json', '')}`;
+  const wrote = shared.writeToInbox('engine', slug, summary);
+  if (wrote) log('info', `PRD completion summary written to notes/inbox/`);
 
   // Persist _completionNotified flag atomically BEFORE creating work items.
   // This prevents duplicate inbox notes on re-entry. Work item creation below has its own
@@ -892,8 +885,7 @@ function createReviewFeedbackForAuthor(reviewerAgentId, pr, config) {
   const reviewFiles = inboxFiles.filter(f => f.includes(reviewerAgentId) && f.includes(today));
   if (reviewFiles.length === 0) return;
   const reviewContent = reviewFiles.map(f => safeRead(path.join(INBOX_DIR, f))).join('\n\n');
-  const feedbackFile = `feedback-${authorAgentId}-from-${reviewerAgentId}-${pr.id}-${today}.md`;
-  const feedbackPath = shared.uniquePath(path.join(INBOX_DIR, feedbackFile));
+  const slug = `feedback-from-${reviewerAgentId}-${pr.id}`;
   const content = `# Review Feedback for ${config.agents[authorAgentId]?.name || authorAgentId}\n\n` +
     `**PR:** ${pr.id} — ${pr.title || ''}\n` +
     `**Reviewer:** ${config.agents[reviewerAgentId]?.name || reviewerAgentId}\n` +
@@ -902,8 +894,8 @@ function createReviewFeedbackForAuthor(reviewerAgentId, pr, config) {
     `## Action Required\n\nRead this feedback carefully. When you work on similar tasks in the future, ` +
     `avoid the patterns flagged here. If you are assigned to fix this PR, ` +
     `address every point raised above.\n`;
-  shared.safeWrite(feedbackPath, content);
-  log('info', `Created review feedback for ${authorAgentId} from ${reviewerAgentId} on ${pr.id}`);
+  const wrote = shared.writeToInbox(authorAgentId, slug, content);
+  if (wrote) log('info', `Created review feedback for ${authorAgentId} from ${reviewerAgentId} on ${pr.id}`);
 }
 
 function updateMetrics(agentId, dispatchItem, result, taskUsage, prsCreatedCount, model) {

--- a/engine/meeting.js
+++ b/engine/meeting.js
@@ -206,15 +206,13 @@ function collectMeetingFindings(meetingId, agentId, roundName, output) {
     meeting.status = 'completed';
     meeting.completedAt = new Date().toISOString();
 
-    // Write transcript to inbox so agents learn from it
+    // Write transcript to inbox so agents learn from it (slug-based dedup)
     const config = queries.getConfig();
     const agents = config.agents || {};
     const transcript = meeting.transcript.map(t =>
       `### ${agents[t.agent]?.name || t.agent} (${t.type}, Round ${t.round})\n\n${t.content}`
     ).join('\n\n---\n\n');
-    const inboxPath = path.join(__dirname, '..', 'notes', 'inbox',
-      `meeting-${meetingId}-${new Date().toISOString().slice(0, 10)}.md`);
-    safeWrite(inboxPath, `# Meeting Transcript: ${meeting.title}\n\n${transcript}`);
+    shared.writeToInbox('meeting', meetingId, `# Meeting Transcript: ${meeting.title}\n\n${transcript}`);
 
     log('info', `Meeting ${meetingId} completed — transcript written to inbox`);
     saveMeeting(meeting);

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -169,6 +169,33 @@ function uniquePath(filePath) {
   return `${base}-${Date.now()}${ext}`;
 }
 
+// ── Inbox Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Write a file to notes/inbox/ with slug+date-based dedup.
+ * Filename: `{agentId}-{slug}-{YYYY-MM-DD}.md`
+ * If a file with the same prefix already exists for today, skip the write.
+ * Pattern matches writeInboxAlert() in dispatch.js.
+ * @param {string} agentId - Agent or source identifier (e.g. 'engine', 'ralph')
+ * @param {string} slug - Short descriptive slug (e.g. 'prd-completion-plan1')
+ * @param {string} content - Markdown content to write
+ * @returns {boolean} true if a write occurred, false if deduped/skipped
+ */
+function writeToInbox(agentId, slug, content, _inboxDir) {
+  try {
+    const inboxDir = _inboxDir || path.join(MINIONS_DIR, 'notes', 'inbox');
+    const prefix = `${agentId}-${slug}-${dateStamp()}`;
+    const existing = safeReadDir(inboxDir).find(f => f.startsWith(prefix));
+    if (existing) return false;
+    const filePath = path.join(inboxDir, `${prefix}.md`);
+    safeWrite(filePath, content);
+    return true;
+  } catch (e) {
+    log('warn', `writeToInbox failed: ${e.message}`);
+    return false;
+  }
+}
+
 // ── Process Spawning ────────────────────────────────────────────────────────
 // All child process calls go through these to ensure windowsHide: true
 
@@ -479,6 +506,7 @@ module.exports = {
   mutateJsonFileLocked,
   uid,
   uniquePath,
+  writeToInbox,
   exec,
   execSilent,
   run,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -154,6 +154,51 @@ async function testIdGeneration() {
     assert.ok(result.endsWith('file-4.txt'), `Expected -4, got: ${result}`);
   });
 
+  // ── writeToInbox ──
+
+  await test('writeToInbox writes file with agentId-slug-date pattern', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const result = shared.writeToInbox('ralph', 'test-slug', '# Test content', inboxDir);
+    assert.strictEqual(result, true, 'Should return true when write occurs');
+    const files = fs.readdirSync(inboxDir);
+    assert.strictEqual(files.length, 1, 'Should have exactly one file');
+    assert.ok(files[0].startsWith('ralph-test-slug-'), `File should start with ralph-test-slug-, got: ${files[0]}`);
+    assert.ok(files[0].endsWith('.md'), 'File should end with .md');
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.strictEqual(content, '# Test content');
+  });
+
+  await test('writeToInbox deduplicates on same agentId+slug+date', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const first = shared.writeToInbox('engine', 'prd-completion', '# First', inboxDir);
+    assert.strictEqual(first, true, 'First write should succeed');
+    const second = shared.writeToInbox('engine', 'prd-completion', '# Second', inboxDir);
+    assert.strictEqual(second, false, 'Second write should be deduped');
+    const files = fs.readdirSync(inboxDir);
+    assert.strictEqual(files.length, 1, 'Should still have only one file');
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.strictEqual(content, '# First', 'Content should be from first write');
+  });
+
+  await test('writeToInbox allows different slugs on same day', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    shared.writeToInbox('engine', 'slug-a', '# A', inboxDir);
+    shared.writeToInbox('engine', 'slug-b', '# B', inboxDir);
+    const files = fs.readdirSync(inboxDir);
+    assert.strictEqual(files.length, 2, 'Different slugs should create separate files');
+  });
+
+  await test('writeToInbox returns false on error (missing dir)', () => {
+    const result = shared.writeToInbox('test', 'slug', 'content', '/nonexistent/path/inbox');
+    assert.strictEqual(result, false, 'Should return false on error');
+  });
+
   await test('nextWorkItemId increments from existing items', () => {
     const items = [{ id: 'W001' }, { id: 'W002' }, { id: 'W005' }];
     assert.strictEqual(shared.nextWorkItemId(items, 'W'), 'W006');


### PR DESCRIPTION
## Summary
- Adds `writeToInbox(agentId, slug, content)` to `engine/shared.js` with slug+date existence check to prevent duplicate inbox writes on the same day
- Migrates 3 callers: `checkPlanCompletion` (lifecycle.js), meeting transcript (meeting.js), and review feedback (lifecycle.js)
- `writeInboxAlert` in dispatch.js is intentionally unchanged (engine-specific, already works correctly)
- Returns boolean indicating whether a write occurred, for logging

## Test plan
- [x] 4 new unit tests for writeToInbox (write, dedup, different slugs, error handling)
- [x] All 500 existing tests pass (0 failures)
- [ ] Manual: trigger PRD completion, verify inbox file uses new naming pattern
- [ ] Manual: complete a meeting, verify transcript uses writeToInbox dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)