### PR TITLE
feat(P-f7g3h2j6): add evaluate type to routing and playbooks

### DIFF
--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -481,7 +481,7 @@ function selectPlaybook(workType, item) {
   if (workType === 'review' && !item?._pr && !item?.pr_id) {
     return 'work-item';
   }
-  const typeSpecificPlaybooks = ['explore', 'review', 'test', 'plan-to-prd', 'plan', 'ask', 'verify', 'decompose', 'meeting-investigate', 'meeting-debate', 'meeting-conclude'];
+  const typeSpecificPlaybooks = ['explore', 'review', 'test', 'plan-to-prd', 'plan', 'ask', 'verify', 'decompose', 'evaluate', 'meeting-investigate', 'meeting-debate', 'meeting-conclude'];
   return typeSpecificPlaybooks.includes(workType) ? workType : 'work-item';
 }
 

--- a/playbooks/evaluate.md
+++ b/playbooks/evaluate.md
@@ -1,0 +1,149 @@
+# Playbook: Evaluate
+
+You are {{agent_name}}, the {{agent_role}} on the {{project_name}} project.
+TEAM ROOT: {{team_root}}
+
+## Your Task
+
+Evaluate the implementation quality of a completed work item against its acceptance criteria and code quality standards.
+
+## Work Item Under Evaluation
+
+- **ID:** {{item_id}}
+- **Title:** {{item_title}}
+- **Description:** {{item_description}}
+- **Branch:** `{{branch_name}}`
+- **Project:** {{project_name}} (`{{project_path}}`)
+
+{{#acceptance_criteria}}
+## Acceptance Criteria
+
+{{acceptance_criteria}}
+{{/acceptance_criteria}}
+
+{{#references}}
+## References
+
+{{references}}
+{{/references}}
+
+## Evaluation Rubric
+
+Score each category on a 1-5 scale. A category **passes** at 3 or above.
+
+### 1. Correctness (weight: 30%)
+
+Does the implementation do what the task description and acceptance criteria require?
+
+- **5 — Excellent:** All acceptance criteria met, edge cases handled, no functional gaps
+- **4 — Good:** All core criteria met, minor edge cases not handled
+- **3 — Adequate:** Most criteria met, one minor gap that doesn't block usage
+- **2 — Deficient:** One or more acceptance criteria not met
+- **1 — Failing:** Core functionality missing or broken
+
+**Pass threshold:** 3
+
+### 2. Completeness (weight: 25%)
+
+Is the implementation finished end-to-end? No TODO stubs, no half-wired features, no missing integration points.
+
+- **5 — Excellent:** Fully integrated, no loose ends, documentation updated if applicable
+- **4 — Good:** Feature complete, minor polish items remain (comments, naming)
+- **3 — Adequate:** Core feature works, one non-critical integration point incomplete
+- **2 — Deficient:** Significant pieces missing or stubbed out
+- **1 — Failing:** Skeleton or partial implementation only
+
+**Pass threshold:** 3
+
+### 3. Code Quality (weight: 25%)
+
+Does the code follow existing project patterns, naming conventions, and architectural decisions?
+
+- **5 — Excellent:** Clean, idiomatic, follows all project conventions, well-structured
+- **4 — Good:** Follows conventions, minor style inconsistencies
+- **3 — Adequate:** Generally follows patterns, one area deviates without justification
+- **2 — Deficient:** Multiple convention violations, poor structure
+- **1 — Failing:** Ignores project patterns, introduces anti-patterns
+
+**Pass threshold:** 3
+
+### 4. Test Coverage (weight: 20%)
+
+Are there tests for the new functionality? Do existing tests still pass?
+
+- **5 — Excellent:** Comprehensive tests for happy path and edge cases, all passing
+- **4 — Good:** Tests cover core functionality, existing tests pass
+- **3 — Adequate:** At least one test for the main feature, no regressions
+- **2 — Deficient:** No new tests, but existing tests pass
+- **1 — Failing:** No tests, or existing tests broken
+
+**Pass threshold:** 3
+
+## Evaluation Steps
+
+1. **Fetch and review the diff:**
+   ```bash
+   git fetch origin
+   git diff {{main_branch}}...origin/{{branch_name}}
+   ```
+
+2. **Check acceptance criteria** one by one — mark each as MET or NOT MET with evidence
+
+3. **Review code quality** — check for pattern adherence, naming, structure
+
+4. **Verify tests:**
+   ```bash
+   cd {{project_path}}
+   npm test
+   ```
+
+5. **Calculate scores** using the rubric above
+
+6. **Determine verdict:**
+   - **PASS** — all four categories score 3 or above
+   - **FAIL** — any category scores below 3
+
+## Output Format
+
+Structure your evaluation result as follows:
+
+```
+## Evaluation Result
+
+**Item:** {{item_id}} — {{item_title}}
+**Verdict:** PASS | FAIL
+**Weighted Score:** X.X / 5.0
+
+### Scores
+
+| Category | Score | Pass | Notes |
+|----------|-------|------|-------|
+| Correctness | X/5 | YES/NO | ... |
+| Completeness | X/5 | YES/NO | ... |
+| Code Quality | X/5 | YES/NO | ... |
+| Test Coverage | X/5 | YES/NO | ... |
+
+### Acceptance Criteria Checklist
+
+- [x] Criterion 1 — evidence
+- [ ] Criterion 2 — what's missing
+
+### Issues Found
+
+1. **[severity]** Description (file:line)
+
+### Recommendations
+
+- What to fix before merging (if FAIL)
+- Suggestions for improvement (if PASS)
+```
+
+## Rules
+
+- Base your evaluation on **evidence from the diff and test output** — not assumptions
+- If acceptance criteria are missing, evaluate against the task description
+- A FAIL verdict should include actionable feedback — what specifically needs to change
+- Do NOT modify any code — this is a read-only evaluation
+- NEVER checkout branches in the main working tree — use `git diff` and `git show` only
+
+**Note:** Do NOT write to `agents/*/status.json` — the engine manages your status automatically.

--- a/routing.md
+++ b/routing.md
@@ -17,6 +17,7 @@ How the engine decides who handles what. Parsed by engine.js — keep the table 
 | test | dallas | ralph |
 | ask | ripley | rebecca |
 | verify | dallas | ralph |
+| evaluate | ripley | rebecca |
 | decompose | ripley | rebecca |
 | meeting | ripley | rebecca |
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3447,6 +3447,26 @@ async function testRenderPlaybook() {
       'Should not set critical_vars_missing error for plan type');
   });
 
+  await test('renderPlaybook with type=evaluate returns content from evaluate.md, not work-item.md', () => {
+    const result = renderPlaybook('evaluate', {
+      agent_name: 'TestAgent', agent_role: 'Lead', agent_id: 'ripley',
+      project_name: 'TestProject', project_path: '/tmp', main_branch: 'main',
+      task_title: 'Evaluate feature', task_description: 'Evaluate quality of implementation',
+      work_item_id: 'W-eval01', item_id: 'W-eval01', item_title: 'Test eval',
+      item_description: 'Evaluate quality', branch_name: 'work/W-eval01',
+      team_root: MINIONS_DIR, date: '2024-01-01',
+    });
+    assert.ok(typeof result === 'string' && result.length > 0,
+      'Should return rendered evaluate playbook');
+    assert.ok(result.includes('Evaluation Rubric'),
+      'Should contain evaluation rubric from evaluate.md');
+    assert.ok(result.includes('Correctness') && result.includes('Completeness') &&
+      result.includes('Code Quality') && result.includes('Test Coverage'),
+      'Should contain all four scoring categories');
+    assert.ok(!result.includes('Branch Naming Convention'),
+      'Should NOT contain work-item.md content (branch naming section)');
+  });
+
   await test('CRITICAL_VARS map defines expected entries', () => {
     let CRITICAL_VARS;
     try { CRITICAL_VARS = require(path.join(MINIONS_DIR, 'engine', 'playbook')).CRITICAL_VARS; } catch {}


### PR DESCRIPTION
## Summary

- Adds `| evaluate | ripley | rebecca |` row to `routing.md` so evaluate tasks route to the correct agents
- Creates `playbooks/evaluate.md` with a structured 4-category evaluation rubric (correctness, completeness, code quality, test coverage) — each with 1-5 scoring scale and pass/fail thresholds
- Adds `'evaluate'` to the `typeSpecificPlaybooks` array in `engine/playbook.js` so evaluate work items use the dedicated playbook instead of falling through to `work-item.md`
- Adds unit test verifying `renderPlaybook('evaluate', ...)` returns content from `evaluate.md` (not `work-item.md`)

## Test plan

- [x] All 646 unit tests pass (0 failures, 2 skipped)
- [x] New test confirms evaluate playbook renders with rubric categories
- [x] New test confirms evaluate playbook does NOT contain work-item.md content
- [ ] Manual: create an evaluate work item and verify it dispatches with the evaluate playbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)