### PR TITLE
feat(P-w8n4q1r6): Buffer log() writes to reduce lock contention

### DIFF
--- a/engine/cli.js
+++ b/engine/cli.js
@@ -391,6 +391,7 @@ const commands = {
       if (e.activeProcesses.size === 0) {
         safeWrite(CONTROL_PATH, { state: 'stopped', stopped_at: e.ts() });
         e.log('info', 'Graceful shutdown complete (no active agents)');
+        shared.flushLogs(); // drain buffered log entries before exit
         console.log('No active agents — stopped.');
         process.exit(0);
       }
@@ -404,6 +405,7 @@ const commands = {
           clearInterval(poll);
           safeWrite(CONTROL_PATH, { state: 'stopped', stopped_at: e.ts() });
           e.log('info', 'Graceful shutdown complete (all agents finished)');
+          shared.flushLogs(); // drain buffered log entries before exit
           console.log('All agents finished — stopped.');
           process.exit(0);
         }
@@ -411,6 +413,7 @@ const commands = {
           clearInterval(poll);
           safeWrite(CONTROL_PATH, { state: 'stopped', stopped_at: e.ts() });
           e.log('warn', `Graceful shutdown timed out after ${timeout / 1000}s with ${e.activeProcesses.size} agent(s) still active`);
+          shared.flushLogs(); // drain buffered log entries before exit
           console.log(`Shutdown timeout (${timeout / 1000}s) — force exiting with ${e.activeProcesses.size} agent(s) still running.`);
           process.exit(1);
         }

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -18,18 +18,54 @@ function ts() { return new Date().toISOString(); }
 function logTs() { return new Date().toLocaleTimeString(); }
 function dateStamp() { return new Date().toISOString().slice(0, 10); }
 
+// ── Log Buffering ──────────────────────────────────────────────────────────
+// Buffer log entries in memory and flush to disk periodically to reduce lock
+// contention (~139 calls/tick → 1 lock acquisition per flush).
+const _logBuffer = [];
+let _logFlushTimer = null;
+
 function log(level, msg, meta = {}) {
   const entry = { timestamp: ts(), level, message: msg, ...meta };
+  // Console output remains immediate
   console.log(`[${logTs()}] [${level}] ${msg}`);
 
+  _logBuffer.push(entry);
+
+  // Start the flush timer lazily on first buffered entry
+  if (!_logFlushTimer) {
+    _logFlushTimer = setInterval(() => {
+      _flushLogBuffer();
+    }, ENGINE_DEFAULTS.logFlushInterval);
+    // Unref so the timer doesn't keep the process alive during shutdown
+    if (_logFlushTimer.unref) _logFlushTimer.unref();
+  }
+
+  // Flush immediately when buffer exceeds threshold
+  if (_logBuffer.length >= ENGINE_DEFAULTS.logBufferSize) {
+    _flushLogBuffer();
+  }
+}
+
+function _flushLogBuffer() {
+  if (_logBuffer.length === 0) return;
+  const entries = _logBuffer.splice(0);
   try {
     mutateJsonFileLocked(LOG_PATH, (logData) => {
       if (!Array.isArray(logData)) logData = logData?.entries || [];
-      logData.push(entry);
+      logData.push(...entries);
       if (logData.length >= 2500) logData.splice(0, logData.length - 2000);
       return logData;
     }, { defaultValue: [] });
   } catch { /* logging should never crash the caller */ }
+}
+
+/** Flush buffered log entries to disk. Call during graceful shutdown to drain the buffer. */
+function flushLogs() {
+  _flushLogBuffer();
+  if (_logFlushTimer) {
+    clearInterval(_logFlushTimer);
+    _logFlushTimer = null;
+  }
 }
 
 // ── File I/O ─────────────────────────────────────────────────────────────────
@@ -441,6 +477,8 @@ const ENGINE_DEFAULTS = {
   pipelineApiRetries: 2, // max attempts for pipeline API calls
   pipelineApiRetryDelay: 2000, // ms delay between pipeline API retries
   versionCheckInterval: 3600000, // 1 hour — how often to check npm for updates (ms)
+  logFlushInterval: 5000, // 5s — how often to flush buffered log entries to disk
+  logBufferSize: 50, // flush immediately when buffer exceeds this many entries
 };
 
 // ─── Status & Type Constants ─────────────────────────────────────────────────
@@ -729,5 +767,7 @@ module.exports = {
   killGracefully,
   killImmediate,
   LOCK_STALE_MS,
+  flushLogs,
+  _logBuffer, // exported for testing
 };
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2162,6 +2162,34 @@ async function testStateIntegrity() {
       'log rotation should NOT use tight > 2000 threshold');
   });
 
+  await test('Log buffering batches writes and flushLogs drains buffer', () => {
+    const shared = require(path.join(MINIONS_DIR, 'engine', 'shared.js'));
+    // Verify buffer and flushLogs are exported
+    assert.ok(Array.isArray(shared._logBuffer), '_logBuffer should be an exported array');
+    assert.ok(typeof shared.flushLogs === 'function', 'flushLogs should be exported');
+    // Verify ENGINE_DEFAULTS has buffer config
+    assert.strictEqual(shared.ENGINE_DEFAULTS.logFlushInterval, 5000,
+      'logFlushInterval should default to 5000ms');
+    assert.strictEqual(shared.ENGINE_DEFAULTS.logBufferSize, 50,
+      'logBufferSize should default to 50 entries');
+    // Source-level: log() pushes to buffer, not directly to mutateJsonFileLocked
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(src.includes('_logBuffer.push(entry)'),
+      'log() should push entries to in-memory buffer');
+    assert.ok(src.includes('_flushLogBuffer()'),
+      'log() should call _flushLogBuffer when threshold exceeded');
+    assert.ok(src.includes('logData.push(...entries)'),
+      'flush should batch-append all entries in a single lock acquisition');
+    assert.ok(src.includes("clearInterval(_logFlushTimer)"),
+      'flushLogs should clear the flush timer');
+  });
+
+  await test('Graceful shutdown calls flushLogs before exit', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(src.includes('shared.flushLogs()'),
+      'graceful shutdown should call shared.flushLogs() to drain buffered log entries');
+  });
+
   await test('Dashboard uses lock-backed dispatch mutations for API writes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     assert.ok(src.includes('mutateJsonFileLocked'),


### PR DESCRIPTION
## Summary
- Buffers log entries in a module-level array instead of acquiring a file lock per call (~139 calls/tick → 1 lock per flush)
- Flushes to disk every 5s via setInterval or immediately when buffer exceeds 50 entries (both configurable via ENGINE_DEFAULTS)
- Exports `flushLogs()` from shared.js; called during graceful shutdown in cli.js to drain buffer before exit
- Console.log output remains immediate; log rotation (2500 cap → splice to 2000) preserved in flush

## Test plan
- [x] Existing unit tests pass (812 passed, 1 pre-existing unrelated failure)
- [x] New test: `Log buffering batches writes and flushLogs drains buffer` — verifies exports, ENGINE_DEFAULTS values, and source-level buffer patterns
- [x] New test: `Graceful shutdown calls flushLogs before exit` — verifies cli.js calls shared.flushLogs()

🤖 Generated with [Claude Code](https://claude.com/claude-code)