### PR TITLE
feat(P-a8d2c7e3): standardize maxTurns config resolution

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1011,7 +1011,8 @@ function updateMetrics(agentId, dispatchItem, result, taskUsage, prsCreatedCount
     if (taskUsage.numTurns > cp.maxTurns) cp.maxTurns = taskUsage.numTurns;
     // Check if this dispatch hit the turn limit
     const engineConfig = require('./queries').getConfig()?.engine || {};
-    const turnLimit = engineConfig.maxTurns || 100;
+    // maxTurns default defined in ENGINE_DEFAULTS (shared.js) — avoid hardcoded fallback
+    const turnLimit = engineConfig.maxTurns || shared.ENGINE_DEFAULTS.maxTurns;
     if (taskUsage.numTurns >= turnLimit) cp.turnLimitHits++;
   }
 
@@ -1206,7 +1207,8 @@ function runPostCompletionHooks(dispatchItem, agentId, code, stdout, config) {
   if (meta?.item?.id) {
     try {
       const engineConfig = (config.engine || {});
-      const turnLimit = engineConfig.maxTurns || 100;
+      // maxTurns resolved from config, fallback to ENGINE_DEFAULTS (shared.js)
+      const turnLimit = engineConfig.maxTurns || shared.ENGINE_DEFAULTS.maxTurns;
       const turnCount = taskUsage?.numTurns || 0;
       const hitTurnLimit = turnCount >= turnLimit;
       let outputLogSizeBytes = 0;


### PR DESCRIPTION
## Summary
- Replace hardcoded `|| 100` fallback with `|| shared.ENGINE_DEFAULTS.maxTurns` in `engine/lifecycle.js` (lines 1014 and 1209)
- Adds inline comments explaining the config resolution chain
- Matches the pattern already used in `engine.js:443` and `engine.js:564`

## Details
PR-32 introduced context utilization metrics that reference `engineConfig.maxTurns || 100`. While `ENGINE_DEFAULTS.maxTurns` is also `100`, using a hardcoded fallback diverges from the resolution pattern used elsewhere. If `ENGINE_DEFAULTS.maxTurns` ever changes, these two sites would silently use a stale value.

No other phantom config references were found in the affected code.

## Test plan
- [x] All 638 unit tests pass
- [x] Verified no remaining `|| 100` hardcoded maxTurns fallbacks in lifecycle.js
- [x] Confirmed `shared.ENGINE_DEFAULTS.maxTurns` is already accessible (used elsewhere in lifecycle.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)