### PR TITLE
feat(W-mngnrsqly0o6): add pill styles for evaluate, meeting, verify, decompose types

### DIFF
--- a/dashboard/js/render-work-items.js
+++ b/dashboard/js/render-work-items.js
@@ -92,7 +92,7 @@ function renderWorkItems(items) {
 function editWorkItem(id, source) {
   const item = allWorkItems.find(i => i.id === id);
   if (!item) return;
-  const types = ['implement', 'fix', 'review', 'plan', 'verify', 'investigate', 'refactor', 'test', 'docs'];
+  const types = ['implement', 'fix', 'review', 'plan', 'verify', 'evaluate', 'decompose', 'meeting', 'investigate', 'refactor', 'test', 'explore', 'ask', 'docs'];
   const priorities = ['critical', 'high', 'medium', 'low'];
   const agentOpts = (cmdAgents || []).map(a => '<option value="' + escHtml(a.id) + '"' + (item.agent === a.id ? ' selected' : '') + '>' + escHtml(a.name) + '</option>').join('');
   const typeOpts = types.map(t => '<option value="' + t + '"' + ((item.type || 'implement') === t ? ' selected' : '') + '>' + t + '</option>').join('');
@@ -282,7 +282,7 @@ async function submitFeedback(id, source) {
 }
 
 function openCreateWorkItemModal() {
-  const typeOpts = ['implement', 'fix', 'explore', 'test', 'review', 'ask', 'plan'].map(t =>
+  const typeOpts = ['implement', 'fix', 'explore', 'test', 'review', 'ask', 'plan', 'verify', 'evaluate', 'decompose', 'meeting'].map(t =>
     '<option value="' + t + '"' + (t === 'implement' ? ' selected' : '') + '>' + t + '</option>'
   ).join('');
   const priOpts = ['high', 'medium', 'low'].map(p =>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -507,6 +507,10 @@
   .dispatch-type.plan { background: rgba(168,85,247,0.15); color: #a855f7; }
   .dispatch-type.plan-to-prd { background: rgba(168,85,247,0.1); color: #a855f7; }
   .dispatch-type.ask { background: rgba(63,185,80,0.15); color: var(--green); }
+  .dispatch-type.evaluate { background: rgba(248,81,73,0.15); color: var(--red); }
+  .dispatch-type.verify { background: rgba(63,185,80,0.2); color: var(--green); }
+  .dispatch-type.meeting { background: rgba(88,166,255,0.2); color: var(--blue); }
+  .dispatch-type.decompose { background: rgba(188,140,255,0.2); color: var(--purple); }
   .dispatch-type.manual { background: rgba(139,148,158,0.15); color: var(--muted); }
   .dispatch-agent { font-weight: 600; color: var(--text); }
   .dispatch-task { flex: 1; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
## Summary
- Added distinct colored CSS pill styles for `evaluate` (red), `meeting` (blue), `verify` (green), and `decompose` (purple) work item types that were falling back to unstyled appearance
- Added all routable types to the edit work item type dropdown and create work item modal
- Colors chosen to be visually distinct while harmonizing with existing palette

## Files Changed
- `dashboard/styles.css` — 4 new `.dispatch-type.*` rules
- `dashboard/js/render-work-items.js` — expanded type arrays in edit modal and create modal

## Test plan
- [x] All 638 unit tests pass
- [ ] Visual verification: open dashboard, check work items with type evaluate/meeting/verify/decompose show colored pills
- [ ] Create work item modal shows all new types in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)