### PR TITLE
feat(P-d8n3x5q1): Add null guards to dashboard.js request handlers

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -845,9 +845,9 @@ const server = http.createServer(async (req, res) => {
 
       // Check if verify was created
       const project = PROJECTS.find(p => {
-        const plan = JSON.parse(safeRead(activePath) || safeRead(prdPath) || '{}');
-        return p.name?.toLowerCase() === (plan.project || '').toLowerCase();
-      }) || PROJECTS[0];
+        const plan = safeJson(activePath) || safeJson(prdPath);
+        return plan && p.name?.toLowerCase() === (plan.project || '').toLowerCase();
+      }) || PROJECTS[0] || null;
       if (project) {
         const wiPath = shared.projectWorkItemsPath(project);
         const items = JSON.parse(safeRead(wiPath) || '[]');
@@ -1037,6 +1037,7 @@ const server = http.createServer(async (req, res) => {
       if (body.project) {
         // Write to project-specific queue
         const targetProject = PROJECTS.find(p => p.name === body.project) || PROJECTS[0];
+        if (!targetProject) return jsonReply(res, 400, { error: 'No projects configured' });
         wiPath = shared.projectWorkItemsPath(targetProject);
       } else {
         // Write to central queue — agent decides which project

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6290,6 +6290,36 @@ async function testAuxModuleBugFixes() {
     assert.ok(src.includes('w.length <= 200'), 'Should cap word length at 200 chars');
   });
 
+  // P-d8n3x5q1: dashboard.js null guards for PROJECTS[0] and safeJson results
+  await test('dashboard.js: handleWorkItemsCreate guards PROJECTS[0] with null check', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // The handleWorkItemsCreate function should guard PROJECTS[0] fallback
+    assert.ok(src.includes("No projects configured"), 'Should return error when no projects configured');
+    // Find the targetProject = ... || PROJECTS[0] line and verify guard follows
+    const createIdx = src.indexOf('handleWorkItemsCreate');
+    const guardIdx = src.indexOf("if (!targetProject)", createIdx);
+    assert.ok(guardIdx > createIdx, 'Should have !targetProject guard after PROJECTS[0] fallback in create handler');
+  });
+
+  await test('dashboard.js: PRD completion handler uses safeJson instead of JSON.parse for plan reading', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // The verify-was-created block should use safeJson (null-safe) not JSON.parse
+    const verifyBlock = src.indexOf('Check if verify was created');
+    assert.ok(verifyBlock > 0, 'Should have verify-was-created comment');
+    const nextJsonParse = src.indexOf('JSON.parse(safeRead(activePath)', verifyBlock);
+    const nextSafeJson = src.indexOf('safeJson(activePath)', verifyBlock);
+    // safeJson should appear before (or instead of) JSON.parse for activePath in this block
+    assert.ok(nextSafeJson > verifyBlock, 'Should use safeJson for activePath in verify block');
+    if (nextJsonParse > 0) {
+      assert.ok(nextSafeJson < nextJsonParse, 'safeJson should replace JSON.parse for activePath');
+    }
+  });
+
+  await test('dashboard.js: PROJECTS[0] at line 1159 uses optional chaining', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(src.includes('PROJECTS[0]?.name'), 'Should use optional chaining for PROJECTS[0].name');
+  });
+
   // Bug #38: notes.md truncation on section boundary
   await test('consolidation.js: truncation scans for section boundary', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'consolidation.js'), 'utf8');


### PR DESCRIPTION
## Summary
- Guard `PROJECTS[0]` fallback in `handleWorkItemsCreate` with early 400 return when no projects configured
- Replace unsafe `JSON.parse(safeRead(...))` with `safeJson()` in PRD completion verify block to prevent null-property crashes
- Add `|| null` explicit fallback for empty PROJECTS in completion handler (existing `if (project)` guard already handles it, but now it's consistent)
- 3 new unit tests covering the empty-PROJECTS edge case for affected endpoints

## Test plan
- [x] All 646 unit tests pass (`npm test`)
- [ ] Manual: verify dashboard POST to `/api/work-items` returns 400 when config has no projects
- [ ] Manual: verify PRD completion check doesn't crash when plan file is corrupted/missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)