### PR TITLE
feat(P-d4e8n1q7): deduplicate PR entries in pull-requests.json

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -5,7 +5,7 @@
 
 const path = require('path');
 const shared = require('./shared');
-const { exec, getAdoOrgBase, addPrLink, log, dateStamp } = shared;
+const { exec, getAdoOrgBase, addPrLink, deduplicatePrs, log, dateStamp } = shared;
 const { getPrs } = require('./queries');
 
 // Lazy require to avoid circular dependency — only needed for engine().handlePostMerge
@@ -343,7 +343,8 @@ async function reconcilePrs(config) {
 
     const prPath = shared.projectPrPath(project);
     const existingPrs = shared.safeJson(prPath) || [];
-    const existingIds = new Set(existingPrs.map(p => p.id));
+    deduplicatePrs(existingPrs); // clean up any pre-existing duplicates
+    const existingIds = new Set(existingPrs.map(p => String(p.id).toUpperCase()));
     let projectAdded = 0;
 
     // Load work items to match branches to work item IDs
@@ -365,11 +366,12 @@ async function reconcilePrs(config) {
       const linkedItem = linkedItemId ? allItems.find(i => i.id === linkedItemId) : null;
       const confirmedItemId = linkedItem ? linkedItemId : null;
 
-      if (existingIds.has(prId)) {
+      const normPrId = prId.toUpperCase();
+      if (existingIds.has(normPrId)) {
         // PR already tracked — write link to pr-links.json if we can extract an ID
         if (confirmedItemId) {
           addPrLink(prId, confirmedItemId);
-          const existing = existingPrs.find(p => p.id === prId);
+          const existing = existingPrs.find(p => String(p.id).toUpperCase() === normPrId);
           if (existing && !(existing.prdItems || []).includes(confirmedItemId)) {
             existing.prdItems = Array.isArray(existing.prdItems) ? existing.prdItems : [];
             existing.prdItems.push(confirmedItemId);
@@ -392,7 +394,7 @@ async function reconcilePrs(config) {
         prdItems: confirmedItemId ? [confirmedItemId] : [],
       });
       if (confirmedItemId) addPrLink(prId, confirmedItemId);
-      existingIds.add(prId);
+      existingIds.add(normPrId);
       projectAdded++;
       log('info', `PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);
     }

--- a/engine/github.js
+++ b/engine/github.js
@@ -5,7 +5,7 @@
  */
 
 const shared = require('./shared');
-const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, MINIONS_DIR, addPrLink, log, dateStamp } = shared;
+const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, MINIONS_DIR, addPrLink, deduplicatePrs, log, dateStamp } = shared;
 const { getPrs } = require('./queries');
 const path = require('path');
 
@@ -321,7 +321,8 @@ async function reconcilePrs(config) {
 
     const prPath = projectPrPath(project);
     const existingPrs = safeJson(prPath) || [];
-    const existingIds = new Set(existingPrs.map(p => p.id));
+    deduplicatePrs(existingPrs); // clean up any pre-existing duplicates
+    const existingIds = new Set(existingPrs.map(p => String(p.id).toUpperCase()));
     let projectAdded = 0;
 
     // Load work items to match branches
@@ -339,10 +340,11 @@ async function reconcilePrs(config) {
       const linkedItem = linkedItemId ? allItems.find(i => i.id === linkedItemId) : null;
       const confirmedItemId = linkedItem ? linkedItemId : null;
 
-      if (existingIds.has(prId)) {
+      const normPrId = prId.toUpperCase();
+      if (existingIds.has(normPrId)) {
         if (confirmedItemId) {
           addPrLink(prId, confirmedItemId);
-          const existing = existingPrs.find(p => p.id === prId);
+          const existing = existingPrs.find(p => String(p.id).toUpperCase() === normPrId);
           if (existing && !(existing.prdItems || []).includes(confirmedItemId)) {
             existing.prdItems = Array.isArray(existing.prdItems) ? existing.prdItems : [];
             existing.prdItems.push(confirmedItemId);
@@ -365,7 +367,7 @@ async function reconcilePrs(config) {
         prdItems: confirmedItemId ? [confirmedItemId] : [],
       });
       if (confirmedItemId) addPrLink(prId, confirmedItemId);
-      existingIds.add(prId);
+      existingIds.add(normPrId);
       projectAdded++;
 
       log('info', `GitHub PR reconciliation: added ${prId} (branch: ${branch}${confirmedItemId ? ', linked to ' + confirmedItemId : ''}) to ${project.name}`);

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const shared = require('./shared');
 const { safeRead, safeJson, safeWrite, safeReadDir, execSilent, projectPrPath, getPrLinks, addPrLink,
-  mutateJsonFileLocked, log, ts, dateStamp } = shared;
+  mutateJsonFileLocked, deduplicatePrs, log, ts, dateStamp } = shared;
 const { trackEngineUsage } = require('./llm');
 const queries = require('./queries');
 const { getConfig, getInboxFiles, getNotes, getPrs, getDispatch,
@@ -603,7 +603,8 @@ function syncPrsFromOutput(output, agentId, meta, config) {
       dirtyTargets.set(targetName, { prs: safeJson(prPath) || [], prPath });
     }
     const entry = dirtyTargets.get(targetName);
-    if (entry.prs.some(p => p.id === fullId || String(p.id) === String(prId))) continue;
+    const normFullId = fullId.toUpperCase();
+    if (entry.prs.some(p => String(p.id).toUpperCase() === normFullId || String(p.id) === String(prId))) continue;
 
     let title = meta?.item?.title || '';
     const titleMatch = output.match(new RegExp(`${prId}[^\\n]*?[—–-]\\s*([^\\n]+)`, 'i'));
@@ -632,6 +633,7 @@ function syncPrsFromOutput(output, agentId, meta, config) {
   }
 
   for (const [name, entry] of dirtyTargets) {
+    deduplicatePrs(entry.prs);
     shared.safeWrite(entry.prPath, entry.prs);
     log('info', `Synced PR(s) from ${agentName}'s output to ${name === '_central' ? 'central' : name}/pull-requests.json`);
   }

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -534,6 +534,58 @@ function addPrLink(prId, itemId) {
 }
 
 /**
+ * Deduplicate PR entries in-place. When multiple entries share the same PR id
+ * (case-insensitive), merge them into a single entry — the most-recently-created
+ * entry's fields win, but prdItems arrays are unioned. Agent name comparison is
+ * also case-insensitive when detecting duplicates.
+ * Returns the deduplicated array (same reference, mutated).
+ */
+function deduplicatePrs(prs) {
+  if (!Array.isArray(prs) || prs.length === 0) return prs;
+  const seen = new Map(); // normalized id -> index in result
+  const result = [];
+  for (const pr of prs) {
+    const normId = String(pr.id || '').toUpperCase();
+    if (!normId) { result.push(pr); continue; }
+    if (seen.has(normId)) {
+      // Merge into existing entry — newer entry's scalar fields win
+      const existing = result[seen.get(normId)];
+      // Pick the entry with the more recent created date as the "winner"
+      const existingDate = existing.created || '';
+      const incomingDate = pr.created || '';
+      const winner = incomingDate > existingDate ? pr : existing;
+      // Snapshot the loser before mutation (existing and loser may be the same ref)
+      const loserSnapshot = {};
+      const loserRef = winner === pr ? existing : pr;
+      for (const key of Object.keys(loserRef)) loserSnapshot[key] = loserRef[key];
+      // Merge: winner fields take precedence, but union arrays
+      for (const key of Object.keys(winner)) {
+        if (key === 'prdItems') continue; // handled below
+        existing[key] = winner[key];
+      }
+      // Fill in blank/missing fields from loser snapshot
+      for (const key of Object.keys(loserSnapshot)) {
+        if (!(key in existing) || existing[key] === undefined || existing[key] === '') {
+          existing[key] = loserSnapshot[key];
+        }
+      }
+      // Union prdItems
+      const items = new Set([...(existing.prdItems || []), ...(pr.prdItems || [])]);
+      existing.prdItems = [...items];
+      // Normalize the ID to canonical PR-{num} form
+      existing.id = normId.startsWith('PR-') ? normId : `PR-${normId}`;
+    } else {
+      seen.set(normId, result.length);
+      result.push({ ...pr });
+    }
+  }
+  // Replace contents in-place
+  prs.length = 0;
+  prs.push(...result);
+  return prs;
+}
+
+/**
  * Locked mutation of a project's pull-requests.json.
  * Single source of truth for PR data including prdItems links.
  */
@@ -598,6 +650,7 @@ module.exports = {
   projectPrPath,
   getPrLinks,
   addPrLink,
+  deduplicatePrs,
   mutatePrs,
   linkPrToItem,
   nextWorkItemId,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3722,8 +3722,8 @@ async function testSyncPrsFromOutput() {
   await test('PR dedup uses strict equality, not substring includes', () => {
     assert.ok(!src.includes("String(p.id).includes(prId)"),
       'Should not use String.includes for PR dedup — causes false positives (PR 123 matching 1234)');
-    assert.ok(src.includes("String(p.id) === String(prId)"),
-      'Should use strict equality for PR ID comparison');
+    assert.ok(src.includes("String(p.id) === String(prId)") || src.includes('.toUpperCase() === normFullId'),
+      'Should use strict equality (case-insensitive) for PR ID comparison');
   });
 }
 
@@ -5573,6 +5573,9 @@ async function main() {
 
     // P-k7m2a9f4: Pipeline artifact navigation links
     await testPipelineArtifactLinks();
+
+    // P-d4e8n1q7: PR deduplication in pull-requests.json
+    await testPrDeduplication();
   } finally {
     cleanupTmpDirs();
   }
@@ -6210,6 +6213,91 @@ async function testPipelineStepProgress() {
   await test('progress bar appears in both list and detail views', () => {
     assert.ok(src.includes('progressHtml'), 'List view should insert progress HTML');
     assert.ok(src.includes('detailRun'), 'Detail view should compute progress from detailRun');
+  });
+}
+
+// ─── P-d4e8n1q7: PR deduplication in pull-requests.json ─────────────────────
+
+async function testPrDeduplication() {
+  console.log('\n── PR deduplication (P-d4e8n1q7) ──');
+
+  // Test deduplicatePrs directly
+  await test('deduplicatePrs merges entries with same PR id', () => {
+    const prs = [
+      { id: 'PR-64', title: 'first', agent: 'ralph', branch: 'work/test', status: 'active', created: '2026-04-01', prdItems: ['P-001'] },
+      { id: 'PR-64', title: 'second', agent: 'Ralph', branch: 'work/test', status: 'active', created: '2026-04-02', prdItems: ['P-002'] },
+    ];
+    shared.deduplicatePrs(prs);
+    assert.strictEqual(prs.length, 1, 'Should merge duplicates into 1 entry');
+    assert.strictEqual(prs[0].id, 'PR-64', 'Should preserve canonical PR id');
+    assert.strictEqual(prs[0].title, 'second', 'Newer entry fields should win');
+    assert.deepStrictEqual(prs[0].prdItems, ['P-001', 'P-002'], 'prdItems should be unioned');
+  });
+
+  await test('deduplicatePrs handles case-insensitive id match', () => {
+    const prs = [
+      { id: 'PR-49', agent: 'dallas', status: 'active', created: '2026-04-01', prdItems: [] },
+      { id: 'pr-49', agent: 'Dallas', status: 'merged', created: '2026-04-02', prdItems: ['P-003'] },
+    ];
+    shared.deduplicatePrs(prs);
+    assert.strictEqual(prs.length, 1, 'Case-insensitive ids should be treated as duplicates');
+    assert.strictEqual(prs[0].status, 'merged', 'Newer entry status should win');
+    assert.deepStrictEqual(prs[0].prdItems, ['P-003'], 'prdItems should be unioned');
+  });
+
+  await test('deduplicatePrs preserves unique entries', () => {
+    const prs = [
+      { id: 'PR-10', agent: 'a', status: 'active', created: '2026-04-01', prdItems: [] },
+      { id: 'PR-20', agent: 'b', status: 'active', created: '2026-04-01', prdItems: [] },
+      { id: 'PR-30', agent: 'c', status: 'active', created: '2026-04-01', prdItems: [] },
+    ];
+    shared.deduplicatePrs(prs);
+    assert.strictEqual(prs.length, 3, 'Unique entries should all be preserved');
+  });
+
+  await test('deduplicatePrs handles empty and null inputs', () => {
+    assert.deepStrictEqual(shared.deduplicatePrs([]), [], 'Empty array returns empty');
+    assert.strictEqual(shared.deduplicatePrs(null), null, 'null returns null');
+  });
+
+  await test('deduplicatePrs merges fields — most recent status/agent wins', () => {
+    const prs = [
+      { id: 'PR-55', agent: 'dallas', status: 'active', reviewStatus: 'pending', created: '2026-04-01', prdItems: ['P-A'], url: '', branch: 'work/test' },
+      { id: 'PR-55', agent: 'Dallas', status: 'merged', reviewStatus: 'approved', created: '2026-04-02', prdItems: ['P-B'], url: 'https://example.com/pr/55', branch: '' },
+    ];
+    shared.deduplicatePrs(prs);
+    assert.strictEqual(prs.length, 1);
+    assert.strictEqual(prs[0].status, 'merged', 'Newer status wins');
+    assert.strictEqual(prs[0].reviewStatus, 'approved', 'Newer reviewStatus wins');
+    assert.strictEqual(prs[0].url, 'https://example.com/pr/55', 'Winner url wins');
+    assert.strictEqual(prs[0].branch, 'work/test', 'Loser branch fills empty winner field');
+    assert.deepStrictEqual(prs[0].prdItems, ['P-A', 'P-B'], 'prdItems unioned');
+  });
+
+  // Source code checks for dedup integration
+  const lifecycleSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+  const adoSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+  const ghSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'github.js'), 'utf8');
+
+  await test('syncPrsFromOutput uses case-insensitive dedup', () => {
+    assert.ok(lifecycleSrc.includes('toUpperCase()'),
+      'syncPrsFromOutput should use case-insensitive comparison for PR IDs');
+    assert.ok(lifecycleSrc.includes('deduplicatePrs(entry.prs)'),
+      'syncPrsFromOutput should call deduplicatePrs before writing');
+  });
+
+  await test('ADO reconcilePrs uses case-insensitive dedup', () => {
+    assert.ok(adoSrc.includes('toUpperCase()'),
+      'ADO reconcilePrs should normalize PR IDs to uppercase for comparison');
+    assert.ok(adoSrc.includes('deduplicatePrs(existingPrs)'),
+      'ADO reconcilePrs should call deduplicatePrs to clean up existing duplicates');
+  });
+
+  await test('GitHub reconcilePrs uses case-insensitive dedup', () => {
+    assert.ok(ghSrc.includes('toUpperCase()'),
+      'GitHub reconcilePrs should normalize PR IDs to uppercase for comparison');
+    assert.ok(ghSrc.includes('deduplicatePrs(existingPrs)'),
+      'GitHub reconcilePrs should call deduplicatePrs to clean up existing duplicates');
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds `deduplicatePrs()` helper to `shared.js` that merges duplicate PR entries by case-insensitive ID — newer entry's fields win, `prdItems` arrays are unioned, blank fields backfilled from older entry
- Integrates dedup into all three PR write paths: `syncPrsFromOutput` (lifecycle.js), ADO `reconcilePrs` (ado.js), GitHub `reconcilePrs` (github.js)
- Existing duplicates (PR-49, PR-55, PR-64) are cleaned up automatically on next reconciliation pass
- 8 new unit tests covering merge logic, case-insensitive matching, field priority, and integration checks

## Test plan
- [x] All 653 unit tests pass (0 failures)
- [ ] Verify PR-49, PR-55, PR-64 duplicates are cleaned up after next engine tick
- [ ] Verify no new duplicates are created when syncPrsFromOutput and reconcilePrs both process the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)