### PR TITLE
feat(P-d7a3e1f4): add evaluate to playbook routing

### DIFF
--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -478,7 +478,7 @@ function selectPlaybook(workType, item) {
   if (workType === 'review' && !item?._pr && !item?.pr_id) {
     return 'work-item';
   }
-  const typeSpecificPlaybooks = ['explore', 'review', 'test', 'plan-to-prd', 'plan', 'ask', 'verify', 'decompose', 'meeting-investigate', 'meeting-debate', 'meeting-conclude'];
+  const typeSpecificPlaybooks = ['explore', 'review', 'test', 'plan-to-prd', 'plan', 'ask', 'verify', 'evaluate', 'decompose', 'meeting-investigate', 'meeting-debate', 'meeting-conclude'];
   return typeSpecificPlaybooks.includes(workType) ? workType : 'work-item';
 }
 


### PR DESCRIPTION
## Summary
- Adds `evaluate` to the `typeSpecificPlaybooks` array in `selectPlaybook()` at `engine/playbook.js:481`
- This ensures evaluate work items use the `evaluate.md` playbook instead of silently falling back to the generic `work-item` playbook
- The routing table in `routing.md` already had the evaluate row — no change needed there

## Notes
The `evaluate.md` playbook file arrives via PR-29. This fix is safe to land first — `loadPlaybook` gracefully falls back if the file is missing, and it becomes functional once PR-29 merges.

## Test plan
- [x] All 638 unit tests pass (`npm test`)
- [x] Verified `selectPlaybook('evaluate', item)` now returns `'evaluate'` instead of `'work-item'`
- [x] No other playbook routing affected (single array addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)