### PR TITLE
feat(P-4c3d2e1f): create evaluate playbook, routing entry, and config flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,9 @@ Work items can declare `depends_on: ["P-001", "P-003"]`. Before spawning, the en
     "heartbeatTimeout": 300000,
     "shutdownTimeout": 300000,
     "allowTempAgents": false,
-    "autoDecompose": true
+    "autoDecompose": true,
+    "evalLoop": true,
+    "evalMaxIterations": 3
   },
   "schedules": [{
     "id": "nightly-tests", "cron": "0 2 *", "type": "test",
@@ -131,11 +133,11 @@ Work items can declare `depends_on: ["P-001", "P-003"]`. Before spawning, the en
 
 ## Routing
 
-`routing.md` maps work types to agents: `implement → dallas`, `review → ripley`, `fix → _author_`, `decompose → ripley`, etc. The engine reads this on each tick.
+`routing.md` maps work types to agents: `implement → dallas`, `review → ripley`, `evaluate → ripley`, `fix → _author_`, `decompose → ripley`, etc. The engine reads this on each tick.
 
 ## Playbooks
 
-Templates in `playbooks/` (`implement.md`, `review.md`, `fix.md`, `plan.md`, `plan-to-prd.md`, `verify.md`, `decompose.md`, etc.) with `{{template_variables}}` filled at dispatch time. These define what agents actually do.
+Templates in `playbooks/` (`implement.md`, `review.md`, `fix.md`, `plan.md`, `plan-to-prd.md`, `verify.md`, `evaluate.md`, `decompose.md`, etc.) with `{{template_variables}}` filled at dispatch time. These define what agents actually do.
 
 ## Skills
 

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -342,6 +342,8 @@ const ENGINE_DEFAULTS = {
   autoApprovePlans: false, // auto-approve PRDs without waiting for human approval
   autoReview: true, // auto-dispatch review agents for new PRs (disable for manual review workflow)
   meetingRoundTimeout: 600000, // 10min per meeting round before auto-advance
+  evalLoop: true, // enable evaluate→fix loop after implementation completes
+  evalMaxIterations: 3, // max evaluate→fix cycles before escalating to human
 };
 
 const DEFAULT_AGENTS = {

--- a/playbooks/evaluate.md
+++ b/playbooks/evaluate.md
@@ -1,0 +1,114 @@
+# Evaluate: {{item_name}}
+
+> Agent: {{agent_name}} ({{agent_role}}) | Team root: {{team_root}}
+
+## Context
+
+Project: {{project_name}}
+Repo: {{repo_name}} | Org: {{ado_org}} | ADO Project: {{ado_project}}
+PR: {{pr_url}}
+Work Item: {{item_id}}
+
+## Acceptance Criteria
+
+{{acceptance_criteria}}
+
+## Task Description
+
+{{task_description}}
+
+## Your Task
+
+You are the **Evaluator** in the Planner-Generator-Evaluator pattern. Your job is to independently verify whether the implementation in the PR branch meets the acceptance criteria. You are NOT the implementer — you are the skeptic.
+
+**Mindset: Do not pass unless build succeeds AND all acceptance criteria are demonstrably met.** Assume the implementation is incomplete or wrong until proven otherwise. Look for edge cases, missing requirements, and silent failures.
+
+## Step 1: Check Out the PR Branch
+
+```bash
+cd {{project_path}}
+git fetch origin
+git checkout {{branch_name}}
+git pull origin {{branch_name}}
+```
+
+## Step 2: Build
+
+Run the project build. Check `CLAUDE.md`, `package.json`, or `README` for build instructions.
+
+```bash
+# Typical:
+npm install && npm run build
+# Or whatever the project uses
+```
+
+Record: **PASS** or **FAIL** with error output.
+
+If the build fails, **stop here** — the verdict is `pass: false`. Include the build error in feedback.
+
+## Step 3: Run Tests
+
+Run the full test suite:
+
+```bash
+npm test
+```
+
+Record: **X passed / Y failed / Z skipped**.
+
+If any tests fail, note which ones and whether they are related to the changes.
+
+## Step 4: Diff Review Against Acceptance Criteria
+
+Review the actual code changes:
+
+```bash
+git diff {{main_branch}}...{{branch_name}} --stat
+git diff {{main_branch}}...{{branch_name}}
+```
+
+For **each** acceptance criterion, determine:
+- **Met**: The diff demonstrably satisfies this criterion. Cite the specific file/line.
+- **Not met**: The diff does not satisfy this criterion, or satisfies it only partially. Explain what's missing.
+
+Be precise. "Looks good" is not an evaluation — cite file paths and line numbers.
+
+## Step 5: Output Structured Verdict
+
+After completing your evaluation, output the following JSON block as your final output. This MUST be valid JSON wrapped in a `json` fenced code block:
+
+```json
+{
+  "pass": false,
+  "build": true,
+  "tests": "42/42",
+  "criteria_met": [
+    "criterion 1 — met because X (source: path/to/file.js:42)"
+  ],
+  "criteria_failed": [
+    "criterion 2 — not met because Y is missing"
+  ],
+  "feedback": "Summary of what needs to change for this to pass. Be specific — file names, line numbers, what to add/fix."
+}
+```
+
+Field definitions:
+- `pass`: `true` only if build succeeds AND **all** acceptance criteria are met. Otherwise `false`.
+- `build`: `true` if the build completed without errors, `false` otherwise.
+- `tests`: String in format `"passed/total"` (e.g., `"38/40"`). Use `"N/A"` if no test suite exists.
+- `criteria_met`: Array of strings — one per criterion that IS met. Include source references.
+- `criteria_failed`: Array of strings — one per criterion that is NOT met. Explain why.
+- `feedback`: Actionable feedback for the implementer. Be specific about what to fix. If `pass` is `true`, use this for minor suggestions or "LGTM".
+
+## Rules
+
+- **No Playwright / browser testing** — this phase evaluates build, tests, and code review only.
+- **Do NOT fix code** — only evaluate and report. You are the evaluator, not the implementer.
+- **Do NOT rubber-stamp** — if a criterion is ambiguous, evaluate conservatively (fail it and explain).
+- **Build failure is an automatic fail** — do not evaluate criteria if the build doesn't pass.
+- **Every criterion must be addressed** — `criteria_met` + `criteria_failed` should cover all acceptance criteria.
+- **Cite sources** — reference file paths and line numbers for every met/failed criterion.
+
+{{references}}
+
+**Note:** Do NOT write to `agents/*/status.json` — the engine manages your status automatically.

--- a/routing.md
+++ b/routing.md
@@ -17,6 +17,7 @@ How the engine decides who handles what. Parsed by engine.js — keep the table 
 | test | dallas | ralph |
 | ask | ripley | rebecca |
 | verify | dallas | ralph |
+| evaluate | ripley | lambert |
 | decompose | ripley | rebecca |
 | meeting | ripley | rebecca |
 


### PR DESCRIPTION
## Summary

- **New playbook** `playbooks/evaluate.md` — implements the Evaluator role in the Planner-Generator-Evaluator pattern. Checks out PR branch, runs build/tests, diff-reviews against acceptance criteria, outputs structured JSON verdict with explicit skepticism tuning.
- **Routing entry** in `routing.md` — `evaluate → ripley | lambert` (evaluator must differ from implementer)
- **Config flags** in `engine/shared.js` ENGINE_DEFAULTS — `evalLoop: true` (enable evaluate→fix loop), `evalMaxIterations: 3` (max cycles before human escalation)
- **Documentation** updated in `CLAUDE.md` config section and playbooks list

## Test plan

- [x] Unit tests pass (578 passed, 0 failed)
- [ ] Verify `playbooks/evaluate.md` uses `{{acceptance_criteria}}`, `{{pr_url}}`, `{{branch_name}}` template variables
- [ ] Verify playbook outputs structured JSON verdict with all required fields
- [ ] Verify routing.md has evaluate entry with ripley/lambert
- [ ] Verify ENGINE_DEFAULTS includes evalLoop and evalMaxIterations
- [ ] Verify CLAUDE.md documents the new config flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)