### PR TITLE
feat(P-j5r1h8c3): Playbook subagent guidance and health check preamble

### DIFF
--- a/playbooks/decompose.md
+++ b/playbooks/decompose.md
@@ -21,6 +21,10 @@ A work item has been flagged as too large for a single agent dispatch. Analyze t
 {{acceptance_criteria}}
 {{/acceptance_criteria}}
 
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks. For codebase exploration, reading files, and writing the decomposition output, work directly — do not spawn subagents.
+
 ## Instructions
 
 1. **Explore the codebase** at `{{project_path}}` — understand the existing structure, patterns, and dependencies

--- a/playbooks/explore.md
+++ b/playbooks/explore.md
@@ -52,6 +52,10 @@ If the task is purely exploratory (no deliverable requested), skip this step.
 ### 6. Status
 **Note:** Do NOT write to `agents/*/status.json` — the engine manages your status automatically.
 
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks. For reading files, exploring directories, and writing findings, work directly — do not spawn subagents.
+
 ## Rules
 - Do NOT modify existing code unless the task explicitly asks for it.
 - Use the appropriate MCP tools for PR creation — check available tools before starting.

--- a/playbooks/fix.md
+++ b/playbooks/fix.md
@@ -17,6 +17,14 @@ Branch: `{{pr_branch}}`
 
 {{review_note}}
 
+## Health Check
+
+Before starting work, run `git status` and verify the worktree is clean and on the expected branch (`{{pr_branch}}`). If the worktree is dirty or on the wrong branch, report the issue and stop.
+
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks. For sequential work, single-file edits, searches, and file reads, work directly — do not spawn subagents.
+
 ## How to Fix
 
 1. You are already in the correct worktree on branch `{{pr_branch}}`. Do NOT create additional worktrees.

--- a/playbooks/implement-shared.md
+++ b/playbooks/implement-shared.md
@@ -45,6 +45,14 @@ git push origin {{branch_name}}
 - Remove the worktree — the next plan item needs it
 - Create a new worktree — one already exists at `{{worktree_path}}`
 
+## Health Check
+
+Before starting work, run `git status` and verify the worktree is clean and on the expected branch (`{{branch_name}}`). If the worktree is dirty or on the wrong branch, report the issue and stop.
+
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks. For sequential work, single-file edits, searches, and file reads, work directly — do not spawn subagents.
+
 ## Instructions
 
 1. Read relevant source code and reference implementations before writing anything

--- a/playbooks/implement.md
+++ b/playbooks/implement.md
@@ -30,6 +30,14 @@ If this feature spans multiple projects, you may need to:
 3. If changes are needed in other projects, create separate worktrees and PRs for each
 4. Note cross-repo dependencies in PR descriptions (e.g., "Requires office-bohemia PR #123")
 
+## Health Check
+
+Before starting work, run `git status` and verify the worktree is clean and on the expected branch. If the worktree is dirty or on the wrong branch, report the issue and stop.
+
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks (e.g., editing files in unrelated modules simultaneously). For sequential work, single-file edits, searches, and file reads, work directly — do not spawn subagents.
+
 ## Instructions
 
 1. Read relevant source code and reference implementations before writing anything

--- a/playbooks/review.md
+++ b/playbooks/review.md
@@ -11,6 +11,10 @@ Repo: {{repo_name}} | Org: {{ado_org}} | Project: {{ado_project}}
 Review **{{pr_id}}**: {{pr_title}}
 Branch: `{{pr_branch}}`
 
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks (e.g., reviewing unrelated files simultaneously). For reading diffs, checking patterns, and writing the review, work directly — do not spawn subagents.
+
 ## How to Review
 
 1. Fetch latest and read the diff:

--- a/playbooks/test.md
+++ b/playbooks/test.md
@@ -26,6 +26,10 @@ This is a **test/build/run task**. Your goal is to build, run, test, or verify s
 5. **Test** if the task asks for it (e.g., `yarn test`, `pytest`, etc.)
 6. **Report results** — what worked, what failed, build output, test results, localhost URL if running
 
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks. For building, testing, and reporting results, work directly — do not spawn subagents.
+
 ## Rules
 
 - **Do NOT create pull requests** — this is a test/verification task only

--- a/playbooks/verify.md
+++ b/playbooks/verify.md
@@ -209,6 +209,10 @@ For each project worktree:
 
 4. Note the E2E PR URLs in the testing guide.
 
+## Working Style
+
+Use subagents only for genuinely parallel, independent tasks (e.g., building separate project worktrees simultaneously). For sequential steps like reading docs, running tests, and writing the report, work directly — do not spawn subagents.
+
 ## Rules
 
 - **Read the project docs first** — never assume a build system, language, or framework


### PR DESCRIPTION
## Summary

- Adds "Working Style" section to 8 playbooks (implement, implement-shared, fix, review, decompose, verify, explore, test) instructing agents to avoid unnecessary subagent spawning — work directly for sequential tasks, single-file edits, searches, and file reads
- Adds "Health Check" preamble to implement, implement-shared, and fix playbooks requiring `git status` verification before starting work
- No CAPS emphasis introduced; playbooks remain platform-agnostic

## Test plan

- [ ] Verify implement.md, fix.md, review.md contain subagent guidance
- [ ] Verify implement.md, implement-shared.md, fix.md contain health check preamble
- [ ] Confirm no CAPS emphasis (CRITICAL, MUST, NEVER, ALWAYS) in new text
- [ ] Confirm playbooks remain platform-agnostic
- [ ] Run `npm test` — 687 passed, 7 pre-existing failures (unrelated to .md changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)