### PR TITLE
feat(P-r4x8m2k6): Fix null crashes in lifecycle.js

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -617,6 +617,7 @@ function syncPrsFromOutput(output, agentId, meta, config) {
   const inboxFiles = getInboxFiles().filter(f => f.includes(agentId) && f.includes(today));
   for (const f of inboxFiles) {
     const content = safeRead(path.join(INBOX_DIR, f));
+    if (!content) continue;
     const prHeaderPattern = /\*\*PR[:\*]*\*?\s*[#-]*\s*(?:(?:visualstudio\.com|dev\.azure\.com)[^\s"]*?pullrequest\/(\d+)|github\.com\/[^\s"]*?\/pull\/(\d+))/gi;
     while ((match = prHeaderPattern.exec(content)) !== null) prMatches.add(match[1] || match[2]);
   }
@@ -988,7 +989,7 @@ function createReviewFeedbackForAuthor(reviewerAgentId, pr, config) {
   const inboxFiles = getInboxFiles();
   const reviewFiles = inboxFiles.filter(f => f.includes(reviewerAgentId) && f.includes(today));
   if (reviewFiles.length === 0) return;
-  const reviewContent = reviewFiles.map(f => safeRead(path.join(INBOX_DIR, f))).join('\n\n');
+  const reviewContent = reviewFiles.map(f => safeRead(path.join(INBOX_DIR, f))).filter(Boolean).join('\n\n');
   const feedbackFile = `feedback-${authorAgentId}-from-${reviewerAgentId}-${pr.id}-${today}.md`;
   const feedbackPath = shared.uniquePath(path.join(INBOX_DIR, feedbackFile));
   const content = `# Review Feedback for ${config.agents[authorAgentId]?.name || authorAgentId}\n\n` +


### PR DESCRIPTION
## Summary
- **syncPrsFromOutput** (~line 619): `safeRead()` returns null on missing/unreadable inbox files. Added `if (!content) continue;` guard before calling `.exec(content)` to prevent TypeError crash.
- **createReviewFeedbackForAuthor** (~line 991): `safeRead()` returns null on failure, causing `.join('\n\n')` to produce literal `'null'` strings in review feedback. Added `.filter(Boolean)` before `.join()`.

## Test plan
- [x] `npm test` passes with 767 passed, 0 failed
- [ ] Verify syncPrsFromOutput doesn't crash when inbox files are missing/unreadable
- [ ] Verify createReviewFeedbackForAuthor produces clean feedback without 'null' strings

**Plan:** minions-2026-04-06-3.json | **Item:** P-r4x8m2k6

🤖 Generated with [Claude Code](https://claude.com/claude-code)