### PR TITLE
feat(P-9d4e5f6a): pick first non-busy participant as meeting concluder

### DIFF
--- a/engine/meeting.js
+++ b/engine/meeting.js
@@ -79,8 +79,12 @@ function discoverMeetingWork(config) {
     const agents = config.agents || {};
 
     if (roundName === 'concluding') {
-      // Only one agent concludes (first participant)
-      const concluder = meeting.participants[0];
+      // Pick the first non-busy participant as concluder (fallback to any participant)
+      const busyAgents = new Set(
+        (dispatch.active || []).map(d => d.agent).filter(Boolean)
+      );
+      const concluder = meeting.participants.find(p => !busyAgents.has(p))
+        || meeting.participants[0];
       if (!concluder) continue;
       const key = `meeting-${meeting.id}-r${round}-${concluder}`;
       if (activeKeys.has(key)) continue;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4634,9 +4634,14 @@ async function testMeetings() {
       'Should create work items for each participant in investigate round');
   });
 
-  await test('discoverMeetingWork dispatches only concluder for conclude round', () => {
-    assert.ok(meetingSrc.includes('participants[0]') && meetingSrc.includes('meeting-conclude'),
-      'Should dispatch only first participant for conclusion');
+  await test('discoverMeetingWork picks first non-busy participant as concluder', () => {
+    assert.ok(meetingSrc.includes('busyAgents') && meetingSrc.includes('participants.find') && meetingSrc.includes('meeting-conclude'),
+      'Should pick first non-busy participant for conclusion, falling back to participants[0]');
+  });
+
+  await test('concluder fallback: if all participants busy, falls back to first participant', () => {
+    assert.ok(meetingSrc.includes("|| meeting.participants[0]"),
+      'Should fall back to participants[0] when all are busy');
   });
 
   await test('debate round includes all findings from round 1', () => {


### PR DESCRIPTION
## Summary
- Meeting concluder no longer hardcoded to `participants[0]` — now picks the first participant not in `dispatch.active`
- Falls back to `participants[0]` if all participants are busy, ensuring meetings always conclude
- Updated unit tests to verify the new selection logic and fallback behavior

## Changes
- `engine/meeting.js`: Replace `participants[0]` with `participants.find(p => !busyAgents.has(p)) || participants[0]`
- `test/unit.test.js`: Updated concluder test + added fallback test (579 pass, 0 fail)

## Test plan
- [x] Unit tests pass (579 passed, 0 failed, 2 skipped)
- [ ] Manual: create a meeting where participants[0] is busy — verify another participant concludes
- [ ] Verify existing timeout and empty output rejection still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)