### PR TITLE
feat(P-a8f4c2d9): add checkpoint handling to fan-out dispatch path

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1802,6 +1802,41 @@ function discoverCentralWorkItems(config) {
         assignedProject: projects.length > 0 ? projects[i % projects.length] : null
       }));
 
+      // Inject checkpoint context if agent left a checkpoint.json from a prior run
+      let fanOutCheckpointContext = '';
+      try {
+        const fanFirstProject = projects[0];
+        const fanBranch = item.branch || `work/${item.id}`;
+        const fanWtPath = fanFirstProject?.localPath
+          ? path.resolve(fanFirstProject.localPath, config.engine?.worktreeRoot || '../worktrees', fanBranch)
+          : '';
+        const fanCpPath = fanWtPath ? path.join(fanWtPath, 'checkpoint.json') : '';
+        if (fanCpPath && fs.existsSync(fanCpPath)) {
+          const fanCpData = JSON.parse(fs.readFileSync(fanCpPath, 'utf8'));
+          const fanCpCount = (item._checkpointCount || 0) + 1;
+          if (fanCpCount > 3) {
+            log('warn', `Work item ${item.id} exceeded 3 checkpoint-resumes — marking as needs-human-review`);
+            item.status = 'needs-human-review';
+            item._checkpointCount = fanCpCount;
+            needsWrite = true;
+            continue;
+          }
+          item._checkpointCount = fanCpCount;
+          const fanCpSummary = [
+            `## Checkpoint (Resume #${fanCpCount}/3)`,
+            '',
+            'A previous agent run timed out but left a checkpoint. Continue from where it left off.',
+            '',
+            Array.isArray(fanCpData.completed) && fanCpData.completed.length > 0 ? `### Completed\n${fanCpData.completed.map(s => '- ' + s).join('\n')}` : '',
+            Array.isArray(fanCpData.remaining) && fanCpData.remaining.length > 0 ? `### Remaining\n${fanCpData.remaining.map(s => '- ' + s).join('\n')}` : '',
+            Array.isArray(fanCpData.blockers) && fanCpData.blockers.length > 0 ? `### Blockers\n${fanCpData.blockers.map(s => '- ' + s).join('\n')}` : '',
+            fanCpData.branch_state ? `### Branch State\n${fanCpData.branch_state}` : '',
+          ].filter(Boolean).join('\n');
+          fanOutCheckpointContext = fanCpSummary;
+          log('info', `Injecting checkpoint context for ${item.id} (resume #${fanCpCount})`);
+        }
+      } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
+
       for (const { agent, assignedProject } of assignments) {
         const fanKey = `${key}-${agent.id}`;
         if (isAlreadyDispatched(fanKey)) continue;
@@ -1832,6 +1867,10 @@ function discoverCentralWorkItems(config) {
         vars.pr_section = item.skipPr
           ? '## Push Branch\n\n**PR creation is skipped for this work item.** Push your branch and report the branch name.\n\n```bash\ngit push -u origin ' + fanBranch + '\n```\n\nInclude the branch name in your completion summary.'
           : '## Create PR (MANDATORY)\n\n**Your task is NOT complete until a pull request exists.** If PR creation fails, retry up to 3 times before reporting the error.\n\n{{pr_create_instructions}}\n- sourceRefName: `refs/heads/' + fanBranch + '`\n- targetRefName: `refs/heads/{{main_branch}}`\n- title: `{{commit_message}}`\n- labels: `["minions:{{agent_id}}"]`\n\nInclude in the PR description:\n- What was built and why\n- Files changed\n- How to build and test, browser URL if applicable\n- Test plan\n\n## Post self-review on PR\n\n{{pr_comment_instructions}}\n- pullRequestId: `<from PR creation>`\n- Re-read your own diff critically before posting\n- Sign: `Built by Minions ({{agent_name}} — {{agent_role}})`';
+
+        // Inject checkpoint context (computed once above the loop)
+        vars.checkpoint_context = fanOutCheckpointContext;
+
 
         if (workType === 'ask') {
           vars.question = item.title + (item.description ? '\n\n' + item.description : '');


### PR DESCRIPTION
## Summary

- Mirrors checkpoint.json logic from the single-agent dispatch path into the fan-out dispatch loop in `engine.js`
- Reads checkpoint.json from the worktree, injects `checkpoint_context` into template vars, increments `_checkpointCount`, and escalates to `needs-human-review` after 3 resumes
- Adds 6 unit tests covering fan-out checkpoint injection, escalation, and persistence

## Test plan

- [x] All 647 unit tests pass (6 new fan-out checkpoint tests)
- [ ] Verify fan-out dispatch with a checkpoint.json present picks up context
- [ ] Verify fan-out item exceeding 3 checkpoint resumes gets escalated

🤖 Generated with [Claude Code](https://claude.com/claude-code)