### PR TITLE
fix: dashboard audit pass 2 — CC error handling, charter edits, archived PRDs

### DIFF
--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -348,6 +348,12 @@ function ccRetryLast() {
   _ccDoSend(text.trim());
 }
 
+async function _ccFetch(url, body) {
+  const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  if (!res.ok) { const d = await res.json().catch(() => ({})); throw new Error(d.error || 'Request failed (' + res.status + ')'); }
+  return res;
+}
+
 async function ccExecuteAction(action) {
   const msgs = document.getElementById('cc-messages');
   const status = document.createElement('div');
@@ -356,13 +362,10 @@ async function ccExecuteAction(action) {
   try {
     switch (action.type) {
       case 'dispatch': {
-        const res = await fetch('/api/work-items', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
+        const res = await _ccFetch('/api/work-items', {
             title: action.title, type: action.workType || 'implement',
             priority: action.priority || 'medium', description: action.description || '',
             project: action.project || '', agents: action.agents || [],
-          })
         });
         const d = await res.json();
         status.innerHTML = '&#10003; Dispatched: <strong>' + escHtml(d.id || action.title) + '</strong>';
@@ -371,49 +374,33 @@ async function ccExecuteAction(action) {
         break;
       }
       case 'note': {
-        const today = new Date().toISOString().slice(0, 10);
-        await fetch('/api/notes', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: action.title, what: action.content || action.description, author: 'command-center' })
-        });
+        await _ccFetch('/api/notes', { title: action.title, what: action.content || action.description, author: 'command-center' });
         status.innerHTML = '&#10003; Note saved: <strong>' + escHtml(action.title) + '</strong>';
         status.style.color = 'var(--green)';
         break;
       }
       case 'pin': {
-        await fetch('/api/pinned', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: action.title, content: action.content || action.description, level: action.level || '' })
-        });
+        await _ccFetch('/api/pinned', { title: action.title, content: action.content || action.description, level: action.level || '' });
         status.innerHTML = '&#x1F4CC; Pinned: <strong>' + escHtml(action.title) + '</strong> — visible to all agents';
         status.style.color = 'var(--green)';
         refresh();
         break;
       }
       case 'plan': {
-        await fetch('/api/plan', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: action.title, description: action.description, project: action.project, branchStrategy: action.branchStrategy || 'parallel' })
-        });
+        await _ccFetch('/api/plan', { title: action.title, description: action.description, project: action.project, branchStrategy: action.branchStrategy || 'parallel' });
         status.innerHTML = '&#10003; Plan queued: <strong>' + escHtml(action.title) + '</strong>';
         status.style.color = 'var(--green)';
         break;
       }
       case 'cancel': {
-        await fetch('/api/agents/cancel', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ agentId: action.agent, reason: action.reason || 'Cancelled via command center' })
-        });
+        await _ccFetch('/api/agents/cancel', { agentId: action.agent, reason: action.reason || 'Cancelled via command center' });
         status.innerHTML = '&#10003; Cancelled agent: <strong>' + escHtml(action.agent) + '</strong>';
         status.style.color = 'var(--orange)';
         break;
       }
       case 'retry': {
         for (const id of (action.ids || [])) {
-          await fetch('/api/work-items/retry', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id, source: '' })
-          });
+          await _ccFetch('/api/work-items/retry', { id, source: '' });
         }
         status.innerHTML = '&#10003; Retried: <strong>' + escHtml((action.ids || []).join(', ')) + '</strong>';
         status.style.color = 'var(--green)';
@@ -421,46 +408,31 @@ async function ccExecuteAction(action) {
         break;
       }
       case 'pause-plan': {
-        await fetch('/api/plans/pause', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ file: action.file })
-        });
+        await _ccFetch('/api/plans/pause', { file: action.file });
         status.innerHTML = '&#10003; Paused plan: <strong>' + escHtml(action.file) + '</strong>';
         status.style.color = 'var(--orange)';
         break;
       }
       case 'approve-plan': {
-        await fetch('/api/plans/approve', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ file: action.file })
-        });
+        await _ccFetch('/api/plans/approve', { file: action.file });
         status.innerHTML = '&#10003; Approved plan: <strong>' + escHtml(action.file) + '</strong>';
         status.style.color = 'var(--green)';
         break;
       }
       case 'edit-prd-item': {
-        await fetch('/api/prd-items/update', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ source: action.source, itemId: action.itemId, name: action.name, description: action.description, priority: action.priority, estimated_complexity: action.complexity })
-        });
+        await _ccFetch('/api/prd-items/update', { source: action.source, itemId: action.itemId, name: action.name, description: action.description, priority: action.priority, estimated_complexity: action.complexity });
         status.innerHTML = '&#10003; Updated PRD item: <strong>' + escHtml(action.itemId) + '</strong>';
         status.style.color = 'var(--green)';
         break;
       }
       case 'remove-prd-item': {
-        await fetch('/api/prd-items/remove', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ source: action.source, itemId: action.itemId })
-        });
+        await _ccFetch('/api/prd-items/remove', { source: action.source, itemId: action.itemId });
         status.innerHTML = '&#10003; Removed PRD item: <strong>' + escHtml(action.itemId) + '</strong>';
         status.style.color = 'var(--orange)';
         break;
       }
       case 'delete-work-item': {
-        await fetch('/api/work-items/delete', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: action.id, source: action.source || '' })
-        });
+        await _ccFetch('/api/work-items/delete', { id: action.id, source: action.source || '' });
         status.innerHTML = '&#10003; Deleted work item: <strong>' + escHtml(action.id) + '</strong>';
         status.style.color = 'var(--orange)';
         break;
@@ -585,48 +557,33 @@ async function ccExecuteAction(action) {
         break;
       }
       case 'unpin': {
-        await fetch('/api/pinned/remove', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: action.title })
-        });
+        await _ccFetch('/api/pinned/remove', { title: action.title });
         status.innerHTML = '&#10003; Unpinned: <strong>' + escHtml(action.title) + '</strong>';
         status.style.color = 'var(--green)';
         refresh();
         break;
       }
       case 'archive-plan': {
-        await fetch('/api/plans/archive', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ file: action.file })
-        });
+        await _ccFetch('/api/plans/archive', { file: action.file });
         status.innerHTML = '&#10003; Archived plan: <strong>' + escHtml(action.file) + '</strong>';
         status.style.color = 'var(--green)';
         refresh();
         break;
       }
       case 'reject-plan': {
-        await fetch('/api/plans/reject', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ file: action.file, reason: action.reason || '' })
-        });
+        await _ccFetch('/api/plans/reject', { file: action.file, reason: action.reason || '' });
         status.innerHTML = '&#10003; Rejected plan: <strong>' + escHtml(action.file) + '</strong>';
         status.style.color = 'var(--orange)';
         break;
       }
       case 'steer-agent': {
-        await fetch('/api/agents/steer', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ agent: action.agent, message: action.message || action.content })
-        });
+        await _ccFetch('/api/agents/steer', { agent: action.agent, message: action.message || action.content });
         status.innerHTML = '&#10003; Steering message sent to <strong>' + escHtml(action.agent) + '</strong>';
         status.style.color = 'var(--green)';
         break;
       }
       case 'add-meeting-note': {
-        await fetch('/api/meetings/note', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: action.id, note: action.note || action.content })
-        });
+        await _ccFetch('/api/meetings/note', { id: action.id, note: action.note || action.content });
         status.innerHTML = '&#10003; Note added to meeting <strong>' + escHtml(action.id) + '</strong>';
         status.style.color = 'var(--green)';
         break;
@@ -643,30 +600,21 @@ async function ccExecuteAction(action) {
         break;
       }
       case 'link-pr': {
-        await fetch('/api/pull-requests/link', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ url: action.url, title: action.title || '', project: action.project || '', autoObserve: action.autoObserve !== false })
-        });
+        await _ccFetch('/api/pull-requests/link', { url: action.url, title: action.title || '', project: action.project || '', autoObserve: action.autoObserve !== false });
         status.innerHTML = '&#10003; PR linked: <strong>' + escHtml(action.url) + '</strong>';
         status.style.color = 'var(--green)';
         refresh();
         break;
       }
       case 'archive-meeting': {
-        await fetch('/api/meetings/archive', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: action.id })
-        });
+        await _ccFetch('/api/meetings/archive', { id: action.id });
         status.innerHTML = '&#10003; Meeting archived: <strong>' + escHtml(action.id) + '</strong>';
         status.style.color = 'var(--green)';
         refresh();
         break;
       }
       case 'update-routing': {
-        await fetch('/api/settings/routing', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: action.content })
-        });
+        await _ccFetch('/api/settings/routing', { content: action.content });
         status.innerHTML = '&#10003; Routing updated';
         status.style.color = 'var(--green)';
         break;

--- a/dashboard/js/detail-panel.js
+++ b/dashboard/js/detail-panel.js
@@ -1,5 +1,7 @@
 // dashboard/js/detail-panel.js — Agent detail panel extracted from dashboard.html
 
+let _charterRawCache = ''; // stored outside DOM to survive innerHTML rewrites on tab switch
+
 function closeDetail() {
   document.getElementById('detail-overlay').classList.remove('open');
   document.getElementById('detail-panel').classList.remove('open');
@@ -88,7 +90,7 @@ function renderDetailContent(detail, tab) {
       '</div>' +
       '<div id="charter-view" class="section">' + renderMd(charterContent || 'No charter found. Click Edit to create one.') + '</div>' +
       '<textarea id="charter-editor" style="display:none;width:100%;min-height:300px;padding:8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:Consolas,monospace;font-size:12px;resize:vertical">' + escHtml(charterContent) + '</textarea>';
-    el._charterRaw = charterContent;
+    _charterRawCache = charterContent;
   } else if (tab === 'history') {
     let html = '';
     // Recent dispatch results
@@ -126,7 +128,7 @@ function _toggleCharterEdit() {
 
 function _cancelCharterEdit() {
   const el = document.getElementById('detail-content');
-  document.getElementById('charter-editor').value = el._charterRaw || '';
+  document.getElementById('charter-editor').value = _charterRawCache || '';
   document.getElementById('charter-view').style.display = '';
   document.getElementById('charter-editor').style.display = 'none';
   document.getElementById('charter-edit-btn').style.display = '';
@@ -146,7 +148,7 @@ async function _saveCharter() {
     });
     if (res.ok) {
       document.getElementById('charter-view').innerHTML = renderMd(content);
-      document.getElementById('detail-content')._charterRaw = content;
+      _charterRawCache = content;
       _cancelCharterEdit();
       showToast('cmd-toast', 'Charter saved', true);
     } else {

--- a/dashboard/js/render-kb.js
+++ b/dashboard/js/render-kb.js
@@ -62,7 +62,7 @@ function renderKnowledgeBase() {
       if (!Array.isArray(catItems)) continue;
       for (const item of catItems) items.push({ ...item, category: cat });
     }
-    items.sort((a, b) => b.date.localeCompare(a.date));
+    items.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
   } else {
     items = (_kbData[_kbActiveTab] || []).map(i => ({ ...i, category: _kbActiveTab }));
   }

--- a/dashboard/js/render-plans.js
+++ b/dashboard/js/render-plans.js
@@ -400,7 +400,11 @@ function _renderPlanModal(normalizedFile, raw, lastMod) {
   let text = '';
 
   if (normalizedFile.endsWith('.json')) {
-    const plan = JSON.parse(raw);
+    let plan;
+    try { plan = JSON.parse(raw); } catch (e) {
+      document.getElementById('modal-body').innerHTML = '<p style="color:var(--red)">Failed to parse plan JSON: ' + escHtml(e.message) + '</p><pre style="font-size:10px;max-height:200px;overflow:auto">' + escHtml((raw || '').slice(0, 500)) + '</pre>';
+      return;
+    }
     title = plan.plan_summary || normalizedFile;
     const items = (plan.missing_features || []).map((f, i) =>
       (i + 1) + '. [' + f.id + '] ' + f.name + ' (' + (f.estimated_complexity || '?') + ', ' + (f.priority || '?') + ')' +

--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -550,7 +550,14 @@ function showArchivedPrdDetail(idxOrFile) {
 }
 
 async function prdItemEdit(source, itemId) {
-  const item = _prdItems.find(i => i.source === source && i.id === itemId);
+  let item = _prdItems.find(i => i.source === source && i.id === itemId);
+  // Also search archived groups if not found in active items
+  if (!item && window._archivedPrdGroups) {
+    for (const g of window._archivedPrdGroups) {
+      item = (g.items || []).find(i => i.source === source && i.id === itemId);
+      if (item) break;
+    }
+  }
   if (!item) return;
 
   // Look up work item and dispatch completion info

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5500,6 +5500,9 @@ async function main() {
 
     // Dashboard audit: low-severity polish
     await testDashboardAuditLow();
+
+    // Dashboard audit pass 2
+    await testDashboardAuditPass2();
   } finally {
     cleanupTmpDirs();
   }
@@ -7289,6 +7292,54 @@ async function testDashboardAuditLow() {
       'submitWorkItemEdit must accept event parameter');
     assert.ok(src.includes('_submitCreateWorkItem(e)') || src.includes('function _submitCreateWorkItem(e'),
       '_submitCreateWorkItem must accept event parameter');
+  });
+}
+
+// ─── Dashboard Audit Pass 2 ─────────────────────────────────────────────────
+
+async function testDashboardAuditPass2() {
+  console.log('\n── Dashboard Audit Pass 2 ──');
+
+  await test('CC actions use _ccFetch helper with res.ok check', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'command-center.js'), 'utf8');
+    assert.ok(src.includes('async function _ccFetch'), '_ccFetch helper must exist');
+    assert.ok(src.includes('res.ok'), '_ccFetch must check res.ok');
+    // Count direct fetch calls vs _ccFetch calls in ccExecuteAction
+    const actionFn = src.match(/async function ccExecuteAction[\s\S]*?^}/m);
+    assert.ok(actionFn, 'ccExecuteAction must exist');
+    const directFetches = (actionFn[0].match(/await fetch\('/g) || []).length;
+    // Remaining direct fetches are for cases that already have their own res.ok checks
+    // (schedule, meetings, settings, pipelines, doc-chat) or are read-only (plan content fetch)
+    assert.ok(directFetches <= 10,
+      'ccExecuteAction should use _ccFetch for simple mutations, found ' + directFetches + ' direct fetch calls');
+  });
+
+  await test('_renderPlanModal wraps JSON.parse in try/catch', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-plans.js'), 'utf8');
+    const fn = src.match(/function _renderPlanModal[\s\S]*?^}/m);
+    assert.ok(fn, '_renderPlanModal must exist');
+    assert.ok(fn[0].includes('try') && fn[0].includes('JSON.parse'),
+      'JSON.parse must be wrapped in try/catch');
+  });
+
+  await test('charter raw content stored outside DOM element', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'detail-panel.js'), 'utf8');
+    assert.ok(src.includes('_charterRawCache'), 'should use module-level _charterRawCache variable');
+    assert.ok(!src.includes('el._charterRaw'), 'should not use DOM expando el._charterRaw');
+  });
+
+  await test('KB sort handles undefined date', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-kb.js'), 'utf8');
+    assert.ok(src.includes("b.date || ''") || src.includes("(b.date||'')"),
+      'KB sort must handle undefined date with fallback');
+  });
+
+  await test('prdItemEdit searches archived groups as fallback', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    const fn = src.match(/async function prdItemEdit[\s\S]*?^}/m);
+    assert.ok(fn, 'prdItemEdit must exist');
+    assert.ok(fn[0].includes('_archivedPrdGroups'),
+      'prdItemEdit must search archived groups when item not in _prdItems');
   });
 }
 


### PR DESCRIPTION
## Summary

Second-pass audit findings after initial 4 PRs (#210-#213):

- **Command Center silent failures (High)**: 15+ `ccExecuteAction` branches showed green success toast even when the API returned errors. Added `_ccFetch` helper that checks `res.ok` and throws on failure — the existing `catch(e)` block now surfaces the error properly
- **Plan modal crash on bad JSON (Medium)**: `_renderPlanModal` called `JSON.parse(raw)` without try/catch — corrupted PRD files produced cascading uncaught exceptions. Now shows an error message
- **Charter edit data loss on tab switch (Medium)**: `_charterRaw` was stored as a DOM expando on `#detail-content` — `innerHTML` reassignment on tab switch destroyed it. Moved to module-level `_charterRawCache` variable
- **Archived PRD items unclickable (Medium)**: `prdItemEdit` only searched `_prdItems` (active items); archived items returned silently. Now falls back to `_archivedPrdGroups`
- **KB panel crash on undefined date (Low)**: `b.date.localeCompare(a.date)` threw TypeError for entries with missing date field

## Test plan
- [x] 5 new tests covering all fixes
- [x] 697 passed, 2 failed (pre-existing), 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)