### PR TITLE
feat(W-mngm9ub33al7): horizontally resizable command center panel

### DIFF
--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -9,6 +9,7 @@ let _ccQueue = [];
 function toggleCommandCenter() {
   _ccOpen = !_ccOpen;
   const drawer = document.getElementById('cc-drawer');
+  if (_ccOpen) ccApplySavedWidth();
   drawer.style.display = _ccOpen ? 'flex' : 'none';
   if (_ccOpen) {
     clearNotifBadge(document.getElementById('cc-toggle-btn'));
@@ -460,6 +461,64 @@ async function ccExecuteAction(action) {
   msgs.appendChild(status);
   msgs.scrollTop = msgs.scrollHeight;
   refresh();
+}
+
+// --- CC Resize Logic ---
+const CC_MIN_WIDTH = 320;
+const CC_MAX_WIDTH_RATIO = 0.8; // 80% of viewport
+const CC_DEFAULT_WIDTH = 420;
+const CC_WIDTH_KEY = 'cc-drawer-width';
+
+function ccApplySavedWidth() {
+  const drawer = document.getElementById('cc-drawer');
+  if (!drawer) return;
+  const saved = parseInt(localStorage.getItem(CC_WIDTH_KEY), 10);
+  if (saved && saved >= CC_MIN_WIDTH) {
+    const maxW = Math.floor(window.innerWidth * CC_MAX_WIDTH_RATIO);
+    drawer.style.width = Math.min(saved, maxW) + 'px';
+  }
+}
+
+function ccInitResize() {
+  const handle = document.getElementById('cc-resize-handle');
+  const drawer = document.getElementById('cc-drawer');
+  if (!handle || !drawer) return;
+
+  let startX = 0;
+  let startW = 0;
+
+  function onMouseMove(e) {
+    const maxW = Math.floor(window.innerWidth * CC_MAX_WIDTH_RATIO);
+    const delta = startX - e.clientX; // dragging left = wider
+    const newW = Math.max(CC_MIN_WIDTH, Math.min(startW + delta, maxW));
+    drawer.style.width = newW + 'px';
+  }
+
+  function onMouseUp() {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    document.body.classList.remove('cc-resizing');
+    handle.classList.remove('active');
+    // Persist
+    try { localStorage.setItem(CC_WIDTH_KEY, parseInt(drawer.style.width, 10)); } catch {}
+  }
+
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    startX = e.clientX;
+    startW = drawer.offsetWidth;
+    document.body.classList.add('cc-resizing');
+    handle.classList.add('active');
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+}
+
+// Init resize on DOM ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', ccInitResize);
+} else {
+  ccInitResize();
 }
 
 window.MinionsCC = { toggleCommandCenter, ccNewSession, ccRestoreMessages, ccSaveState, ccUpdateSessionIndicator, ccAddMessage, ccSend, ccExecuteAction };

--- a/dashboard/layout.html
+++ b/dashboard/layout.html
@@ -22,6 +22,7 @@
 
 <!-- Command Center Drawer -->
 <div id="cc-drawer" style="display:none;position:fixed;top:0;right:0;bottom:0;width:420px;background:var(--surface);border-left:1px solid var(--border);z-index:300;flex-direction:column">
+  <div id="cc-resize-handle" class="cc-resize-handle"></div>
   <div style="padding:12px 16px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between">
     <div style="display:flex;align-items:center;gap:8px">
       <span style="font-weight:700;color:var(--blue);font-size:14px">Command Center</span>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -579,6 +579,13 @@
   .notif-badge.processing span:nth-child(2) { animation-delay: 0.2s; }
   .notif-badge.processing span:nth-child(3) { animation-delay: 0.4s; }
   @keyframes notifPulse { 0%,100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+  /* Command Center resize handle */
+  .cc-resize-handle { position: absolute; top: 0; left: -3px; bottom: 0; width: 6px; cursor: col-resize; z-index: 301; }
+  .cc-resize-handle::after { content: ''; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 2px; height: 32px; background: var(--border); border-radius: 2px; opacity: 0; transition: opacity 0.15s; }
+  .cc-resize-handle:hover::after, .cc-resize-handle.active::after { opacity: 1; background: var(--blue); }
+  body.cc-resizing { cursor: col-resize !important; user-select: none !important; }
+
   .modal-body { padding: var(--space-7) var(--space-8); overflow-y: auto; overflow-x: auto; white-space: pre-wrap; font-size: var(--text-md); line-height: 1.7; color: var(--muted); font-family: Consolas, monospace; }
 
   /* Responsive: tablet / narrow window */


### PR DESCRIPTION
## Summary
- Adds a drag handle on the left edge of the Command Center drawer panel for horizontal resizing
- Persists user-chosen width in localStorage across page reloads
- Enforces minimum width of 320px and maximum of 80% viewport width
- Visual indicator (blue line) appears on hover/drag for discoverability

## Changes
- `dashboard/layout.html` — added `cc-resize-handle` div inside the drawer
- `dashboard/styles.css` — resize handle styling with hover/active states, body cursor override during drag
- `dashboard/js/command-center.js` — resize logic (mousedown/mousemove/mouseup), localStorage persistence, width restore on panel open

## Test plan
- [ ] Open CC panel, verify drag handle appears on left edge (subtle line on hover)
- [ ] Drag handle left to widen panel, right to narrow — width follows cursor
- [ ] Release drag, close and reopen panel — width should be preserved
- [ ] Drag to minimum (320px) — should not go narrower
- [ ] Drag past 80% of viewport — should clamp
- [ ] All 578 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)