### PR TITLE
fix: medium dashboard bugs — settings, work items, schedules, plans

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -959,15 +959,18 @@ const server = http.createServer(async (req, res) => {
       }
       if (!wiPath) return jsonReply(res, 404, { error: 'source not found' });
 
-      const items = JSON.parse(safeRead(wiPath) || '[]');
-      const idx = items.findIndex(i => i.id === id);
-      if (idx === -1) return jsonReply(res, 404, { error: 'item not found' });
-
-      const item = items[idx];
-
-      // Remove item from work-items file
-      items.splice(idx, 1);
-      safeWrite(wiPath, items);
+      let item = null;
+      let found = false;
+      mutateJsonFileLocked(wiPath, (items) => {
+        if (!Array.isArray(items)) return items;
+        const idx = items.findIndex(i => i.id === id);
+        if (idx === -1) return items;
+        item = items[idx];
+        items.splice(idx, 1);
+        found = true;
+        return items;
+      }, { defaultValue: [] });
+      if (!found) return jsonReply(res, 404, { error: 'item not found' });
 
       // Clean dispatch entries + kill running agent
       const dispatchRemoved = cleanDispatchEntries(d =>
@@ -1080,6 +1083,7 @@ const server = http.createServer(async (req, res) => {
       if (body.agents) item.agents = body.agents;
       if (body.references) item.references = body.references;
       if (body.acceptanceCriteria) item.acceptanceCriteria = body.acceptanceCriteria;
+      if (body.skipPr) item.skipPr = true;
       items.push(item);
       safeWrite(wiPath, items);
       return jsonReply(res, 200, { ok: true, id });
@@ -3297,6 +3301,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       config.claude = { ...shared.DEFAULT_CLAUDE };
       config.agents = { ...shared.DEFAULT_AGENTS };
       safeWrite(path.join(MINIONS_DIR, 'config.json'), config);
+      reloadConfig();
+      invalidateStatusCache();
       return jsonReply(res, 200, { ok: true });
     } catch (e) { return jsonReply(res, 500, { error: e.message }); }
   }

--- a/dashboard/js/render-plans.js
+++ b/dashboard/js/render-plans.js
@@ -255,7 +255,7 @@ function renderPlans(plans) {
         '<div><div class="plan-card-title">' + escHtml(p.summary || p.file) + versionBadge + '</div>' +
           '<div class="plan-card-meta">' +
             '<span style="font-weight:600;color:' + (statusColors[effectiveStatus] || 'var(--muted)') + '">' + label + '</span>' +
-            '<span>' + escHtml(p.project) + '</span>' +
+            (p.project ? '<span>' + escHtml(p.project) + '</span>' : '') +
             '<span>' + p.itemCount + ' items</span>' +
             (p.updatedAt ? '<span title="Last updated: ' + p.updatedAt + '">Updated ' + timeAgo(p.updatedAt) + '</span>' : '') +
             (p.completedAt ? '<span>' + p.completedAt.slice(0, 10) + '</span>' : '') +
@@ -370,6 +370,7 @@ async function planSubmitRevise(file) {
   try {
     const res = await fetch('/api/plans/revise', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, feedback }) });
     const data = await res.json();
+    if (!res.ok) { showToast('cmd-toast', 'Revision failed: ' + (data.error || 'unknown'), false); return; }
     showToast('cmd-toast', 'Revision requested — agent will update the plan (' + data.workItemId + ')', true);
     planHideRevise(file);
     refreshPlans();

--- a/dashboard/js/render-prs.js
+++ b/dashboard/js/render-prs.js
@@ -96,9 +96,10 @@ function openModal(i) {
 }
 
 function openAddPrModal() {
-  const projOpts = (typeof cmdProjects !== 'undefined' ? cmdProjects : []).map(p =>
-    '<option value="' + escHtml(p) + '">' + escHtml(p) + '</option>'
-  ).join('');
+  const projOpts = (typeof cmdProjects !== 'undefined' ? cmdProjects : []).map(p => {
+    const name = typeof p === 'object' ? p.name : p;
+    return '<option value="' + escHtml(name) + '">' + escHtml(name) + '</option>';
+  }).join('');
   const inputStyle = 'display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit';
 
   document.getElementById('modal-title').textContent = 'Link Pull Request';

--- a/dashboard/js/render-schedules.js
+++ b/dashboard/js/render-schedules.js
@@ -484,6 +484,7 @@ function openEditScheduleModal(id) {
   document.getElementById('modal-body').innerHTML = _scheduleFormHtml(sched, true);
   window._editScheduleId = id;
   document.getElementById('modal').classList.add('open');
+  _updateCronPreview();
 }
 
 async function submitSchedule(isEdit) {

--- a/dashboard/js/render-work-items.js
+++ b/dashboard/js/render-work-items.js
@@ -84,7 +84,7 @@ function renderWorkItems(items) {
   allWorkItems = items;
   const el = document.getElementById('work-items-content');
   const countEl = document.getElementById('wi-count');
-  countEl.textContent = items.length;
+  if (countEl) countEl.textContent = items.length;
   if (!items.length) {
     el.innerHTML = '<p class="empty">No work items. Add tasks via Command Center above.</p>';
     return;

--- a/dashboard/js/utils.js
+++ b/dashboard/js/utils.js
@@ -38,7 +38,7 @@ function timeAgo(isoStr) {
 }
 
 function statusColor(s) {
-  return s === 'working' ? 'working' : s === 'done' ? 'done' : '';
+  return s === 'working' ? 'working' : s === 'done' ? 'done' : s === 'error' ? 'error' : '';
 }
 
 function llmCopyBtn() {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5494,6 +5494,9 @@ async function main() {
 
     // Dashboard audit: XSS fixes
     await testDashboardAuditXss();
+
+    // Dashboard audit: medium bugs
+    await testDashboardAuditMedium();
   } finally {
     cleanupTmpDirs();
   }
@@ -7057,7 +7060,6 @@ async function testStatusMutationGuards() {
   });
 }
 
-<<<<<<< HEAD
 // ─── Dashboard Audit: Critical Functional Bugs ─────────────────────────────
 
 async function testDashboardAuditCritical() {
@@ -7183,6 +7185,71 @@ async function testDashboardAuditXss() {
     const tdMatch = rowFn ? (rowFn[0].match(/<td>/g) || []) : [];
     assert.strictEqual(thMatch.length, tdMatch.length,
       `PR table headers (${thMatch.length}) must match cell count (${tdMatch.length})`);
+  });
+}
+
+// ─── Dashboard Audit: Medium Bugs ───────────────────────────────────────────
+
+async function testDashboardAuditMedium() {
+  console.log('\n── Dashboard Audit: Medium Bugs ──');
+
+  await test('handleSettingsReset calls reloadConfig and invalidateStatusCache', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const resetFn = src.match(/function handleSettingsReset[\s\S]*?^  \}/m);
+    assert.ok(resetFn, 'handleSettingsReset must exist');
+    assert.ok(resetFn[0].includes('reloadConfig()'), 'reset must call reloadConfig');
+    assert.ok(resetFn[0].includes('invalidateStatusCache()'), 'reset must invalidate cache');
+  });
+
+  await test('handleWorkItemsCreate persists skipPr flag', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(src.includes('body.skipPr') && src.includes('item.skipPr'),
+      'work item create must copy skipPr from body to item');
+  });
+
+  await test('handleWorkItemsDelete uses mutateJsonFileLocked', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // Find delete handler — it's after "Remove item from work-items file" or uses splice
+    const deleteSections = src.match(/Remove item from work-items|mutateJsonFileLocked\(wiPath[\s\S]*?splice/g) || [];
+    // Should use mutateJsonFileLocked, not raw safeRead+safeWrite
+    assert.ok(src.includes('mutateJsonFileLocked(wiPath') || !src.includes("JSON.parse(safeRead(wiPath) || '[]')"),
+      'delete must use mutateJsonFileLocked for atomic read-modify-write');
+  });
+
+  await test('openEditScheduleModal calls _updateCronPreview', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-schedules.js'), 'utf8');
+    const editFn = src.match(/function openEditScheduleModal[\s\S]*?^}/m);
+    assert.ok(editFn, 'openEditScheduleModal must exist');
+    assert.ok(editFn[0].includes('_updateCronPreview'), 'edit modal must call _updateCronPreview');
+  });
+
+  await test('wi-count element has null guard', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-work-items.js'), 'utf8');
+    assert.ok(src.includes('if (countEl)'), 'wi-count access must be null-guarded');
+  });
+
+  await test('render-plans.js guards p.project against undefined', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-plans.js'), 'utf8');
+    assert.ok(src.includes('p.project ?') || src.includes('p.project?'),
+      'p.project must be guarded before rendering');
+  });
+
+  await test('render-prs.js cmdProjects handles object items', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prs.js'), 'utf8');
+    assert.ok(src.includes('p.name') && src.includes("typeof p === 'object'"),
+      'cmdProjects items must be unwrapped from {name} objects');
+  });
+
+  await test('planSubmitRevise checks res.ok before success toast', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-plans.js'), 'utf8');
+    const reviseFn = src.match(/async function planSubmitRevise[\s\S]*?^}/m);
+    assert.ok(reviseFn, 'planSubmitRevise must exist');
+    assert.ok(reviseFn[0].includes('res.ok'), 'must check res.ok before showing success');
+  });
+
+  await test('statusColor handles error state', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'utils.js'), 'utf8');
+    assert.ok(src.includes("'error'"), 'statusColor must handle error state');
   });
 }
 


### PR DESCRIPTION
## Summary
- **Settings reset stale cache**: `handleSettingsReset` wrote config but didn't call `reloadConfig()`/`invalidateStatusCache()` — settings page showed stale values after reset
- **skipPr flag lost**: Work item create handler never persisted `body.skipPr` — items marked "skip PR" still generated PRs
- **Work item delete race condition**: Used raw `safeRead`+`safeWrite` alongside locked retry handler — replaced with `mutateJsonFileLocked`
- **Schedule edit cron stale**: `openEditScheduleModal` didn't call `_updateCronPreview()` — saving immediately used stale cron from previous session
- **wi-count null crash**: `renderWorkItems` crashed when called from non-work page (e.g. retry handler)
- **Plan project "undefined"**: `escHtml(p.project)` rendered literal `"undefined"` for projectless plans
- **PR dropdown "[object Object]"**: `cmdProjects` items are `{name}` objects, not strings — project dropdown showed `[object Object]`
- **Plan revise silent failure**: `planSubmitRevise` showed success toast before checking `res.ok`
- **Error agents invisible**: `statusColor('error')` returned empty string — error agents looked identical to idle

## Test plan
- [x] 9 new tests covering all fixes
- [x] 701 passed, 2 failed (pre-existing), 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)