### PR TITLE
feat(P-a3c5j7d1): Low-priority code quality cleanup

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -2328,9 +2328,8 @@ If nothing to do: { "duplicates": [], "reclassify": [], "remove": [] }`;
     try {
       const body = await readBody(req);
       if (!body.file) return jsonReply(res, 400, { error: 'file required' });
-      if (body.file.includes('..') || body.file.includes('\0') || body.file.includes('/') || body.file.includes('\\')) {
-        return jsonReply(res, 400, { error: 'invalid filename' });
-      }
+      try { shared.sanitizePath(body.file, body.file.endsWith('.json') ? PRD_DIR : PLANS_DIR); }
+      catch { return jsonReply(res, 400, { error: 'invalid filename' }); }
       const isJson = body.file.endsWith('.json');
       const targetDir = isJson ? PRD_DIR : PLANS_DIR;
       const archivePath = path.join(targetDir, 'archive', body.file);

--- a/engine/ado.js
+++ b/engine/ado.js
@@ -381,7 +381,7 @@ async function reconcilePrs(config) {
       const title = adoPr.title || '';
       // Extract item ID from branch name or PR title (e.g., feat(P-2cafdc2a): ...)
       const branchMatch = branch.match(/(P-[a-z0-9]{6,})/i) || branch.match(/(W-[a-z0-9]{6,})/i) || branch.match(/(PL-[a-z0-9]{6,})/i);
-      const titleMatch = title.match(/\((P-[a-z0-9]{6,})\)/) || title.match(/\((W-[a-z0-9]{6,})\)/) || title.match(/\((W-[a-z0-9]{6,})\)/) || title.match(/\((PL-[a-z0-9]{6,})\)/);
+      const titleMatch = title.match(/\((P-[a-z0-9]{6,})\)/) || title.match(/\((W-[a-z0-9]{6,})\)/) || title.match(/\((PL-[a-z0-9]{6,})\)/);
       const linkedItemId = branchMatch?.[1] || titleMatch?.[1] || null;
       const linkedItem = linkedItemId ? allItems.find(i => i.id === linkedItemId) : null;
       const confirmedItemId = linkedItem ? linkedItemId : null;

--- a/engine/llm.js
+++ b/engine/llm.js
@@ -160,25 +160,12 @@ function callLLMStreaming(promptText, sysPromptText, { timeout = 120000, label =
               if (block.type === 'text' && block.text && block.text !== lastTextSent) {
                 lastTextSent = block.text;
                 onChunk(block.text);
-              }
-            }
-          }
-        } catch { /* incomplete JSON or non-JSON line */ }
-      }
-      // Also emit tool_use events so the frontend can show "Using tool: Read..."
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || !trimmed.startsWith('{')) continue;
-        try {
-          const obj = JSON.parse(trimmed);
-          if (obj.type === 'assistant' && obj.message?.content) {
-            for (const block of obj.message.content) {
-              if (block.type === 'tool_use' && block.name && onToolUse) {
+              } else if (block.type === 'tool_use' && block.name && onToolUse) {
                 onToolUse(block.name, block.input);
               }
             }
           }
-        } catch {}
+        } catch { /* incomplete JSON or non-JSON line */ }
       }
     });
     proc.stderr.on('data', d => { stderr += d.toString(); });

--- a/engine/preflight.js
+++ b/engine/preflight.js
@@ -27,7 +27,13 @@ function findClaudeBinary() {
     path.join(path.dirname(process.execPath), '..', 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
     // fnm / volta — sibling to the node binary
     path.join(path.dirname(process.execPath), 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
-  ].filter(Boolean);
+  ].filter(p => {
+    if (!p) {
+      if (process.env.MINIONS_DEBUG) console.log('[preflight] Dropped empty CLI search path entry');
+      return false;
+    }
+    return true;
+  });
   for (const p of searchPaths) {
     try { if (fs.existsSync(p)) return p; } catch {}
   }


### PR DESCRIPTION
## Summary
- **ADO reconciliation regex dedup** (ado.js): Removed copy-paste duplicate `W-` pattern from `titleMatch` chain
- **LLM streaming parse consolidation** (llm.js): Merged two separate `for` loops (text + tool_use) into a single parse loop
- **Preflight debug logging** (preflight.js): Added debug-level logging when `.filter(Boolean)` drops empty CLI search paths (gated behind `MINIONS_DEBUG`)
- **Plan path validation alignment** (dashboard.js): Replaced manual slash/backslash rejection in `handlePlansUnarchive` with `shared.sanitizePath()` to match all other plan handlers
- **buildBaseVars null guards verified** (engine.js): All 3 call sites already have explicit null checks — no change needed

## Test plan
- [x] `npm test` passes with 767/767 tests, 0 failures
- [ ] Verify ADO PR reconciliation still links P-/W-/PL- items correctly
- [ ] Verify LLM streaming still emits both text chunks and tool_use events
- [ ] Verify plan unarchive rejects traversal paths but accepts valid filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)