### PR TITLE
feat(P-g2j6w4c8): Replace raw status strings with WI_STATUS constants

### DIFF
--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -116,7 +116,7 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
       const maxRetries = ENGINE_DEFAULTS.maxRetries;
       if (retryableFailure && retries < maxRetries) {
         log('info', `Dispatch error for ${item.meta.item.id} — auto-retry ${retries + 1}/${maxRetries}`);
-        lifecycle().updateWorkItemStatus(item.meta, 'pending', '');
+        lifecycle().updateWorkItemStatus(item.meta, WI_STATUS.PENDING, '');
         // Remove this dispatch key from completed so dedupe doesn't block immediate redispatch.
         if (item.meta?.dispatchKey) {
           try {
@@ -150,7 +150,7 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
         const finalReason = !retryableFailure
           ? `Non-retryable failure: ${reason || 'Unknown error'}`
           : (reason || `Failed after ${maxRetries} retries`);
-        lifecycle().updateWorkItemStatus(item.meta, 'failed', finalReason);
+        lifecycle().updateWorkItemStatus(item.meta, WI_STATUS.FAILED, finalReason);
         // Alert: find items blocked by this failure and write inbox note
         try {
           const config = getConfig();

--- a/engine/queries.js
+++ b/engine/queries.js
@@ -10,7 +10,8 @@ const os = require('os');
 const shared = require('./shared');
 
 const { safeRead, safeReadDir, safeJson, safeWrite, getProjects,
-  projectWorkItemsPath, projectPrPath, parseSkillFrontmatter, KB_CATEGORIES } = shared;
+  projectWorkItemsPath, projectPrPath, parseSkillFrontmatter, KB_CATEGORIES,
+  WI_STATUS } = shared;
 
 // ── Paths ───────────────────────────────────────────────────────────────────
 
@@ -179,7 +180,7 @@ function getAgentStatus(agentId) {
     const latestInFlight = allItems
       .filter(w =>
         (w.dispatched_to || '').toLowerCase() === String(agentId).toLowerCase() &&
-        w.status === 'dispatched'
+        w.status === WI_STATUS.DISPATCHED
       )
       .sort((a, b) => (b.dispatched_at || '').localeCompare(a.dispatched_at || ''))[0];
     if (latestInFlight) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -604,8 +604,8 @@ async function testQueriesAgents() {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
     assert.ok(src.includes('Fallback: derive active state from work-item markers.'),
       'getAgentStatus should include multi-source fallback from work-items');
-    assert.ok(src.includes("w.status === 'dispatched'"),
-      'fallback should only treat dispatched work items as working');
+    assert.ok(src.includes("w.status === WI_STATUS.DISPATCHED"),
+      'fallback should only treat dispatched work items as working (using WI_STATUS constant)');
     assert.ok(src.includes("(w.dispatched_to || '').toLowerCase() === String(agentId).toLowerCase()"),
       'fallback should map by dispatched_to marker');
   });


### PR DESCRIPTION
## Summary
- Replace 5 raw status string literals with `WI_STATUS` constants across `engine.js`, `engine/dispatch.js`, and `engine/queries.js`
- Add `WI_STATUS` import to `queries.js` (already imported in the other two files)
- Update source-pattern test assertion in `unit.test.js` to match the new constant usage

## Changes
| File | Change |
|------|--------|
| `engine.js:2296` | `'failed'` → `WI_STATUS.FAILED` (stall recovery filter) |
| `engine.js:2338` | `'pending'` → `WI_STATUS.PENDING` (un-fail cascade deps) |
| `engine/dispatch.js:119` | `'pending'` → `WI_STATUS.PENDING` (auto-retry status) |
| `engine/dispatch.js:153` | `'failed'` → `WI_STATUS.FAILED` (final failure status) |
| `engine/queries.js:182` | `'dispatched'` → `WI_STATUS.DISPATCHED` (agent status fallback) |

## Test plan
- [x] `npm test` — 767 passed, 0 failed
- [x] Updated source-pattern assertion in test to match new constant usage
- [x] No new raw status strings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)