### PR TITLE
feat(P-e6b0d3a5): clean up checkpoint.json after consumption and fix _pendingReason persistence

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1521,6 +1521,7 @@ function discoverFromWorkItems(config, project) {
         ].filter(Boolean).join('\n');
         vars.checkpoint_context = cpSummary;
         log('info', `Injecting checkpoint context for ${item.id} (resume #${cpCount})`);
+        try { fs.unlinkSync(cpPath); } catch (ue) { log('warn', `checkpoint cleanup for ${item.id}: ${ue.message}`); }
       }
     } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
 
@@ -1834,6 +1835,7 @@ function discoverCentralWorkItems(config) {
           ].filter(Boolean).join('\n');
           fanOutCheckpointContext = fanCpSummary;
           log('info', `Injecting checkpoint context for ${item.id} (resume #${fanCpCount})`);
+          try { fs.unlinkSync(fanCpPath); } catch (ue) { log('warn', `checkpoint cleanup for ${item.id}: ${ue.message}`); }
         }
       } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
 
@@ -1917,6 +1919,7 @@ function discoverCentralWorkItems(config) {
       item.dispatched_to = idleAgents.map(a => a.id).join(', ');
       item.scope = 'fan-out';
       item.fanOutAgents = idleAgents.map(a => a.id);
+      delete item._pendingReason;
       needsWrite = true;
       setCooldown(key);
       log('info', `Fan-out: ${item.id} dispatched to ${idleAgents.length} agents: ${idleAgents.map(a => a.name).join(', ')}`);
@@ -1985,6 +1988,7 @@ function discoverCentralWorkItems(config) {
           ].filter(Boolean).join('\n');
           vars.checkpoint_context = cpSummary;
           log('info', `Injecting checkpoint context for ${item.id} (resume #${cpCount})`);
+          try { fs.unlinkSync(cpPath); } catch (ue) { log('warn', `checkpoint cleanup for ${item.id}: ${ue.message}`); }
         }
       } catch (e) { log('warn', `checkpoint read for ${item.id}: ${e.message}`); }
 
@@ -2067,6 +2071,7 @@ function discoverCentralWorkItems(config) {
       item.status = 'dispatched';
       item.dispatched_at = ts();
       item.dispatched_to = agentId;
+      delete item._pendingReason;
       needsWrite = true;
       setCooldown(key);
     }


### PR DESCRIPTION
## Summary

- **Checkpoint cleanup**: Added `fs.unlinkSync(cpPath)` after successful checkpoint consumption in all three dispatch paths (project, fan-out, single-agent) to prevent stale checkpoints from causing false resumes and inflating `_checkpointCount` on subsequent ticks
- **_pendingReason fix**: Added `delete item._pendingReason` on successful fan-out and single-agent central dispatch, matching the existing project dispatch behavior (line ~1546)
- **Tests**: 5 new source-level assertion tests verifying checkpoint cleanup and _pendingReason clearing across all dispatch paths

## Test plan

- [x] All 5 new tests pass (checkpoint cleanup × 3 paths + _pendingReason × 2 paths)
- [x] 652 passed, 1 pre-existing failure (unrelated P-f7a2d8e1 persistence gate test), 2 skipped
- [ ] Manual: dispatch a work item with a stale checkpoint.json in worktree, verify it's deleted after dispatch
- [ ] Manual: dispatch a fan-out work item that previously had _pendingReason, verify it's cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)