### PR TITLE
feat(P-j4f6v8a2): guard projects[0] fallbacks in lifecycle.js

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -154,7 +154,11 @@ function checkPlanCompletion(meta, config) {
   // Resolve the primary project for writing new work items (PR, verify)
   const projectName = plan.project;
   const primaryProject = projectName
-    ? projects.find(p => p.name?.toLowerCase() === projectName?.toLowerCase()) : projects[0];
+    ? projects.find(p => p.name?.toLowerCase() === projectName?.toLowerCase()) : (projects[0] || null);
+  if (!primaryProject) {
+    log('warn', `checkPlanCompletion: no project available (projects array ${projects.length === 0 ? 'empty' : 'no match for ' + projectName}) — skipping PR/verify creation for ${planFile}`);
+    return;
+  }
   const wiPath = primaryProject ? shared.projectWorkItemsPath(primaryProject) : null;
   const workItems = wiPath ? (safeJson(wiPath) || []) : [];
 
@@ -424,6 +428,10 @@ function chainPlanToPrd(dispatchItem, meta, config) {
 
   const projectName = meta?.item?.project || meta?.project?.name;
   const projects = shared.getProjects(config);
+  if (projects.length === 0) {
+    log('error', 'Plan chaining: no projects configured — cannot chain plan to PRD');
+    return;
+  }
   const targetProject = projectName
     ? projects.find(p => p.name === projectName) || projects[0]
     : projects[0];
@@ -584,7 +592,11 @@ function syncPrsFromOutput(output, agentId, meta, config) {
   if (prMatches.size === 0) return 0;
 
   const projects = shared.getProjects(config);
-  const defaultProject = (meta?.project?.name && projects.find(p => p.name === meta.project.name)) || projects[0];
+  if (projects.length === 0 && !meta?.project?.name) {
+    log('warn', `syncPrsFromOutput: no projects configured and no project in meta — cannot sync PRs`);
+    return 0;
+  }
+  const defaultProject = (meta?.project?.name && projects.find(p => p.name === meta.project.name)) || (projects[0] || null);
   const useCentral = !defaultProject;
 
   // Match each PR to its correct project by finding which repo URL appears near the PR number in output

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5497,6 +5497,9 @@ async function main() {
 
     // P-e9y7xcp5: Auxiliary module bug fixes
     await testAuxModuleBugFixes();
+
+    // P-j4f6v8a2: Empty projects[] guards in lifecycle.js
+    await testEmptyProjectsGuards();
   } finally {
     cleanupTmpDirs();
   }
@@ -6300,6 +6303,100 @@ async function testAuxModuleBugFixes() {
     const regexPath = src.indexOf('lastBoundary');
     assert.ok(llmPath > 0, 'LLM consolidation path should have section-boundary truncation');
     assert.ok(regexPath > 0, 'Regex fallback path should have section-boundary truncation');
+  });
+}
+
+// ─── P-j4f6v8a2: Empty projects[] guards in lifecycle.js ─────────────────────
+
+async function testEmptyProjectsGuards() {
+  console.log('\n── lifecycle.js — empty projects[] guards (P-j4f6v8a2) ──');
+
+  const lifecycle = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
+  const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+
+  // ── Source-level checks ──
+
+  await test('checkPlanCompletion guards empty projects with early return', () => {
+    // After resolving primaryProject, there must be a !primaryProject guard before accessing .name
+    const fnBody = src.slice(src.indexOf('function checkPlanCompletion'), src.indexOf('function archivePlan'));
+    assert.ok(fnBody.includes('if (!primaryProject)'),
+      'Should have an explicit !primaryProject guard');
+    assert.ok(fnBody.includes('return;'),
+      'Should return early when no project available');
+  });
+
+  await test('chainPlanToPrd guards empty projects array before accessing projects[0]', () => {
+    const fnBody = src.slice(src.indexOf('function chainPlanToPrd'), src.indexOf('function syncPrsFromOutput'));
+    assert.ok(fnBody.includes('projects.length === 0'),
+      'Should check for empty projects array before accessing projects[0]');
+  });
+
+  await test('syncPrsFromOutput guards empty projects with early return 0', () => {
+    const fnBody = src.slice(src.indexOf('function syncPrsFromOutput'));
+    assert.ok(fnBody.includes('projects.length === 0'),
+      'Should check for empty projects array');
+    assert.ok(fnBody.includes('return 0'),
+      'Should return 0 when no projects available');
+  });
+
+  // ── Functional: checkPlanCompletion with empty projects ──
+
+  const testPlanFile = '_test-empty-proj.json';
+  const prdDir = path.join(MINIONS_DIR, 'prd');
+  const inboxDir = path.join(MINIONS_DIR, 'notes', 'inbox');
+  fs.mkdirSync(prdDir, { recursive: true });
+  fs.mkdirSync(inboxDir, { recursive: true });
+
+  await test('checkPlanCompletion: empty projects[] does not crash, skips PR/verify creation', () => {
+    // Write a PRD with all items done
+    const prd = {
+      plan_summary: 'Empty proj test',
+      project: null,
+      branch_strategy: 'parallel',
+      missing_features: [
+        { id: 'EP-001', title: 'Feature A', acceptance_criteria: ['AC1'] },
+      ],
+    };
+    shared.safeWrite(path.join(prdDir, testPlanFile), prd);
+
+    // Write matching work items to central location (no project dir)
+    const centralWiPath = path.join(MINIONS_DIR, 'work-items.json');
+    shared.safeWrite(centralWiPath, [
+      { id: 'EP-001', title: 'Implement: Feature A', type: 'implement', status: 'done',
+        sourcePlan: testPlanFile, dispatched_at: '2026-01-01T00:00:00Z', completedAt: '2026-01-01T01:00:00Z' },
+    ]);
+
+    const meta = { item: { sourcePlan: testPlanFile } };
+    const config = { projects: [] };
+
+    // Should not throw
+    lifecycle.checkPlanCompletion(meta, config);
+
+    // The completion summary inbox IS written (before project resolution), but
+    // no verify work item should be created since there's no project for it.
+    // The _completionNotified flag is set before the project guard (to prevent re-runs).
+    const completedPlan = shared.safeJson(path.join(prdDir, testPlanFile));
+    assert.strictEqual(completedPlan._completionNotified, true,
+      '_completionNotified should still be set even with empty projects');
+    assert.strictEqual(completedPlan.status, 'completed',
+      'Plan status should be marked completed');
+
+    // Cleanup
+    const inboxFiles = shared.safeReadDir(inboxDir).filter(f => f.includes('_test-empty-proj'));
+    for (const f of inboxFiles) { try { fs.unlinkSync(path.join(inboxDir, f)); } catch {} }
+    try { fs.unlinkSync(path.join(prdDir, testPlanFile)); } catch {}
+    try { fs.unlinkSync(centralWiPath); } catch {}
+  });
+
+  // ── Functional: syncPrsFromOutput with empty projects ──
+
+  await test('syncPrsFromOutput: empty projects[] returns 0 without crash', () => {
+    const output = '{"type":"result","message":{"content":[{"type":"tool_result","content":"https://github.com/org/repo/pull/999"}]}}';
+    const config = { projects: [] };
+    const meta = {};
+
+    const result = lifecycle.syncPrsFromOutput(output, 'test-agent', meta, config);
+    assert.strictEqual(result, 0, 'Should return 0 when projects is empty and no meta project');
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds empty-array guards at three `projects[0]` access sites in `lifecycle.js` that would crash with `TypeError: Cannot read properties of undefined` when `config.projects` is empty
- **checkPlanCompletion** (line ~157): logs warning and bails if no project resolved — completion summary still written, but PR/verify work items skipped
- **chainPlanToPrd** (lines ~428-429): explicit `projects.length === 0` check before the ternary fallback
- **syncPrsFromOutput** (line ~587): returns 0 early if no projects configured and no project in meta
- 5 new unit tests (3 source-level, 2 functional) — all 648 tests pass

## Test plan
- [x] All 648 existing unit tests pass (`npm test`)
- [x] New tests verify no crash with empty `projects: []` for `checkPlanCompletion`
- [x] New tests verify `syncPrsFromOutput` returns 0 gracefully with empty projects
- [x] Source-level tests confirm guards exist in all three function bodies
- [ ] Manual: run engine with empty `config.projects` and trigger plan completion — should log warning, not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)