### PR TITLE
feat(P-a0b9c8d7): checkpoint artifact support for agent resume on timeout

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1474,6 +1474,38 @@ function discoverFromWorkItems(config, project) {
     const ac = (item.acceptanceCriteria || []).map(c => '- [ ] ' + c).join('\n');
     vars.acceptance_criteria = ac ? '## Acceptance Criteria\n\n' + ac : '';
 
+    // Inject checkpoint context if agent left a checkpoint.json from a prior run
+    vars.checkpoint_context = '';
+    try {
+      const wtPath = vars.worktree_path || root;
+      const cpPath = path.join(wtPath, 'checkpoint.json');
+      if (fs.existsSync(cpPath)) {
+        const cpData = JSON.parse(fs.readFileSync(cpPath, 'utf8'));
+        const cpCount = (item._checkpointCount || 0) + 1;
+        if (cpCount > 3) {
+          log('warn', `Work item ${item.id} exceeded 3 checkpoint-resumes — marking as needs-human-review`);
+          item.status = 'needs-human-review';
+          item._checkpointCount = cpCount;
+          needsWrite = true;
+          continue;
+        }
+        item._checkpointCount = cpCount;
+        needsWrite = true;
+        const cpSummary = [
+          `## Checkpoint (Resume #${cpCount}/3)`,
+          '',
+          'A previous agent run timed out but left a checkpoint. Continue from where it left off.',
+          '',
+          cpData.completed && cpData.completed.length > 0 ? `### Completed\n${cpData.completed.map(s => '- ' + s).join('\n')}` : '',
+          cpData.remaining && cpData.remaining.length > 0 ? `### Remaining\n${cpData.remaining.map(s => '- ' + s).join('\n')}` : '',
+          cpData.blockers && cpData.blockers.length > 0 ? `### Blockers\n${cpData.blockers.map(s => '- ' + s).join('\n')}` : '',
+          cpData.branch_state ? `### Branch State\n${cpData.branch_state}` : '',
+        ].filter(Boolean).join('\n');
+        vars.checkpoint_context = cpSummary;
+        log('info', `Injecting checkpoint context for ${item.id} (resume #${cpCount})`);
+      }
+    } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
+
     // Inject ask-specific variables for the ask playbook
     if (workType === 'ask') {
       vars.question = item.title + (item.description ? '\n\n' + item.description : '');
@@ -1843,6 +1875,39 @@ function discoverCentralWorkItems(config) {
       vars.references = normRefs ? '## References\n\n' + normRefs : '';
       const normAc = (item.acceptanceCriteria || []).map(c => '- [ ] ' + c).join('\n');
       vars.acceptance_criteria = normAc ? '## Acceptance Criteria\n\n' + normAc : '';
+
+      // Inject checkpoint context if agent left a checkpoint.json from a prior run
+      vars.checkpoint_context = '';
+      try {
+        const centralBranch = item.branch || `work/${item.id}`;
+        const centralWtPath = firstProject?.localPath
+          ? path.resolve(firstProject.localPath, config.engine?.worktreeRoot || '../worktrees', centralBranch)
+          : '';
+        const cpPath = centralWtPath ? path.join(centralWtPath, 'checkpoint.json') : '';
+        if (cpPath && fs.existsSync(cpPath)) {
+          const cpData = JSON.parse(fs.readFileSync(cpPath, 'utf8'));
+          const cpCount = (item._checkpointCount || 0) + 1;
+          if (cpCount > 3) {
+            log('warn', `Work item ${item.id} exceeded 3 checkpoint-resumes — marking as needs-human-review`);
+            item.status = 'needs-human-review';
+            item._checkpointCount = cpCount;
+            continue;
+          }
+          item._checkpointCount = cpCount;
+          const cpSummary = [
+            `## Checkpoint (Resume #${cpCount}/3)`,
+            '',
+            'A previous agent run timed out but left a checkpoint. Continue from where it left off.',
+            '',
+            cpData.completed && cpData.completed.length > 0 ? `### Completed\n${cpData.completed.map(s => '- ' + s).join('\n')}` : '',
+            cpData.remaining && cpData.remaining.length > 0 ? `### Remaining\n${cpData.remaining.map(s => '- ' + s).join('\n')}` : '',
+            cpData.blockers && cpData.blockers.length > 0 ? `### Blockers\n${cpData.blockers.map(s => '- ' + s).join('\n')}` : '',
+            cpData.branch_state ? `### Branch State\n${cpData.branch_state}` : '',
+          ].filter(Boolean).join('\n');
+          vars.checkpoint_context = cpSummary;
+          log('info', `Injecting checkpoint context for ${item.id} (resume #${cpCount})`);
+        }
+      } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
 
       // Inject plan-specific variables for the plan playbook
       if (workType === 'plan') {

--- a/playbooks/fix.md
+++ b/playbooks/fix.md
@@ -11,6 +11,8 @@ Repo: {{repo_name}} | Org: {{ado_org}} | Project: {{ado_project}}
 Fix issues found by {{reviewer}} on **{{pr_id}}**: {{pr_title}}
 Branch: `{{pr_branch}}`
 
+{{checkpoint_context}}
+
 ## Review Findings to Address
 
 {{review_note}}

--- a/playbooks/implement.md
+++ b/playbooks/implement.md
@@ -18,6 +18,8 @@ Implement PRD item **{{item_id}}: {{item_name}}**
 - Complexity: {{item_complexity}}
 - Description: {{item_description}}
 
+{{checkpoint_context}}
+
 ## Projects
 
 Primary repo: **{{repo_name}}** ({{ado_org}}/{{ado_project}}) at `{{project_path}}`

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4962,6 +4962,9 @@ async function main() {
 
     // Session 2026-03-31 features
     await testSessionFeatures();
+
+    // Checkpoint resume support
+    await testCheckpointResume();
   } finally {
     cleanupTmpDirs();
   }
@@ -5274,6 +5277,72 @@ async function testSessionFeatures() {
   await testAutoModeStatus();
   await testApiRoutesInCcPreamble();
   await testKbSweepBatching();
+}
+
+// ─── Checkpoint Resume Tests ────────────────────────────────────────────────
+
+async function testCheckpointResume() {
+  console.log('\n── Checkpoint Resume ──');
+
+  const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+  const implementPb = fs.readFileSync(path.join(MINIONS_DIR, 'playbooks', 'implement.md'), 'utf8');
+  const fixPb = fs.readFileSync(path.join(MINIONS_DIR, 'playbooks', 'fix.md'), 'utf8');
+
+  await test('engine.js detects checkpoint.json in worktree', () => {
+    assert.ok(engineSrc.includes("checkpoint.json") && engineSrc.includes("fs.existsSync(cpPath)"),
+      'Should look for checkpoint.json in the agent worktree directory');
+  });
+
+  await test('engine.js injects checkpoint_context variable from checkpoint.json', () => {
+    assert.ok(engineSrc.includes("vars.checkpoint_context") && engineSrc.includes("cpSummary"),
+      'Should build checkpoint_context variable from checkpoint.json contents');
+  });
+
+  await test('checkpoint_context includes completed/remaining/blockers/branch_state', () => {
+    assert.ok(engineSrc.includes('cpData.completed') && engineSrc.includes('cpData.remaining') &&
+      engineSrc.includes('cpData.blockers') && engineSrc.includes('cpData.branch_state'),
+      'Should read all four checkpoint fields');
+  });
+
+  await test('engine.js tracks _checkpointCount on work items', () => {
+    assert.ok(engineSrc.includes('_checkpointCount'),
+      'Must track _checkpointCount on work items');
+    assert.ok(engineSrc.includes("(item._checkpointCount || 0) + 1"),
+      'Should increment _checkpointCount from current value');
+  });
+
+  await test('engine.js caps checkpoint-resumes at 3', () => {
+    assert.ok(engineSrc.includes('cpCount > 3'),
+      'Should check if checkpoint count exceeds 3');
+    assert.ok(engineSrc.includes("'needs-human-review'"),
+      'Should set status to needs-human-review after 3 checkpoint-resumes');
+  });
+
+  await test('checkpoint_context defaults to empty string when no checkpoint', () => {
+    const matches = engineSrc.match(/vars\.checkpoint_context\s*=\s*''/g);
+    assert.ok(matches && matches.length >= 2,
+      'Should default checkpoint_context to empty string in both project and central dispatch paths');
+  });
+
+  await test('implement.md playbook includes checkpoint_context', () => {
+    assert.ok(implementPb.includes('{{checkpoint_context}}'),
+      'implement.md must include {{checkpoint_context}} template variable');
+  });
+
+  await test('fix.md playbook includes checkpoint_context', () => {
+    assert.ok(fixPb.includes('{{checkpoint_context}}'),
+      'fix.md must include {{checkpoint_context}} template variable');
+  });
+
+  await test('checkpoint resume logs injection info', () => {
+    assert.ok(engineSrc.includes('Injecting checkpoint context for'),
+      'Should log when checkpoint context is injected');
+  });
+
+  await test('checkpoint resume logs needs-human-review escalation', () => {
+    assert.ok(engineSrc.includes('exceeded 3 checkpoint-resumes'),
+      'Should log when work item is escalated to needs-human-review');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Agents can write `checkpoint.json` (`{ completed, remaining, blockers, branch_state }`) to their worktree at milestones
- Engine detects `checkpoint.json` on redispatch and injects contents as `{{checkpoint_context}}` into playbook variables
- Both project-scoped and central work item dispatch paths support checkpoint detection
- `_checkpointCount` tracked on work items, incremented each resume-from-checkpoint
- After 3 checkpoint-resumes, item status set to `needs-human-review` (prevents infinite loops)
- `implement.md` and `fix.md` playbooks include `{{checkpoint_context}}` section (empty string when no checkpoint)

## Files Changed

| File | Change |
|------|--------|
| `engine.js` | Checkpoint detection + `_checkpointCount` tracking in both dispatch paths |
| `playbooks/implement.md` | Added `{{checkpoint_context}}` after task description |
| `playbooks/fix.md` | Added `{{checkpoint_context}}` after task description |
| `test/unit.test.js` | 10 new tests for checkpoint resume behavior |

## Test Plan

- [x] All 588 unit tests pass (0 failures, 2 skipped)
- [x] 10 new checkpoint-specific tests cover: detection, injection, field parsing, count tracking, 3-resume cap, empty default, playbook variables, logging
- [ ] Manual: create a `checkpoint.json` in a worktree, trigger dispatch, verify context appears in rendered playbook

Built by Minions (Ripley — Lead / Explorer)