### PR TITLE
feat(P-k7m3q9w2): Fix review re-dispatch infinite loop

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1264,9 +1264,11 @@ function discoverFromPrs(config, project) {
     // minionsReview tracks metadata (reviewer, note) but not the authoritative status
     const reviewStatus = pr.reviewStatus || 'pending';
 
-    // PRs needing review: pending or waiting (review dispatched but no verdict yet)
+    // PRs needing review: pending review status and not already reviewed without new commits
     const autoReview = config.engine?.autoReview !== false;
-    const needsReview = autoReview && reviewStatus === 'pending';
+    // Skip re-dispatch if already reviewed and no new commits pushed since last review
+    const alreadyReviewed = pr.lastReviewedAt && (!pr.lastPushedAt || pr.lastPushedAt <= pr.lastReviewedAt);
+    const needsReview = autoReview && reviewStatus === 'pending' && !alreadyReviewed;
     if (needsReview) {
       const key = `review-${project?.name || 'default'}-${pr.id}`;
       if (isAlreadyDispatched(key) || isOnCooldown(key, cooldownMs)) continue;

--- a/engine/github.js
+++ b/engine/github.js
@@ -141,6 +141,13 @@ async function pollPrStatus(config) {
     else if (prData.state === 'closed') newStatus = PR_STATUS.ABANDONED;
     else if (prData.state === 'open') newStatus = PR_STATUS.ACTIVE;
 
+    // Track head SHA changes to detect new pushes (used for review re-dispatch gating)
+    if (prData.head?.sha && pr.headSha !== prData.head.sha) {
+      pr.headSha = prData.head.sha;
+      pr.lastPushedAt = new Date().toISOString();
+      updated = true;
+    }
+
     if (pr.status !== newStatus) {
       log('info', `PR ${pr.id} status: ${pr.status} → ${newStatus}`);
       pr.status = newStatus;
@@ -191,6 +198,9 @@ async function pollPrStatus(config) {
       if (states.some(s => s === 'CHANGES_REQUESTED')) newReviewStatus = 'changes-requested';
       else if (states.some(s => s === 'APPROVED')) newReviewStatus = 'approved';
       else if (states.length > 0) newReviewStatus = 'pending';
+      // If all reviews were COMMENTED (filtered out), states is empty but reviews exist.
+      // Set to 'waiting' instead of leaving as 'pending' to prevent infinite review re-dispatch.
+      else if (states.length === 0 && reviews.length > 0 && newReviewStatus === 'pending') newReviewStatus = 'waiting';
 
       if (pr.reviewStatus !== newReviewStatus) {
         log('info', `PR ${pr.id} reviewStatus: ${pr.reviewStatus} → ${newReviewStatus}`);

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -727,6 +727,9 @@ function updatePrAfterReview(agentId, pr, project) {
 
   // Set reviewStatus to 'waiting' (single source of truth — synced from ADO/GitHub votes on next poll)
   target.reviewStatus = 'waiting';
+  // Track when this PR was last reviewed — used by engine.js to prevent re-dispatch
+  // until new commits are pushed (lastPushedAt > lastReviewedAt)
+  target.lastReviewedAt = ts();
   target.minionsReview = {
     reviewer: reviewerName,
     reviewedAt: ts(),

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5716,6 +5716,45 @@ async function testPrWaitingResolve() {
   });
 }
 
+async function testReviewReDispatchLoop() {
+  console.log('\n── Review Re-Dispatch Loop Prevention ──');
+
+  await test('github.js sets reviewStatus to waiting when only COMMENTED reviews exist', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes("reviews.length > 0") && src.includes("newReviewStatus === 'pending'") && src.includes("newReviewStatus = 'waiting'"),
+      'Should set reviewStatus to waiting when all reviews are COMMENTED (states empty but reviews exist)');
+  });
+
+  await test('github.js tracks headSha and lastPushedAt on PR', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes('pr.headSha') && src.includes('pr.lastPushedAt'),
+      'Should track headSha and lastPushedAt for new-commit detection');
+  });
+
+  await test('lifecycle.js sets lastReviewedAt on review completion', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine', 'lifecycle.js'), 'utf8');
+    const reviewFn = src.slice(src.indexOf('function updatePrAfterReview('), src.indexOf('\nfunction ', src.indexOf('function updatePrAfterReview(') + 1));
+    assert.ok(reviewFn.includes('lastReviewedAt'),
+      'updatePrAfterReview should set lastReviewedAt timestamp on PR record');
+  });
+
+  await test('engine.js skips review re-dispatch when lastReviewedAt set and no new commits', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine.js'), 'utf8');
+    assert.ok(src.includes('alreadyReviewed') && src.includes('lastReviewedAt') && src.includes('lastPushedAt'),
+      'Should gate review dispatch on lastReviewedAt vs lastPushedAt comparison');
+    assert.ok(src.includes('!alreadyReviewed'),
+      'needsReview should include !alreadyReviewed check');
+  });
+
+  await test('engine.js allows re-dispatch when new commits pushed after review', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'engine.js'), 'utf8');
+    // The condition: pr.lastPushedAt <= pr.lastReviewedAt means "no new commits"
+    // When lastPushedAt > lastReviewedAt, alreadyReviewed is false, allowing re-dispatch
+    assert.ok(src.includes("pr.lastPushedAt <= pr.lastReviewedAt"),
+      'alreadyReviewed should compare lastPushedAt <= lastReviewedAt so new pushes allow re-review');
+  });
+}
+
 async function testSettingsComprehensive() {
   await test('settings UI includes all ENGINE_DEFAULTS fields', () => {
     const src = fs.readFileSync(path.join(__dirname, '..', 'dashboard', 'js', 'settings.js'), 'utf8');
@@ -5916,6 +5955,7 @@ async function testSessionFeatures() {
   await testScheduleDetailModal();
   await testPlanArchiveApi();
   await testPrWaitingResolve();
+  await testReviewReDispatchLoop();
   await testSettingsComprehensive();
   await testCcActionTypes();
   await testAutoModeStatus();


### PR DESCRIPTION
## Summary

- **COMMENTED-only reviews** in `github.js` now set `reviewStatus` to `'waiting'` instead of leaving it as `'pending'`, preventing infinite re-dispatch when the only reviews are comment-style (e.g., self-owned repos where `gh pr review --comment` is used)
- **`lastReviewedAt` timestamp** set on PR record in `lifecycle.js` when review completes
- **Re-dispatch gating** in `engine.js`: skips review dispatch when `lastReviewedAt` is set and no new commits exist since (`lastPushedAt <= lastReviewedAt`)
- **`headSha` / `lastPushedAt` tracking** in `github.js` pollPrStatus to detect new pushes

## Test plan

- [x] 5 new unit tests covering: COMMENTED-only reviews, headSha tracking, lastReviewedAt, re-dispatch skip logic, re-dispatch after new commits
- [ ] Verify PR-203 stops getting re-reviewed on next engine tick
- [ ] Verify pushing a new commit to a reviewed PR triggers re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)