### PR TITLE
feat(P-c8d2e7f4): fix cooldown context accumulation bloat

### DIFF
--- a/engine/cooldown.js
+++ b/engine/cooldown.js
@@ -7,10 +7,12 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
+const { createHash } = require('crypto');
 const { safeJson, safeWrite, log } = shared;
 const { ENGINE_DIR } = queries;
 
 const COOLDOWN_PATH = path.join(ENGINE_DIR, 'cooldowns.json');
+const PENDING_CONTEXTS_CAP = 10;
 const dispatchCooldowns = new Map(); // key → { timestamp, failures }
 
 function loadCooldowns() {
@@ -24,6 +26,35 @@ function loadCooldowns() {
     }
   }
   log('info', `Loaded ${dispatchCooldowns.size} cooldowns from disk`);
+  // One-time purge of bloated pendingContexts on startup
+  purgeBloatedCooldowns();
+}
+
+/** Deduplicate and cap pendingContexts in all loaded cooldown entries. */
+function purgeBloatedCooldowns() {
+  let totalRemoved = 0;
+  for (const [k, v] of dispatchCooldowns) {
+    if (!Array.isArray(v.pendingContexts) || v.pendingContexts.length <= 1) continue;
+    const seen = new Set();
+    const deduped = [];
+    for (const ctx of v.pendingContexts) {
+      const hash = _contentHash(ctx);
+      if (!seen.has(hash)) {
+        seen.add(hash);
+        deduped.push(ctx);
+      }
+    }
+    const before = v.pendingContexts.length;
+    // Apply FIFO cap after dedup — keep the most recent entries
+    v.pendingContexts = deduped.length > PENDING_CONTEXTS_CAP
+      ? deduped.slice(deduped.length - PENDING_CONTEXTS_CAP)
+      : deduped;
+    totalRemoved += before - v.pendingContexts.length;
+  }
+  if (totalRemoved > 0) {
+    log('info', `Purged ${totalRemoved} duplicate/excess pendingContexts entries from cooldowns`);
+    saveCooldowns();
+  }
 }
 
 let _cooldownWriteTimer = null;
@@ -55,10 +86,26 @@ function setCooldown(key) {
   saveCooldowns();
 }
 
+function _contentHash(content) {
+  const str = typeof content === 'string' ? content : JSON.stringify(content);
+  return createHash('sha256').update(str).digest('hex');
+}
+
 function setCooldownWithContext(key, context) {
   const existing = dispatchCooldowns.get(key);
   const pendingContexts = existing?.pendingContexts || [];
-  if (context) pendingContexts.push(context);
+  if (context) {
+    // Dedup: only append if content differs from all existing entries
+    const newHash = _contentHash(context);
+    const isDuplicate = pendingContexts.some(c => _contentHash(c) === newHash);
+    if (!isDuplicate) {
+      pendingContexts.push(context);
+      // FIFO cap: drop oldest entries when exceeding cap
+      while (pendingContexts.length > PENDING_CONTEXTS_CAP) {
+        pendingContexts.shift();
+      }
+    }
+  }
   dispatchCooldowns.set(key, {
     timestamp: Date.now(),
     failures: existing?.failures || 0,
@@ -101,13 +148,16 @@ function isAlreadyDispatched(key) {
 
 module.exports = {
   COOLDOWN_PATH,
+  PENDING_CONTEXTS_CAP,
   dispatchCooldowns,
   loadCooldowns,
   saveCooldowns,
+  purgeBloatedCooldowns,
   isOnCooldown,
   setCooldown,
   setCooldownWithContext,
   getCoalescedContexts,
   setCooldownFailure,
   isAlreadyDispatched,
+  _contentHash,
 };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3287,6 +3287,123 @@ async function testCooldownSystem() {
     assert.strictEqual(formula(3), 8);
     assert.strictEqual(formula(10), 8); // capped
   });
+
+  await test('setCooldownWithContext uses content-hash dedup', () => {
+    assert.ok(src.includes('_contentHash') && src.includes('isDuplicate'),
+      'Should hash content and check for duplicates before appending');
+  });
+
+  await test('pendingContexts has FIFO cap constant', () => {
+    assert.ok(src.includes('PENDING_CONTEXTS_CAP') && src.includes('= 10'),
+      'Should define PENDING_CONTEXTS_CAP = 10');
+  });
+
+  await test('purgeBloatedCooldowns runs on startup', () => {
+    assert.ok(src.includes('purgeBloatedCooldowns'),
+      'loadCooldowns should call purgeBloatedCooldowns for one-time cleanup');
+  });
+}
+
+// ─── Cooldown Context Dedup & Cap Tests ─────────────────────────────────────
+
+async function testCooldownContextDedup() {
+  console.log('\n── Cooldown Context Dedup & Cap ──');
+
+  const cooldown = require(path.join(MINIONS_DIR, 'engine', 'cooldown'));
+  const { dispatchCooldowns, setCooldownWithContext, purgeBloatedCooldowns, PENDING_CONTEXTS_CAP } = cooldown;
+
+  // Helper to reset state for each test
+  function resetCooldowns() {
+    dispatchCooldowns.clear();
+  }
+
+  await test('setCooldownWithContext deduplicates identical content — 100 calls = 1 entry', () => {
+    resetCooldowns();
+    const key = 'test-dedup-100';
+    const content = 'This is identical feedback content repeated many times';
+    for (let i = 0; i < 100; i++) {
+      setCooldownWithContext(key, content);
+    }
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.pendingContexts.length, 1,
+      `Expected 1 entry after 100 identical calls, got ${entry.pendingContexts.length}`);
+    assert.strictEqual(entry.pendingContexts[0], content);
+  });
+
+  await test('setCooldownWithContext caps at 10 entries with FIFO eviction', () => {
+    resetCooldowns();
+    const key = 'test-cap-15';
+    for (let i = 0; i < 15; i++) {
+      setCooldownWithContext(key, `unique content ${i}`);
+    }
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.pendingContexts.length, PENDING_CONTEXTS_CAP,
+      `Expected ${PENDING_CONTEXTS_CAP} entries after 15 unique calls, got ${entry.pendingContexts.length}`);
+    // FIFO: oldest (0-4) should be dropped, 5-14 should remain
+    assert.strictEqual(entry.pendingContexts[0], 'unique content 5',
+      'Oldest entries should be evicted (FIFO)');
+    assert.strictEqual(entry.pendingContexts[9], 'unique content 14',
+      'Newest entries should be kept');
+  });
+
+  await test('setCooldownWithContext deduplicates object content via JSON hash', () => {
+    resetCooldowns();
+    const key = 'test-dedup-obj';
+    const obj = { feedback: 'review needed', pr: 'PR-42' };
+    setCooldownWithContext(key, obj);
+    setCooldownWithContext(key, obj);
+    setCooldownWithContext(key, { feedback: 'review needed', pr: 'PR-42' }); // same content, new reference
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.pendingContexts.length, 1,
+      'Object content with same shape should be deduplicated');
+  });
+
+  await test('purgeBloatedCooldowns deduplicates existing entries in-place', () => {
+    resetCooldowns();
+    const key = 'test-purge';
+    // Simulate bloated state by directly setting the Map
+    dispatchCooldowns.set(key, {
+      timestamp: Date.now(),
+      failures: 0,
+      pendingContexts: Array(9098).fill('same feedback content 3KB')
+    });
+    purgeBloatedCooldowns();
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.pendingContexts.length, 1,
+      'Purge should deduplicate 9098 identical entries to 1');
+  });
+
+  await test('purgeBloatedCooldowns caps entries to PENDING_CONTEXTS_CAP', () => {
+    resetCooldowns();
+    const key = 'test-purge-cap';
+    // 20 unique entries — should be capped to 10 after purge
+    const contexts = [];
+    for (let i = 0; i < 20; i++) contexts.push(`unique ${i}`);
+    dispatchCooldowns.set(key, {
+      timestamp: Date.now(),
+      failures: 0,
+      pendingContexts: contexts
+    });
+    purgeBloatedCooldowns();
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.pendingContexts.length, PENDING_CONTEXTS_CAP,
+      `Purge should cap at ${PENDING_CONTEXTS_CAP} entries`);
+    // Should keep the most recent (last 10)
+    assert.strictEqual(entry.pendingContexts[0], 'unique 10');
+    assert.strictEqual(entry.pendingContexts[9], 'unique 19');
+  });
+
+  await test('setCooldownWithContext preserves failures count', () => {
+    resetCooldowns();
+    const key = 'test-preserve-failures';
+    dispatchCooldowns.set(key, { timestamp: Date.now(), failures: 5, pendingContexts: [] });
+    setCooldownWithContext(key, 'new context');
+    const entry = dispatchCooldowns.get(key);
+    assert.strictEqual(entry.failures, 5, 'Should preserve existing failure count');
+  });
+
+  // Clean up after tests
+  resetCooldowns();
 }
 
 // ─── engine.js — resolveAgent Tests ─────────────────────────────────────────
@@ -5510,6 +5627,7 @@ async function main() {
     await testIsRetryableFailureReason();
     await testAreDependenciesMet();
     await testCooldownSystem();
+    await testCooldownContextDedup();
     await testResolveAgent();
     await testRenderPlaybook();
     await testCompleteDispatch();


### PR DESCRIPTION
## Summary
- **Content-hash dedup** in `setCooldownWithContext()` — prevents identical feedback from being appended on every poll cycle (~6 min)
- **FIFO cap at 10 entries** on `pendingContexts` — oldest entries evicted when cap exceeded
- **Startup purge** via `purgeBloatedCooldowns()` — deduplicates and caps existing bloated entries in-place on engine load (fixes the 42.9 MB cooldowns.json from PR-64's 9,098 duplicate copies)

## Test plan
- [x] Unit test: 100 identical calls → exactly 1 entry in pendingContexts
- [x] Unit test: 15 unique calls → exactly 10 entries (FIFO cap)
- [x] Unit test: object dedup via JSON hash
- [x] Unit test: purge deduplicates 9098→1 identical entries
- [x] Unit test: purge caps 20 unique→10 (keeps newest)
- [x] Unit test: failures count preserved across setCooldownWithContext calls
- [x] 654 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)