### PR TITLE
feat(W-mnj4tn8bazdz): Fix PR write races in ado.js and github.js

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -7,6 +7,7 @@ const path = require('path');
 const shared = require('./shared');
 const { exec, getAdoOrgBase, addPrLink, log, ts, dateStamp, PR_STATUS } = shared;
 const { getPrs } = require('./queries');
+const { mutateJsonFileLocked } = shared;
 
 // Lazy require to avoid circular dependency — only needed for engine().handlePostMerge
 let _engine = null;
@@ -99,7 +100,15 @@ async function forEachActivePr(config, token, callback) {
     }
 
     if (projectUpdated > 0) {
-      shared.safeWrite(shared.projectPrPath(project), prs);
+      mutateJsonFileLocked(shared.projectPrPath(project), (currentPrs) => {
+        // Merge updated PRs into the locked copy by ID
+        for (const updatedPr of prs) {
+          const idx = currentPrs.findIndex(p => p.id === updatedPr.id);
+          if (idx >= 0) currentPrs[idx] = updatedPr;
+          else currentPrs.push(updatedPr);
+        }
+        return currentPrs;
+      }, { defaultValue: [] });
       totalUpdated += projectUpdated;
     }
   }
@@ -174,11 +183,11 @@ async function pollPrStatus(config) {
         if (authorId) {
           try {
             const metricsPath = path.join(__dirname, 'metrics.json');
-            const metrics = shared.safeJson(metricsPath) || {};
-            if (!metrics[authorId]) metrics[authorId] = {};
-            if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
-            else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
-            shared.safeWrite(metricsPath, metrics);
+            mutateJsonFileLocked(metricsPath, (metrics) => {
+              if (!metrics[authorId]) metrics[authorId] = {};
+              if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
+              else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
+            });
           } catch (err) { log('warn', `Metrics update: ${err.message}`); }
         }
       }
@@ -196,8 +205,8 @@ async function pollPrStatus(config) {
 
     const buildStatuses = [...latest.values()].filter(s => {
       const ctx = ((s.context?.genre || '') + '/' + (s.context?.name || '')).toLowerCase();
-      return ctx.includes('codecoverage') || ctx.includes('build') ||
-             ctx.includes('deploy') || ctx.includes('ci/');
+      return /\bcodecoverage\b/.test(ctx) || /\bbuild\b/.test(ctx) ||
+             /\bdeploy\b/.test(ctx) || /(?:^|\/)ci(?:\/|$)/.test(ctx);
     });
 
     let buildStatus = 'none';
@@ -248,7 +257,8 @@ async function pollPrHumanComments(config) {
     const threadsData = await adoFetch(threadsUrl, token);
     const threads = threadsData.value || [];
 
-    const cutoff = pr.humanFeedback?.lastProcessedCommentDate || pr.created || '1970-01-01';
+    const cutoffStr = pr.humanFeedback?.lastProcessedCommentDate || pr.created || '1970-01-01';
+    const cutoffMs = new Date(cutoffStr).getTime() || 0;
 
     // Collect ALL human comments on the PR for full context
     const allHumanComments = [];
@@ -269,7 +279,8 @@ async function pollPrHumanComments(config) {
         allHumanComments.push(entry);
 
         // Track which comments are new (for triggering — any new comment triggers a fix)
-        if (comment.publishedDate && comment.publishedDate > cutoff) {
+        const commentMs = comment.publishedDate ? new Date(comment.publishedDate).getTime() : 0;
+        if (commentMs && commentMs > cutoffMs) {
           newHumanComments.push(entry);
         }
       }
@@ -285,7 +296,7 @@ async function pollPrHumanComments(config) {
     // Provide ALL comments as context — the agent needs full thread context to fix properly
     const feedbackContent = allHumanComments
       .map(c => {
-        const isNew = c.date > cutoff;
+        const isNew = (new Date(c.date).getTime() || 0) > cutoffMs;
         return `${isNew ? '**[NEW]** ' : ''}**${c.author}** (${c.date}):\n${c.content.replace(/@minions\s*/gi, '').trim()}`;
       })
       .join('\n\n---\n\n');
@@ -412,7 +423,15 @@ async function reconcilePrs(config) {
     }
 
     if (projectAdded > 0 || projectUpdated > 0 || backfilled > 0) {
-      shared.safeWrite(prPath, existingPrs);
+      mutateJsonFileLocked(prPath, (currentPrs) => {
+        // Merge reconciled PRs into the locked copy by ID
+        for (const pr of existingPrs) {
+          const idx = currentPrs.findIndex(p => p.id === pr.id);
+          if (idx >= 0) currentPrs[idx] = pr;
+          else currentPrs.push(pr);
+        }
+        return currentPrs;
+      }, { defaultValue: [] });
       totalAdded += projectAdded;
       if (projectUpdated > 0) log('info', `PR reconciliation: linked ${projectUpdated} existing PR(s) to PRD items in ${project.name}`);
     }

--- a/engine/github.js
+++ b/engine/github.js
@@ -5,7 +5,7 @@
  */
 
 const shared = require('./shared');
-const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, MINIONS_DIR, addPrLink, getPrLinks, log, ts, dateStamp, PR_STATUS } = shared;
+const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, mutateJsonFileLocked, MINIONS_DIR, addPrLink, getPrLinks, log, ts, dateStamp, PR_STATUS } = shared;
 const { getPrs } = require('./queries');
 const path = require('path');
 
@@ -71,7 +71,14 @@ async function forEachActiveGhPr(config, callback) {
     }
 
     if (projectUpdated > 0) {
-      safeWrite(projectPrPath(project), prs);
+      mutateJsonFileLocked(projectPrPath(project), (currentPrs) => {
+        for (const updatedPr of prs) {
+          const idx = currentPrs.findIndex(p => p.id === updatedPr.id);
+          if (idx >= 0) currentPrs[idx] = updatedPr;
+          else currentPrs.push(updatedPr);
+        }
+        return currentPrs;
+      }, { defaultValue: [] });
       totalUpdated += projectUpdated;
     }
   }
@@ -105,7 +112,14 @@ async function forEachActiveGhPr(config, callback) {
     }
   }
   if (centralUpdated > 0) {
-    safeWrite(centralPath, centralPrs);
+    mutateJsonFileLocked(centralPath, (currentPrs) => {
+      for (const updatedPr of centralPrs) {
+        const idx = currentPrs.findIndex(p => p.id === updatedPr.id);
+        if (idx >= 0) currentPrs[idx] = updatedPr;
+        else currentPrs.push(updatedPr);
+      }
+      return currentPrs;
+    }, { defaultValue: [] });
     totalUpdated += centralUpdated;
   }
 
@@ -182,11 +196,11 @@ async function pollPrStatus(config) {
           if (authorId) {
             try {
               const metricsPath = path.join(__dirname, 'metrics.json');
-              const metrics = shared.safeJson(metricsPath) || {};
-              if (!metrics[authorId]) metrics[authorId] = {};
-              if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
-              else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
-              shared.safeWrite(metricsPath, metrics);
+              mutateJsonFileLocked(metricsPath, (metrics) => {
+                if (!metrics[authorId]) metrics[authorId] = {};
+                if (newReviewStatus === 'approved') metrics[authorId].prsApproved = (metrics[authorId].prsApproved || 0) + 1;
+                else metrics[authorId].prsRejected = (metrics[authorId].prsRejected || 0) + 1;
+              });
             } catch (err) { log('warn', `Metrics update: ${err.message}`); }
           }
         }
@@ -258,7 +272,8 @@ async function pollPrHumanComments(config) {
       return true;
     });
 
-    const cutoff = pr.humanFeedback?.lastProcessedCommentDate || pr.created || '1970-01-01';
+    const cutoffStr = pr.humanFeedback?.lastProcessedCommentDate || pr.created || '1970-01-01';
+    const cutoffMs = new Date(cutoffStr).getTime() || 0;
 
     // Collect ALL human comments for full context, track new ones for triggering
     const allCommentEntries = [];
@@ -275,7 +290,8 @@ async function pollPrHumanComments(config) {
       allCommentEntries.push(entry);
 
       // Any new comment triggers a fix — no @minions filter needed
-      if (date > cutoff) {
+      const dateMs = date ? new Date(date).getTime() : 0;
+      if (dateMs && dateMs > cutoffMs) {
         newComments.push(entry);
       }
     }
@@ -290,7 +306,7 @@ async function pollPrHumanComments(config) {
     // Provide ALL comments as context — the agent needs full thread context to fix properly
     const feedbackContent = allCommentEntries
       .map(c => {
-        const isNew = c.date > cutoff;
+        const isNew = (new Date(c.date).getTime() || 0) > cutoffMs;
         return `${isNew ? '**[NEW]** ' : ''}**${c.author}** (${c.date}):\n${c.content.replace(/@minions\s*/gi, '').trim()}`;
       })
       .join('\n\n---\n\n');
@@ -397,7 +413,14 @@ async function reconcilePrs(config) {
     }
 
     if (projectAdded > 0 || backfilled > 0) {
-      safeWrite(prPath, existingPrs);
+      mutateJsonFileLocked(prPath, (currentPrs) => {
+        for (const pr of existingPrs) {
+          const idx = currentPrs.findIndex(p => p.id === pr.id);
+          if (idx >= 0) currentPrs[idx] = pr;
+          else currentPrs.push(pr);
+        }
+        return currentPrs;
+      }, { defaultValue: [] });
       totalAdded += projectAdded;
     }
   }


### PR DESCRIPTION
## Summary

- Convert all `safeWrite` calls in `ado.js` and `github.js` to `mutateJsonFileLocked` for concurrency-safe read-modify-write on `pull-requests.json` and `metrics.json`
- Metrics increments now happen inside locked callback (atomic read-increment-write)
- Date comparisons in comment polling use `new Date().getTime()` instead of string comparison
- Build status context matching in ADO uses anchored regex with word boundaries

## Changes

### ado.js
- `forEachActivePr`: PR write uses `mutateJsonFileLocked` with ID-based merge
- `pollPrStatus` metrics: read+increment+write inside single locked callback
- `reconcilePrs`: PR write uses `mutateJsonFileLocked` with ID-based merge
- `pollPrHumanComments`: date comparison uses `new Date()` parsing
- Build status filter: `includes()` → anchored `\b` regex

### github.js
- `forEachActiveGhPr`: project PR write + central PR write both use `mutateJsonFileLocked`
- `pollPrStatus` metrics: read+increment+write inside single locked callback
- `reconcilePrs`: PR write uses `mutateJsonFileLocked` with ID-based merge
- `pollPrHumanComments`: date comparison uses `new Date()` parsing

## Test plan
- [x] All 643 unit tests pass, 0 failures
- [ ] Verify PR status polling works end-to-end with active PRs
- [ ] Verify metrics.json updates are atomic under concurrent polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)