### PR TITLE
fix: critical dashboard bugs — plan pause, PRD tautology, inbox guard

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1898,9 +1898,9 @@ If nothing to do: { "duplicates": [], "reclassify": [], "remove": [] }`;
                 }
               }
 
-              if (w.status !== 'pending') reset++;
-              w.status = 'pending';
-              delete w._pausedBy;
+              if (w.status !== 'paused') reset++;
+              w.status = 'paused';
+              w._pausedBy = 'prd-pause';
               delete w._resumedAt;
               delete w.dispatched_at;
               delete w.dispatched_to;
@@ -3202,8 +3202,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       const config = queries.getConfig();
       const routing = safeRead(path.join(MINIONS_DIR, 'routing.md')) || '';
       return jsonReply(res, 200, {
-        engine: config.engine || {},
-        claude: config.claude || {},
+        engine: { ...shared.ENGINE_DEFAULTS, ...(config.engine || {}) },
+        claude: { ...shared.DEFAULT_CLAUDE, ...(config.claude || {}) },
         agents: config.agents || {},
         routing,
       });

--- a/dashboard/js/refresh.js
+++ b/dashboard/js/refresh.js
@@ -41,7 +41,7 @@ function _processStatusUpdate(data) {
   renderAgents(data.agents);
   renderPrdProgress(data.prdProgress);
   _cachePrdItems(data.prdProgress);
-  renderInbox(data.inbox);
+  renderInbox(data.inbox || []);
   cmdUpdateAgentList(data.agents);
   cmdUpdateProjectList(data.projects || []);
   renderNotes(data.notes);

--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -200,7 +200,7 @@ function renderPrdProgress(prog) {
 
   const renderGroupHeader = (g) => {
     const done = g.items.filter(i => i.status === 'done').length;
-    const wip = g.items.filter(i => i.status === 'dispatched' || i.status === 'dispatched').length;
+    const wip = g.items.filter(i => i.status === 'dispatched' || i.status === 'pending').length;
     const summary = (g.summary || '').replace(/^Convert plan to PRD:\s*/i, '').slice(0, 80);
     const isAwaitingApproval = g.planStatus === 'awaiting-approval';
     const isPaused = g.planStatus === 'paused';
@@ -564,7 +564,7 @@ async function prdItemEdit(source, itemId) {
   let completionHtml = '';
   const isDone = item.status === 'done';
   const isFailed = item.status === 'failed';
-  const isActive = item.status === 'dispatched' || item.status === 'dispatched';
+  const isActive = item.status === 'dispatched' || item.status === 'pending';
 
   if (isDone || isFailed || isActive) {
     const agent = wi?.dispatched_to || completedEntry?.agent || '';
@@ -604,9 +604,9 @@ async function prdItemEdit(source, itemId) {
         '</select></div>' +
       '<div><label style="font-size:11px;color:var(--muted);display:block;margin-bottom:4px">Complexity</label>' +
         '<select id="prd-edit-complexity" style="padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--text)">' +
-          '<option value="small"' + (item.complexity === 'small' ? ' selected' : '') + '>Small</option>' +
-          '<option value="medium"' + (item.complexity === 'medium' ? ' selected' : '') + '>Medium</option>' +
-          '<option value="large"' + (item.complexity === 'large' ? ' selected' : '') + '>Large</option>' +
+          '<option value="small"' + ((item.estimated_complexity || item.complexity) === 'small' ? ' selected' : '') + '>Small</option>' +
+          '<option value="medium"' + ((item.estimated_complexity || item.complexity) === 'medium' ? ' selected' : '') + '>Medium</option>' +
+          '<option value="large"' + ((item.estimated_complexity || item.complexity) === 'large' ? ' selected' : '') + '>Large</option>' +
         '</select></div>' +
     '</div>' +
     '<div style="display:flex;gap:8px">' +

--- a/dashboard/js/state.js
+++ b/dashboard/js/state.js
@@ -89,6 +89,7 @@ function prunePrdRequeueState(workItems) {
 
 function rerenderPrdFromCache() {
   if (!window._lastStatus || !window._lastStatus.prdProgress) return;
+  renderPrdProgress(window._lastStatus.prdProgress);
   renderPrd(window._lastStatus.prd, window._lastStatus.prdProgress);
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5488,6 +5488,9 @@ async function main() {
 
     // Status mutation guards — comprehensive retry/revert safety
     await testStatusMutationGuards();
+
+    // Dashboard audit: critical functional bugs
+    await testDashboardAuditCritical();
   } finally {
     cleanupTmpDirs();
   }
@@ -7048,6 +7051,63 @@ async function testStatusMutationGuards() {
     const lockCount = (fnBody.match(/mutateJsonFileLocked\(wiPath/g) || []).length;
     assert.ok(lockCount > 0 || safeWriteCount === 0,
       'updateWorkItemStatus must use mutateJsonFileLocked OR not write directly at all');
+  });
+}
+
+// ─── Dashboard Audit: Critical Functional Bugs ─────────────────────────────
+
+async function testDashboardAuditCritical() {
+  console.log('\n── Dashboard Audit: Critical Functional Bugs ──');
+
+  await test('plan pause sets status to paused with _pausedBy tag, not pending', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // Find the pause handler section (between "Propagate pause" and the safeWrite that commits the change)
+    const pauseSection = src.match(/Propagate pause to materialized[\s\S]*?if \(changed\) safeWrite\(wiPath/);
+    assert.ok(pauseSection, 'pause handler section must exist');
+    const section = pauseSection[0];
+    assert.ok(section.includes("w.status = 'paused'"), 'pause must set status to paused, not pending');
+    assert.ok(section.includes("w._pausedBy = 'prd-pause'"), 'pause must set _pausedBy = prd-pause');
+    assert.ok(!section.includes("delete w._pausedBy"), 'pause must NOT delete _pausedBy');
+  });
+
+  await test('plan pause and resume are symmetric — resume finds paused items', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // Resume looks for status === 'paused' && _pausedBy === 'prd-pause'
+    assert.ok(src.includes("w.status === 'paused' && w._pausedBy === 'prd-pause'"),
+      'resume must look for paused + prd-pause tag');
+    // Pause must set those exact values
+    const pauseSection = src.match(/Propagate pause to materialized[\s\S]*?if \(changed\) safeWrite\(wiPath/);
+    assert.ok(pauseSection[0].includes("'paused'") && pauseSection[0].includes("'prd-pause'"),
+      'pause must set the values that resume looks for');
+  });
+
+  await test('PRD isActive check includes both dispatched and pending', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    // Should not have the tautology: dispatched || dispatched
+    const tautology = (src.match(/dispatched.*\|\|.*dispatched/g) || []);
+    assert.strictEqual(tautology.length, 0,
+      'render-prd.js must not have dispatched || dispatched tautology');
+    // Should have dispatched || pending
+    assert.ok(src.includes("'dispatched' || i.status === 'pending'") || src.includes("'dispatched' || item.status === 'pending'"),
+      'isActive/wip check must include both dispatched and pending');
+  });
+
+  await test('rerenderPrdFromCache calls renderPrdProgress', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'state.js'), 'utf8');
+    const fn = src.match(/function rerenderPrdFromCache[\s\S]*?^}/m);
+    assert.ok(fn, 'rerenderPrdFromCache must exist');
+    assert.ok(fn[0].includes('renderPrdProgress'), 'must call renderPrdProgress to update item list');
+  });
+
+  await test('refresh.js passes inbox with fallback to empty array', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'refresh.js'), 'utf8');
+    assert.ok(src.includes('data.inbox || []'), 'renderInbox must receive data.inbox || [] fallback');
+  });
+
+  await test('PRD edit modal uses estimated_complexity field', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    // The complexity dropdown must reference estimated_complexity
+    assert.ok(src.includes('estimated_complexity'), 'edit modal must use estimated_complexity field from PRD JSON');
   });
 }
 


### PR DESCRIPTION
## Summary
- **Plan pause broken**: `handlePlansPause` set items to `pending` instead of `paused` with `_pausedBy='prd-pause'`, so the resume handler could never find paused items — pause was a no-op
- **PRD isActive tautology**: Copy-paste bug `dispatched || dispatched` → fixed to `dispatched || pending` in both `prdItemEdit` and `renderGroupHeader` wip count
- **rerenderPrdFromCache incomplete**: Only called `renderPrd` but not `renderPrdProgress`, so requeue button state changes were invisible until full refresh
- **Inbox null guard**: `renderInbox(data.inbox)` crashed if `data.inbox` was undefined — added `|| []` fallback (every other render call had this)
- **PRD complexity field mismatch**: Edit modal read `item.complexity` but PRD JSON uses `estimated_complexity` — dropdown always defaulted to "Small"

## Test plan
- [x] 6 new tests covering all fixes
- [x] 698 passed, 2 failed (pre-existing), 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)