### PR TITLE
feat(W-mngn2qiz0p1r): remove pr-links.json — derive links from pull-requests.json prdItems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Markdown files with YAML frontmatter in `.claude/skills/<name>/SKILL.md`. Agents
 
 ## ADO Integration
 
-Token via `azureauth ado token --mode iwa --mode broker`. Cached 30 min, 10-min backoff on failure. PR status polled every ~3 min, human comments every ~6 min. PR → PRD item linking tracked in `pr-links.json`.
+Token via `azureauth ado token --mode iwa --mode broker`. Cached 30 min, 10-min backoff on failure. PR status polled every ~3 min, human comments every ~6 min. PR → PRD item linking derived from `pull-requests.json` prdItems.
 
 ## Dashboard
 

--- a/engine.js
+++ b/engine.js
@@ -787,8 +787,7 @@ function detectDependencyCycles(items) {
 // writeInboxAlert — now in engine/dispatch.js
 
 // Reconciles work items against known PRs.
-// Primary linkage comes from prdItems in pull-requests.json; fallback linkage
-// uses engine/pr-links.json so matching does not depend on branch/title parsing.
+// Primary linkage comes from prdItems in pull-requests.json (via getPrLinks()).
 // onlyIds: if provided, only items whose ID is in this Set are eligible.
 function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
   const prLinks = shared.getPrLinks();

--- a/minions.js
+++ b/minions.js
@@ -480,7 +480,7 @@ function nukeMinions() {
   console.log('\n  Cleaning runtime state...');
   const runtimeDirs = ['projects', 'plans', 'prd', 'knowledge', 'skills', 'notes', 'identity'];
   const runtimeFiles = ['config.json', 'work-items.json', 'notes.md', 'routing.md'];
-  const engineRuntimeFiles = ['control.json', 'dispatch.json', 'log.json', 'metrics.json', 'cooldowns.json', 'pr-links.json', 'kb-checkpoint.json', 'cc-session.json', 'doc-sessions.json'];
+  const engineRuntimeFiles = ['control.json', 'dispatch.json', 'log.json', 'metrics.json', 'cooldowns.json', 'kb-checkpoint.json', 'cc-session.json', 'doc-sessions.json'];
 
   for (const dir of runtimeDirs) {
     const p = path.join(MINIONS_HOME, dir);


### PR DESCRIPTION
## Summary
- Remove `engine/pr-links.json` as a separate state file — PR↔work-item links are now derived at runtime from `projects/*/pull-requests.json` prdItems
- Remove `addPrLink()` function, `PR_LINKS_PATH` constant, and all backfill blocks from `github.js` and `ado.js`
- Update `getPrLinks()` in `shared.js` to scan all project pull-requests.json files and build the link map from prdItems arrays
- Add comprehensive unit tests for the new derivation logic (config missing, malformed files, multiple prdItems)
- Add deprecation entry to `docs/deprecated.json` for cleanup tracking

## Files Changed
- `engine/shared.js` — Rewrote `getPrLinks()`, removed `addPrLink()` and `PR_LINKS_PATH`
- `engine/github.js` — Removed `addPrLink` import/calls and backfill block
- `engine/ado.js` — Same cleanup as github.js
- `engine/lifecycle.js` — Removed `addPrLink` import and call
- `engine.js` — Updated comment on reconcileItemsWithPrs
- `engine/queries.js` — Updated comments
- `minions.js` — Removed pr-links.json from runtime cleanup list
- `docs/deprecated.json` — Added pr-links-json entry
- `CLAUDE.md` — Updated ADO integration docs
- `test/unit.test.js` — Replaced addPrLink tests with getPrLinks derivation tests

## Test plan
- [x] All 581 unit tests pass (0 failures)
- [ ] Verify PR reconciliation still links PRs to work items correctly at runtime
- [ ] Confirm engine tick cycle works without pr-links.json on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)