### PR TITLE
fix: low-severity dashboard polish — null guards, event params, UI gaps

### DIFF
--- a/dashboard/js/render-dispatch.js
+++ b/dashboard/js/render-dispatch.js
@@ -6,9 +6,9 @@ let _completedPage = 0;
 let _logPage = 0;
 
 function _completedPrev() { if (_completedPage > 0) { _completedPage--; refresh(); } }
-function _completedNext() { _completedPage++; refresh(); }
+function _completedNext() { _completedPage++; refresh(); } // clamped in renderDispatch
 function _logPrev() { if (_logPage > 0) { _logPage--; refresh(); } }
-function _logNext() { _logPage++; refresh(); }
+function _logNext() { _logPage++; refresh(); } // clamped in renderEngineLog
 
 function renderEngineStatus(engine) {
   const badge = document.getElementById('engine-badge');
@@ -153,6 +153,7 @@ function renderDispatch(dispatch) {
 
 function renderEngineLog(log) {
   const el = document.getElementById('engine-log');
+  if (!el) return;
   if (!log || log.length === 0) {
     el.innerHTML = '<div class="empty">No log entries yet.</div>';
     return;

--- a/dashboard/js/render-inbox.js
+++ b/dashboard/js/render-inbox.js
@@ -140,7 +140,7 @@ async function modalSaveEdit() {
 function modalCancelEdit() {
   const body = document.getElementById('modal-body');
   body.contentEditable = 'false';
-  body.textContent = _modalDocContext.content; // revert
+  body.innerHTML = renderMd(_modalDocContext.content); // revert (render Markdown, not raw text)
   body.style.border = '';
   body.style.padding = '';
   document.getElementById('modal-edit-btn').style.display = '';

--- a/dashboard/js/render-work-items.js
+++ b/dashboard/js/render-work-items.js
@@ -151,14 +151,14 @@ function editWorkItem(id, source) {
       '</label>' +
       '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">' +
         '<button onclick="closeModal()" class="pr-pager-btn" style="padding:6px 16px;font-size:var(--text-md)">Cancel</button>' +
-        '<button onclick="submitWorkItemEdit(\'' + escHtml(id) + '\',\'' + escHtml(source || '') + '\')" style="padding:6px 16px;font-size:var(--text-md);background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Save</button>' +
+        '<button onclick="submitWorkItemEdit(\'' + escHtml(id) + '\',\'' + escHtml(source || '') + '\',event)" style="padding:6px 16px;font-size:var(--text-md);background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Save</button>' +
       '</div>' +
     '</div>';
   document.getElementById('modal').classList.add('open');
 }
 
-async function submitWorkItemEdit(id, source) {
-  var btn = event?.target; if (btn) { btn.disabled = true; btn.textContent = 'Saving...'; }
+async function submitWorkItemEdit(id, source, e) {
+  var btn = (e || window.event)?.target; if (btn) { btn.disabled = true; btn.textContent = 'Saving...'; }
   const title = document.getElementById('wi-edit-title').value.trim();
   const description = document.getElementById('wi-edit-desc').value;
   const type = document.getElementById('wi-edit-type').value;
@@ -320,7 +320,7 @@ function openCreateWorkItemModal() {
   const typeOpts = ['implement', 'fix', 'explore', 'test', 'review', 'ask', 'plan', 'verify', 'decompose', 'meeting'].map(t =>
     '<option value="' + t + '"' + (t === 'implement' ? ' selected' : '') + '>' + t + '</option>'
   ).join('');
-  const priOpts = ['high', 'medium', 'low'].map(p =>
+  const priOpts = ['critical', 'high', 'medium', 'low'].map(p =>
     '<option value="' + p + '"' + (p === 'medium' ? ' selected' : '') + '>' + p + '</option>'
   ).join('');
   const agentOpts = (typeof cmdAgents !== 'undefined' ? cmdAgents : []).map(a =>
@@ -349,7 +349,7 @@ function openCreateWorkItemModal() {
       '<label id="wi-new-skippr-row" style="color:var(--text);font-size:var(--text-md);display:flex;gap:8px;align-items:center;cursor:pointer"><input type="checkbox" id="wi-new-skippr"> Skip PR creation (push branch only)</label>' +
       '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:4px">' +
         '<button onclick="closeModal()" class="pr-pager-btn">Cancel</button>' +
-        '<button onclick="_submitCreateWorkItem()" style="padding:6px 16px;background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Create</button>' +
+        '<button onclick="_submitCreateWorkItem(event)" style="padding:6px 16px;background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Create</button>' +
       '</div>' +
     '</div>';
   document.getElementById('modal').classList.add('open');
@@ -365,8 +365,8 @@ function openCreateWorkItemModal() {
   setTimeout(() => document.getElementById('wi-new-title')?.focus(), 100);
 }
 
-async function _submitCreateWorkItem() {
-  var btn = event?.target; if (btn) { btn.disabled = true; btn.textContent = 'Creating...'; }
+async function _submitCreateWorkItem(e) {
+  var btn = (e || window.event)?.target; if (btn) { btn.disabled = true; btn.textContent = 'Creating...'; }
   const title = document.getElementById('wi-new-title')?.value?.trim();
   if (!title) { if (btn) { btn.disabled = false; btn.textContent = 'Create'; } alert('Title is required'); return; }
   const desc = document.getElementById('wi-new-desc')?.value || '';

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5497,6 +5497,9 @@ async function main() {
 
     // Dashboard audit: medium bugs
     await testDashboardAuditMedium();
+
+    // Dashboard audit: low-severity polish
+    await testDashboardAuditLow();
   } finally {
     cleanupTmpDirs();
   }
@@ -7250,6 +7253,42 @@ async function testDashboardAuditMedium() {
   await test('statusColor handles error state', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'utils.js'), 'utf8');
     assert.ok(src.includes("'error'"), 'statusColor must handle error state');
+  });
+}
+
+// ─── Dashboard Audit: Low-Severity Polish ──────────────────────────────────
+
+async function testDashboardAuditLow() {
+  console.log('\n── Dashboard Audit: Low-Severity Polish ──');
+
+  await test('renderEngineLog has null guard on el', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-dispatch.js'), 'utf8');
+    const fn = src.match(/function renderEngineLog[\s\S]*?^}/m);
+    assert.ok(fn, 'renderEngineLog must exist');
+    assert.ok(fn[0].includes('if (!el) return'), 'must null-guard el for when engine page is not in DOM');
+  });
+
+  await test('modalCancelEdit uses innerHTML with renderMd, not textContent', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-inbox.js'), 'utf8');
+    const fn = src.match(/function modalCancelEdit[\s\S]*?^}/m);
+    assert.ok(fn, 'modalCancelEdit must exist');
+    assert.ok(fn[0].includes('innerHTML') && fn[0].includes('renderMd'),
+      'must use innerHTML with renderMd to show rendered Markdown, not raw text via textContent');
+  });
+
+  await test('create work item modal includes critical priority', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-work-items.js'), 'utf8');
+    const createFn = src.match(/function openCreateWorkItemModal[\s\S]*?^}/m);
+    assert.ok(createFn, 'openCreateWorkItemModal must exist');
+    assert.ok(createFn[0].includes("'critical'"), 'priority list must include critical');
+  });
+
+  await test('submitWorkItemEdit and _submitCreateWorkItem accept event parameter', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-work-items.js'), 'utf8');
+    assert.ok(src.includes('submitWorkItemEdit(id, source, e)') || src.includes('function submitWorkItemEdit(id, source, e'),
+      'submitWorkItemEdit must accept event parameter');
+    assert.ok(src.includes('_submitCreateWorkItem(e)') || src.includes('function _submitCreateWorkItem(e'),
+      '_submitCreateWorkItem must accept event parameter');
   });
 }
 


### PR DESCRIPTION
## Summary
- **renderEngineLog crash**: No null guard on `el` — crashed when engine page wasn't in DOM
- **modalCancelEdit raw text**: Used `textContent` to revert, showing raw Markdown instead of rendered content — fixed to use `innerHTML` + `renderMd`
- **Missing critical priority**: Create work item modal only had high/medium/low — added `critical` to match edit modal
- **Implicit event globals**: `submitWorkItemEdit` and `_submitCreateWorkItem` relied on `window.event` — now accept explicit event parameter to prevent double-submit in strict mode

## Test plan
- [x] 4 new tests covering all fixes
- [x] 696 passed, 2 failed (pre-existing), 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)