### PR TITLE
feat(P-b8c7d6e5): replace engine() lazy-requires with shared.js imports

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -5,10 +5,10 @@
 
 const path = require('path');
 const shared = require('./shared');
-const { exec, getAdoOrgBase, addPrLink } = shared;
+const { exec, getAdoOrgBase, addPrLink, log, dateStamp } = shared;
 const { getPrs } = require('./queries');
 
-// Lazy require to avoid circular dependency
+// Lazy require to avoid circular dependency — only needed for engine().handlePostMerge
 let _engine = null;
 function engine() {
   if (!_engine) _engine = require('../engine');
@@ -37,7 +37,7 @@ function getAdoToken() {
       return token;
     }
   } catch (e) {
-    engine().log('warn', `Failed to get ADO token: ${e.message}`);
+    log('warn', `Failed to get ADO token: ${e.message}`);
   }
   // Back off for 10 minutes to avoid spamming browser auth popups
   _adoTokenFailedUntil = Date.now() + 10 * 60 * 1000;
@@ -57,7 +57,7 @@ async function adoFetch(url, token, _retryCount = 0) {
     if (_retryCount < MAX_RETRIES) {
       const freshToken = getAdoToken();
       if (freshToken) {
-        engine().log('info', 'ADO token expired mid-session — refreshed and retrying');
+        log('info', 'ADO token expired mid-session — refreshed and retrying');
         return adoFetch(url, freshToken, _retryCount + 1);
       }
     }
@@ -94,7 +94,7 @@ async function forEachActivePr(config, token, callback) {
         const updated = await callback(project, pr, prNum, orgBase);
         if (updated) projectUpdated++;
       } catch (err) {
-        try { engine().log('warn', `Failed to poll status for ${pr.id}: ${err.message}`); } catch { /* engine not available */ }
+        log('warn', `Failed to poll status for ${pr.id}: ${err.message}`);
       }
     }
 
@@ -110,10 +110,9 @@ async function forEachActivePr(config, token, callback) {
 // ─── PR Status Polling ───────────────────────────────────────────────────────
 
 async function pollPrStatus(config) {
-  const e = engine();
   const token = getAdoToken();
   if (!token) {
-    e.log('warn', 'Skipping PR status poll — no ADO token available');
+    log('warn', 'Skipping PR status poll — no ADO token available');
     return;
   }
 
@@ -129,14 +128,14 @@ async function pollPrStatus(config) {
     else if (prData.status === 'active') newStatus = 'active';
 
     if (pr.status !== newStatus) {
-      e.log('info', `PR ${pr.id} status: ${pr.status} → ${newStatus}`);
+      log('info', `PR ${pr.id} status: ${pr.status} → ${newStatus}`);
       pr.status = newStatus;
       updated = true;
 
       if (newStatus === 'merged' || newStatus === 'abandoned') {
         if (pr.reviewStatus === 'waiting') {
           pr.reviewStatus = newStatus === 'merged' ? 'approved' : 'pending';
-          e.log('info', `PR ${pr.id} reviewStatus: waiting → ${pr.reviewStatus} (${newStatus})`);
+          log('info', `PR ${pr.id} reviewStatus: waiting → ${pr.reviewStatus} (${newStatus})`);
         }
         await engine().handlePostMerge(pr, project, config, newStatus);
       }
@@ -153,7 +152,7 @@ async function pollPrStatus(config) {
     }
 
     if (pr.reviewStatus !== newReviewStatus) {
-      e.log('info', `PR ${pr.id} reviewStatus: ${pr.reviewStatus} → ${newReviewStatus}`);
+      log('info', `PR ${pr.id} reviewStatus: ${pr.reviewStatus} → ${newReviewStatus}`);
       pr.reviewStatus = newReviewStatus;
       updated = true;
       // Update author metrics when verdict changes to approved/rejected
@@ -167,7 +166,7 @@ async function pollPrStatus(config) {
             if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
             else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
             shared.safeWrite(metricsPath, metrics);
-          } catch (err) { try { engine().log('warn', `Metrics update: ${err.message}`); } catch { /* engine not available */ } }
+          } catch (err) { log('warn', `Metrics update: ${err.message}`); }
         }
       }
     }
@@ -209,7 +208,7 @@ async function pollPrStatus(config) {
     }
 
     if (pr.buildStatus !== buildStatus) {
-      e.log('info', `PR ${pr.id} build: ${pr.buildStatus || 'none'} → ${buildStatus}${buildFailReason ? ' (' + buildFailReason + ')' : ''}`);
+      log('info', `PR ${pr.id} build: ${pr.buildStatus || 'none'} → ${buildStatus}${buildFailReason ? ' (' + buildFailReason + ')' : ''}`);
       pr.buildStatus = buildStatus;
       if (buildFailReason) pr.buildFailReason = buildFailReason;
       else delete pr.buildFailReason;
@@ -221,14 +220,13 @@ async function pollPrStatus(config) {
   });
 
   if (totalUpdated > 0) {
-    e.log('info', `PR status poll: updated ${totalUpdated} PR(s)`);
+    log('info', `PR status poll: updated ${totalUpdated} PR(s)`);
   }
 }
 
 // ─── Poll Human Comments on PRs ──────────────────────────────────────────────
 
 async function pollPrHumanComments(config) {
-  const e = engine();
   const token = getAdoToken();
   if (!token) return;
 
@@ -285,12 +283,12 @@ async function pollPrHumanComments(config) {
       feedbackContent
     };
 
-    e.log('info', `PR ${pr.id}: ${newHumanComments.length} new comment(s), ${allHumanComments.length} total — full thread context provided`);
+    log('info', `PR ${pr.id}: ${newHumanComments.length} new comment(s), ${allHumanComments.length} total — full thread context provided`);
     return true;
   });
 
   if (totalUpdated > 0) {
-    e.log('info', `PR comment poll: found human feedback on ${totalUpdated} PR(s)`);
+    log('info', `PR comment poll: found human feedback on ${totalUpdated} PR(s)`);
   }
 }
 
@@ -301,10 +299,9 @@ async function pollPrHumanComments(config) {
  * in pull-requests.json, and add them. Matches PRs to work items by branch name.
  */
 async function reconcilePrs(config) {
-  const e = engine();
   const token = getAdoToken();
   if (!token) {
-    e.log('warn', 'Skipping PR reconciliation — no ADO token available');
+    log('warn', 'Skipping PR reconciliation — no ADO token available');
     return;
   }
 
@@ -322,7 +319,7 @@ async function reconcilePrs(config) {
     try {
       prData = await adoFetch(url, token);
     } catch (err) {
-      e.log('warn', `PR reconciliation failed for ${project.name}: ${err.message}`);
+      log('warn', `PR reconciliation failed for ${project.name}: ${err.message}`);
       continue;
     }
 
@@ -379,14 +376,14 @@ async function reconcilePrs(config) {
         branch,
         reviewStatus: 'pending',
         status: 'active',
-        created: (adoPr.creationDate || '').slice(0, 10) || e.dateStamp(),
+        created: (adoPr.creationDate || '').slice(0, 10) || dateStamp(),
         url: prUrl,
         prdItems: confirmedItemId ? [confirmedItemId] : [],
       });
       if (confirmedItemId) addPrLink(prId, confirmedItemId);
       existingIds.add(prId);
       projectAdded++;
-      e.log('info', `PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);
+      log('info', `PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);
     }
 
     // Backfill prdItems from pr-links for any PR with empty array
@@ -404,12 +401,12 @@ async function reconcilePrs(config) {
     if (projectAdded > 0 || projectUpdated > 0 || backfilled > 0) {
       shared.safeWrite(prPath, existingPrs);
       totalAdded += projectAdded;
-      if (projectUpdated > 0) e.log('info', `PR reconciliation: linked ${projectUpdated} existing PR(s) to PRD items in ${project.name}`);
+      if (projectUpdated > 0) log('info', `PR reconciliation: linked ${projectUpdated} existing PR(s) to PRD items in ${project.name}`);
     }
   }
 
   if (totalAdded > 0) {
-    e.log('info', `PR reconciliation: added ${totalAdded} missing PR(s) across projects`);
+    log('info', `PR reconciliation: added ${totalAdded} missing PR(s) across projects`);
   }
 }
 

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -8,7 +8,7 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
-const { exec, execSilent } = shared;
+const { exec, execSilent, log, ts } = shared;
 const { safeJson, safeWrite, safeReadDir, getProjects, projectWorkItemsPath, projectPrPath,
   sanitizeBranch, KB_CATEGORIES } = shared;
 const { getDispatch, getAgentStatus } = queries;
@@ -20,10 +20,9 @@ const PRD_DIR = queries.PRD_DIR;
 const PLANS_DIR = queries.PLANS_DIR;
 
 // Lazy require to break circular dependency with engine.js
+// Only needed for engine().activeProcesses — log/ts come from shared.js
 let _engine = null;
 function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
-function log(level, msg, meta) { return engine().log(level, msg, meta); }
-function ts() { return engine().ts(); }
 
 // Lazy require for dispatch module
 let _dispatch = null;

--- a/engine/cooldown.js
+++ b/engine/cooldown.js
@@ -7,12 +7,8 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
-const { safeJson, safeWrite } = shared;
+const { safeJson, safeWrite, log } = shared;
 const { ENGINE_DIR } = queries;
-
-// Lazy require to avoid circular dependency with engine.js
-let _engine = null;
-function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
 
 const COOLDOWN_PATH = path.join(ENGINE_DIR, 'cooldowns.json');
 const dispatchCooldowns = new Map(); // key → { timestamp, failures }
@@ -27,7 +23,7 @@ function loadCooldowns() {
       dispatchCooldowns.set(k, v);
     }
   }
-  engine().log('info', `Loaded ${dispatchCooldowns.size} cooldowns from disk`);
+  log('info', `Loaded ${dispatchCooldowns.size} cooldowns from disk`);
 }
 
 let _cooldownWriteTimer = null;
@@ -85,7 +81,7 @@ function setCooldownFailure(key) {
   const failures = (existing?.failures || 0) + 1;
   dispatchCooldowns.set(key, { timestamp: Date.now(), failures });
   if (failures >= 3) {
-    engine().log('warn', `${key} has failed ${failures} times — cooldown is now ${Math.min(Math.pow(2, failures), 8)}x`);
+    log('warn', `${key} has failed ${failures} times — cooldown is now ${Math.min(Math.pow(2, failures), 8)}x`);
   }
   saveCooldowns();
 }

--- a/engine/github.js
+++ b/engine/github.js
@@ -5,11 +5,11 @@
  */
 
 const shared = require('./shared');
-const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, MINIONS_DIR, addPrLink, getPrLinks } = shared;
+const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, MINIONS_DIR, addPrLink, getPrLinks, log, dateStamp } = shared;
 const { getPrs } = require('./queries');
 const path = require('path');
 
-// Lazy require to avoid circular dependency
+// Lazy require to avoid circular dependency — only needed for engine().handlePostMerge
 let _engine = null;
 function engine() {
   if (!_engine) _engine = require('../engine');
@@ -37,7 +37,7 @@ function ghApi(endpoint, slug) {
     const result = exec(cmd, { timeout: 30000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
     return JSON.parse(result);
   } catch (e) {
-    engine().log('warn', `GitHub API error (${endpoint}): ${e.message}`);
+    log('warn', `GitHub API error (${endpoint}): ${e.message}`);
     return null;
   }
 }
@@ -66,7 +66,7 @@ async function forEachActiveGhPr(config, callback) {
         const updated = await callback(project, pr, prNum, slug);
         if (updated) projectUpdated++;
       } catch (err) {
-        try { engine().log('warn', `GitHub: failed to poll PR ${pr.id}: ${err.message}`); } catch { /* engine not available */ }
+        log('warn', `GitHub: failed to poll PR ${pr.id}: ${err.message}`);
       }
     }
 
@@ -101,7 +101,7 @@ async function forEachActiveGhPr(config, callback) {
         centralUpdated++;
       }
     } catch (err) {
-      try { engine().log('warn', `GitHub: failed to poll central PR ${pr.id}: ${err.message}`); } catch { /* engine not available */ }
+      log('warn', `GitHub: failed to poll central PR ${pr.id}: ${err.message}`);
     }
   }
   if (centralUpdated > 0) {
@@ -115,8 +115,6 @@ async function forEachActiveGhPr(config, callback) {
 // ─── PR Status Polling ──────────────────────────────────────────────────────
 
 async function pollPrStatus(config) {
-  const e = engine();
-
   const totalUpdated = await forEachActiveGhPr(config, async (project, pr, prNum, slug) => {
     const prData = ghApi(`/pulls/${prNum}`, slug);
     if (!prData) return false;
@@ -130,7 +128,7 @@ async function pollPrStatus(config) {
     else if (prData.state === 'open') newStatus = 'active';
 
     if (pr.status !== newStatus) {
-      e.log('info', `PR ${pr.id} status: ${pr.status} → ${newStatus}`);
+      log('info', `PR ${pr.id} status: ${pr.status} → ${newStatus}`);
       pr.status = newStatus;
       updated = true;
 
@@ -138,7 +136,7 @@ async function pollPrStatus(config) {
         // Resolve stale 'waiting' review status — won't be polled again after this
         if (pr.reviewStatus === 'waiting') {
           pr.reviewStatus = newStatus === 'merged' ? 'approved' : 'pending';
-          e.log('info', `PR ${pr.id} reviewStatus: waiting → ${pr.reviewStatus} (${newStatus})`);
+          log('info', `PR ${pr.id} reviewStatus: waiting → ${pr.reviewStatus} (${newStatus})`);
         }
         await engine().handlePostMerge(pr, project, config, newStatus);
       }
@@ -162,7 +160,7 @@ async function pollPrStatus(config) {
       else if (states.length > 0) newReviewStatus = 'pending';
 
       if (pr.reviewStatus !== newReviewStatus) {
-        e.log('info', `PR ${pr.id} reviewStatus: ${pr.reviewStatus} → ${newReviewStatus}`);
+        log('info', `PR ${pr.id} reviewStatus: ${pr.reviewStatus} → ${newReviewStatus}`);
         pr.reviewStatus = newReviewStatus;
         updated = true;
         // Update author metrics when verdict changes to approved/rejected
@@ -176,7 +174,7 @@ async function pollPrStatus(config) {
               if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
               else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
               shared.safeWrite(metricsPath, metrics);
-            } catch (err) { try { engine().log('warn', `Metrics update: ${err.message}`); } catch { /* engine not available */ } }
+            } catch (err) { log('warn', `Metrics update: ${err.message}`); }
           }
         }
       }
@@ -207,7 +205,7 @@ async function pollPrStatus(config) {
         }
 
         if (pr.buildStatus !== buildStatus) {
-          e.log('info', `PR ${pr.id} build: ${pr.buildStatus || 'none'} → ${buildStatus}${buildFailReason ? ' (' + buildFailReason + ')' : ''}`);
+          log('info', `PR ${pr.id} build: ${pr.buildStatus || 'none'} → ${buildStatus}${buildFailReason ? ' (' + buildFailReason + ')' : ''}`);
           pr.buildStatus = buildStatus;
           if (buildFailReason) pr.buildFailReason = buildFailReason;
           else delete pr.buildFailReason;
@@ -221,15 +219,13 @@ async function pollPrStatus(config) {
   });
 
   if (totalUpdated > 0) {
-    e.log('info', `GitHub PR status poll: updated ${totalUpdated} PR(s)`);
+    log('info', `GitHub PR status poll: updated ${totalUpdated} PR(s)`);
   }
 }
 
 // ─── Poll Human Comments on PRs ─────────────────────────────────────────────
 
 async function pollPrHumanComments(config) {
-  const e = engine();
-
   const totalUpdated = await forEachActiveGhPr(config, async (project, pr, prNum, slug) => {
     // Get issue comments (general PR comments)
     const comments = ghApi(`/issues/${prNum}/comments`, slug);
@@ -292,19 +288,18 @@ async function pollPrHumanComments(config) {
       feedbackContent
     };
 
-    e.log('info', `PR ${pr.id}: ${newComments.length} new comment(s), ${allCommentEntries.length} total — full thread context provided`);
+    log('info', `PR ${pr.id}: ${newComments.length} new comment(s), ${allCommentEntries.length} total — full thread context provided`);
     return true;
   });
 
   if (totalUpdated > 0) {
-    e.log('info', `GitHub PR comment poll: found human feedback on ${totalUpdated} PR(s)`);
+    log('info', `GitHub PR comment poll: found human feedback on ${totalUpdated} PR(s)`);
   }
 }
 
 // ─── PR Reconciliation ──────────────────────────────────────────────────────
 
 async function reconcilePrs(config) {
-  const e = engine();
   const projects = getProjects(config).filter(isGitHub);
   const branchPatterns = [/^work\//i, /^feat\//i, /^user\/yemishin\//i];
   let totalAdded = 0;
@@ -365,7 +360,7 @@ async function reconcilePrs(config) {
         branch,
         reviewStatus: 'pending',
         status: 'active',
-        created: (ghPr.created_at || '').slice(0, 10) || e.dateStamp(),
+        created: (ghPr.created_at || '').slice(0, 10) || dateStamp(),
         url: prUrl,
         prdItems: confirmedItemId ? [confirmedItemId] : [],
       });
@@ -373,7 +368,7 @@ async function reconcilePrs(config) {
       existingIds.add(prId);
       projectAdded++;
 
-      e.log('info', `GitHub PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);
+      log('info', `GitHub PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);
     }
 
     // Backfill prdItems from pr-links for any PR with empty array
@@ -395,7 +390,7 @@ async function reconcilePrs(config) {
   }
 
   if (totalAdded > 0) {
-    e.log('info', `GitHub PR reconciliation: added ${totalAdded} missing PR(s)`);
+    log('info', `GitHub PR reconciliation: added ${totalAdded} missing PR(s)`);
   }
 }
 

--- a/engine/meeting.js
+++ b/engine/meeting.js
@@ -14,8 +14,7 @@ const { renderPlaybook } = require('./playbook');
 /** Patterns that indicate an agent returned no meaningful output */
 const EMPTY_OUTPUT_PATTERNS = ['(no output)', '(no findings)', '(no response)'];
 
-let _engine = null;
-function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
+// No lazy require needed — log comes from shared.js, no engine-specific APIs used
 
 const MEETINGS_DIR = path.join(__dirname, '..', 'meetings');
 
@@ -179,7 +178,6 @@ function discoverMeetingWork(config) {
  * Called from runPostCompletionHooks when type === 'meeting'.
  */
 function collectMeetingFindings(meetingId, agentId, roundName, output) {
-  const e = engine();
   const meeting = getMeeting(meetingId);
   if (!meeting) return;
 
@@ -188,7 +186,7 @@ function collectMeetingFindings(meetingId, agentId, roundName, output) {
 
   // Validate output — reject empty or placeholder responses
   if (!rawContent || EMPTY_OUTPUT_PATTERNS.includes(rawContent)) {
-    e.log('warn', `Meeting ${meetingId}: agent ${agentId} returned empty output for ${roundName} — rejecting`);
+    log('warn', `Meeting ${meetingId}: agent ${agentId} returned empty output for ${roundName} — rejecting`);
     // Don't record it — agent will be re-dispatched on next tick
     saveMeeting(meeting);
     return;
@@ -304,7 +302,6 @@ function deleteMeeting(id) {
  * Called from engine.js tick cycle.
  */
 function checkMeetingTimeouts(config) {
-  const e = engine();
   const meetings = getMeetings();
   const timeout = (config.engine || {}).meetingRoundTimeout
     || ENGINE_DEFAULTS.meetingRoundTimeout;
@@ -324,21 +321,21 @@ function checkMeetingTimeouts(config) {
     const totalCount = meeting.participants.length;
 
     if (meeting.status === 'investigating') {
-      e.log('warn', `Meeting ${meeting.id}: round 1 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to debate`);
+      log('warn', `Meeting ${meeting.id}: round 1 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to debate`);
       meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: `Round 1 timed out — ${respondedCount}/${totalCount} findings received`, at: new Date().toISOString() });
       meeting.status = 'debating';
       meeting.round = 2;
       meeting.roundStartedAt = new Date().toISOString();
       saveMeeting(meeting);
     } else if (meeting.status === 'debating') {
-      e.log('warn', `Meeting ${meeting.id}: round 2 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to conclusion`);
+      log('warn', `Meeting ${meeting.id}: round 2 timed out after ${Math.round(elapsed / 60000)}min — ${respondedCount}/${totalCount} responded, advancing to conclusion`);
       meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: `Round 2 timed out — ${respondedCount}/${totalCount} debate responses received`, at: new Date().toISOString() });
       meeting.status = 'concluding';
       meeting.round = 3;
       meeting.roundStartedAt = new Date().toISOString();
       saveMeeting(meeting);
     } else if (meeting.status === 'concluding') {
-      e.log('warn', `Meeting ${meeting.id}: conclusion round timed out after ${Math.round(elapsed / 60000)}min — ending meeting without conclusion`);
+      log('warn', `Meeting ${meeting.id}: conclusion round timed out after ${Math.round(elapsed / 60000)}min — ending meeting without conclusion`);
       meeting.transcript.push({ round: meeting.round, agent: 'system', type: 'timeout', content: 'Conclusion round timed out — meeting ended without conclusion', at: new Date().toISOString() });
       meeting.status = 'completed';
       meeting.completedAt = new Date().toISOString();

--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -290,15 +290,13 @@ function renderPlaybook(type, vars) {
     .filter(([, val]) => String(val) === '')
     .map(([key]) => key);
   if (emptyVars.length > 0) {
-    const msg = `Playbook "${type}": template variables resolved to empty string: ${emptyVars.join(', ')}`;
-    try { engine().log('warn', msg); } catch { /* engine not ready */ }
+    log('warn', `Playbook "${type}": template variables resolved to empty string: ${emptyVars.join(', ')}`);
   }
 
   // Warn on any remaining unresolved {{variable}} placeholders
   const unresolved = [...new Set((content.match(/\{\{(\w+)\}\}/g) || []).map(m => m.slice(2, -2)))];
   if (unresolved.length > 0) {
-    const msg = `Playbook "${type}": unresolved template variables: ${unresolved.join(', ')}`;
-    try { engine().log('warn', msg); } catch { /* engine not ready */ }
+    log('warn', `Playbook "${type}": unresolved template variables: ${unresolved.join(', ')}`);
   }
 
   return content;

--- a/engine/routing.js
+++ b/engine/routing.js
@@ -8,15 +8,11 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
-const { safeJson, safeRead } = shared;
+const { safeJson, safeRead, log, ts } = shared;
 const { ENGINE_DIR, DISPATCH_PATH } = queries;
 
 const MINIONS_DIR = path.resolve(__dirname, '..');
 const ROUTING_PATH = path.join(MINIONS_DIR, 'routing.md');
-
-// Lazy require to avoid circular dependency with engine.js
-let _engine = null;
-function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
 
 // ─── Temp Agents ─────────────────────────────────────────────────────────────
 
@@ -140,8 +136,8 @@ function resolveAgent(workType, config, authorAgent = null) {
   if (config.engine?.allowTempAgents) {
     const tempId = `temp-${shared.uid()}`;
     _claimedAgents.add(tempId);
-    tempAgents.set(tempId, { name: `Temp-${tempId.slice(5, 9)}`, role: 'Temporary Agent', createdAt: engine().ts() });
-    engine().log('info', `Spawning temp agent ${tempId} — all permanent agents busy`);
+    tempAgents.set(tempId, { name: `Temp-${tempId.slice(5, 9)}`, role: 'Temporary Agent', createdAt: ts() });
+    log('info', `Spawning temp agent ${tempId} — all permanent agents busy`);
     return tempId;
   }
 

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -8,16 +8,15 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
-const { safeRead, safeWrite, safeJson, getProjects, projectWorkItemsPath, ENGINE_DEFAULTS: DEFAULTS } = shared;
+const { safeRead, safeWrite, safeJson, getProjects, projectWorkItemsPath, log, ts, ENGINE_DEFAULTS: DEFAULTS } = shared;
 const { getDispatch, getAgentStatus } = queries;
 const AGENTS_DIR = queries.AGENTS_DIR;
 const MINIONS_DIR = shared.MINIONS_DIR;
 
 // Lazy require to break circular dependency with engine.js
+// Only needed for engine().activeProcesses and engine().engineRestartGraceUntil — log/ts come from shared.js
 let _engine = null;
 function engine() { if (!_engine) _engine = require('../engine'); return _engine; }
-function log(level, msg, meta) { return engine().log(level, msg, meta); }
-function ts() { return engine().ts(); }
 
 // Lazy require for dispatch module (also circular via engine)
 let _dispatch = null;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4960,6 +4960,9 @@ async function main() {
     // Scheduler tests
     await testSchedulerCronParsing();
 
+    // P-b8c7d6e5: shared imports refactor (no circular requires)
+    await testSharedImportsNoCircular();
+
     // Session 2026-03-31 features
     await testSessionFeatures();
   } finally {
@@ -5257,6 +5260,60 @@ async function testKbSweepBatching() {
     assert.ok(src.includes('BATCH_SIZE'), 'sweep should use BATCH_SIZE');
     assert.ok(src.includes('batches.length'), 'sweep should iterate batches');
     assert.ok(src.includes('batch ${b + 1}'), 'sweep should log batch progress');
+  });
+}
+
+async function testSharedImportsNoCircular() {
+  // P-b8c7d6e5: Verify refactored modules import log/ts from shared, not engine
+  await test('cooldown.js has no lazy require of engine.js', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'cooldown.js'), 'utf8');
+    assert.ok(!src.includes("require('../engine')"), 'cooldown.js should not require engine.js');
+    assert.ok(src.includes("log } = shared") || src.includes("log,") || src.includes("log }"), 'cooldown.js should import log from shared');
+  });
+
+  await test('routing.js has no lazy require of engine.js', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'routing.js'), 'utf8');
+    assert.ok(!src.includes("require('../engine')"), 'routing.js should not require engine.js');
+  });
+
+  await test('meeting.js has no lazy require of engine.js', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'meeting.js'), 'utf8');
+    assert.ok(!src.includes("require('../engine')"), 'meeting.js should not require engine.js');
+  });
+
+  await test('playbook.js has no lazy require of engine.js', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'playbook.js'), 'utf8');
+    assert.ok(!src.includes("require('../engine')"), 'playbook.js should not require engine.js');
+  });
+
+  await test('cleanup.js retains lazy require for activeProcesses only', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'cleanup.js'), 'utf8');
+    assert.ok(src.includes("require('../engine')"), 'cleanup.js should still require engine for activeProcesses');
+    assert.ok(!src.includes("engine().log("), 'cleanup.js should not call engine().log()');
+    assert.ok(!src.includes("engine().ts("), 'cleanup.js should not call engine().ts()');
+  });
+
+  await test('timeout.js retains lazy require for activeProcesses only', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'timeout.js'), 'utf8');
+    assert.ok(src.includes("require('../engine')"), 'timeout.js should still require engine for activeProcesses');
+    assert.ok(!src.includes("engine().log("), 'timeout.js should not call engine().log()');
+    assert.ok(!src.includes("engine().ts("), 'timeout.js should not call engine().ts()');
+  });
+
+  await test('ado.js retains lazy require for handlePostMerge only', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'ado.js'), 'utf8');
+    assert.ok(src.includes("require('../engine')"), 'ado.js should still require engine for handlePostMerge');
+    assert.ok(!src.includes("engine().log("), 'ado.js should not call engine().log()');
+    assert.ok(!src.includes("engine().ts("), 'ado.js should not call engine().ts()');
+    assert.ok(!src.includes("engine().dateStamp("), 'ado.js should not call engine().dateStamp()');
+  });
+
+  await test('github.js retains lazy require for handlePostMerge only', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes("require('../engine')"), 'github.js should still require engine for handlePostMerge');
+    assert.ok(!src.includes("engine().log("), 'github.js should not call engine().log()');
+    assert.ok(!src.includes("engine().ts("), 'github.js should not call engine().ts()');
+    assert.ok(!src.includes("engine().dateStamp("), 'github.js should not call engine().dateStamp()');
   });
 }
 


### PR DESCRIPTION
## Summary
- Refactored 8 modules (cleanup, timeout, cooldown, meeting, routing, playbook, ado, github) to import log, ts, dateStamp directly from shared.js instead of lazy-requiring engine.js
- Removed lazy require entirely from 4 modules (cooldown, meeting, routing, playbook) that had no other engine dependencies
- Retained lazy require in 4 modules (cleanup, timeout, ado, github) that still need activeProcesses, handlePostMerge, or engineRestartGraceUntil
- Added 8 unit tests verifying no circular require regressions

## Test plan
- [x] All 586 unit tests pass (8 new, 0 failures)
- [x] No module calls engine().log() or engine().ts()
- [x] Modules with real engine deps retain their lazy require
- [x] Modules without engine deps have lazy require removed

Generated with [Claude Code](https://claude.com/claude-code)