### PR TITLE
feat(P-q9c2w6n3): Optimize getAgentStatus() to read only head+tail of live-output.log

### DIFF
--- a/engine/queries.js
+++ b/engine/queries.js
@@ -13,6 +13,35 @@ const { safeRead, safeReadDir, safeJson, safeWrite, getProjects,
   projectWorkItemsPath, projectPrPath, parseSkillFrontmatter, KB_CATEGORIES,
   WI_STATUS } = shared;
 
+/**
+ * Read the first `bytes` and last `bytes` of a file efficiently using byte offsets.
+ * For files <= 2*bytes, reads the whole file. Returns { head, tail } strings.
+ * Returns { head: '', tail: '' } on any error.
+ */
+function readHeadTail(filePath, bytes = 1024) {
+  try {
+    const stat = fs.statSync(filePath);
+    const size = stat.size;
+    if (size === 0) return { head: '', tail: '' };
+    if (size <= bytes * 2) {
+      const full = fs.readFileSync(filePath, 'utf8');
+      return { head: full, tail: full };
+    }
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const headBuf = Buffer.alloc(bytes);
+      fs.readSync(fd, headBuf, 0, bytes, 0);
+      const tailBuf = Buffer.alloc(bytes);
+      fs.readSync(fd, tailBuf, 0, bytes, size - bytes);
+      return { head: headBuf.toString('utf8'), tail: tailBuf.toString('utf8') };
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return { head: '', tail: '' };
+  }
+}
+
 // ── Paths ───────────────────────────────────────────────────────────────────
 
 const MINIONS_DIR = shared.MINIONS_DIR;
@@ -130,19 +159,20 @@ function getAgentStatus(agentId) {
       branch: active.meta?.branch || '',
       started_at: active.started_at || active.created_at || null,
     };
-    // Detect permission-waiting: check live output for non-bypass permission mode
+    // Detect permission-waiting: read only head+tail of live-output.log (max 2KB total)
     try {
-      const liveLog = shared.safeRead(path.join(AGENTS_DIR, agentId, 'live-output.log'));
-      if (liveLog) {
-        // Check init message for permission mode
-        const initMatch = liveLog.match(/"permissionMode"\s*:\s*"([^"]+)"/);
+      const liveLogPath = path.join(AGENTS_DIR, agentId, 'live-output.log');
+      const { head, tail } = readHeadTail(liveLogPath, 1024);
+      if (head) {
+        // Check init message (in head) for permission mode
+        const initMatch = head.match(/"permissionMode"\s*:\s*"([^"]+)"/);
         if (initMatch && initMatch[1] !== 'bypassPermissions') {
           result._permissionMode = initMatch[1];
         }
-        // Check if agent has been silent for >60s (possible permission prompt wait)
-        const lastLine = liveLog.trimEnd().split('\n').pop();
+        // Check if agent has been silent for >60s (use tail for recent activity)
+        const lastLine = tail.trimEnd().split('\n').pop();
         if (lastLine && lastLine.includes('"type":"assistant"') && lastLine.includes('"tool_use"')) {
-          const liveStat = fs.statSync(path.join(AGENTS_DIR, agentId, 'live-output.log'));
+          const liveStat = fs.statSync(liveLogPath);
           const silentMs = Date.now() - liveStat.mtimeMs;
           if (silentMs > 60000 && result._permissionMode) {
             result._warning = 'Possibly waiting for permission approval — agent is not in bypass mode';
@@ -748,6 +778,7 @@ module.exports = {
 
   // Helpers
   timeSince,
+  readHeadTail, // exported for testing
 
   // Core state
   getConfig, getControl, getDispatch, getDispatchQueue,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -630,6 +630,47 @@ async function testQueriesAgents() {
     assert.ok(typeof detail.statusData === 'object');
     assert.ok(Array.isArray(detail.recentDispatches));
   });
+
+  await test('readHeadTail reads only head and tail for large files', () => {
+    const tmp = createTmpDir();
+    const fp = path.join(tmp, 'big.log');
+    // Create a file >2KB: 1KB head marker + 2KB filler + 1KB tail marker
+    const headContent = 'HEAD_MARKER_START' + 'A'.repeat(1024 - 'HEAD_MARKER_START'.length);
+    const filler = 'B'.repeat(2048);
+    const tailContent = 'C'.repeat(1024 - 'TAIL_MARKER_END'.length) + 'TAIL_MARKER_END';
+    fs.writeFileSync(fp, headContent + filler + tailContent);
+    const { head, tail } = queries.readHeadTail(fp, 1024);
+    assert.strictEqual(head.length, 1024, 'head should be exactly 1024 bytes');
+    assert.strictEqual(tail.length, 1024, 'tail should be exactly 1024 bytes');
+    assert.ok(head.includes('HEAD_MARKER_START'), 'head should contain start of file');
+    assert.ok(tail.includes('TAIL_MARKER_END'), 'tail should contain end of file');
+    assert.ok(!head.includes('TAIL_MARKER_END'), 'head should not contain tail content');
+  });
+
+  await test('readHeadTail reads full file when small (<= 2KB)', () => {
+    const tmp = createTmpDir();
+    const fp = path.join(tmp, 'small.log');
+    const content = 'small file content here';
+    fs.writeFileSync(fp, content);
+    const { head, tail } = queries.readHeadTail(fp, 1024);
+    assert.strictEqual(head, content, 'head should be full file content');
+    assert.strictEqual(tail, content, 'tail should be full file content');
+  });
+
+  await test('readHeadTail returns empty strings for missing file', () => {
+    const { head, tail } = queries.readHeadTail('/nonexistent/path/file.log', 1024);
+    assert.strictEqual(head, '', 'head should be empty for missing file');
+    assert.strictEqual(tail, '', 'tail should be empty for missing file');
+  });
+
+  await test('getAgentStatus uses readHeadTail instead of safeRead for live-output.log', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
+    // Find the getAgentStatus function body and verify it uses readHeadTail
+    assert.ok(src.includes('readHeadTail(liveLogPath'),
+      'getAgentStatus should use readHeadTail for live-output.log');
+    assert.ok(!src.includes('safeRead(path.join(AGENTS_DIR, agentId, \'live-output.log\'))'),
+      'getAgentStatus should NOT use safeRead for live-output.log');
+  });
 }
 
 async function testQueriesWorkItems() {


### PR DESCRIPTION
## Summary
- Replaces full-file `safeRead()` in `getAgentStatus()` with byte-offset `readHeadTail()` that reads only first 1KB + last 1KB of live-output.log
- Files under 2KB still read in full (backward compatible)
- Reduces I/O from ~5MB+ to ~10KB per status poll cycle with 5 agents

## Changes
- `engine/queries.js`: Added `readHeadTail(filePath, bytes)` helper using `fs.openSync`/`fs.readSync` with explicit byte offsets
- `engine/queries.js`: Updated `getAgentStatus()` to use `readHeadTail` instead of `safeRead` for live-output.log
- `test/unit.test.js`: Added 4 tests covering large files, small files, missing files, and source verification

## Test plan
- [x] All existing unit tests pass (814 passed, 1 pre-existing failure unrelated)
- [x] New tests verify head+tail read for >2KB files
- [x] New tests verify full read for <2KB files
- [x] New tests verify graceful handling of missing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)