### PR TITLE
fix: reconcile agent completions during engine downtime

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -838,7 +838,10 @@ function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
   const prLinks = shared.getPrLinks();
   let reconciled = 0;
   for (const wi of items) {
-    if (wi.status !== WI_STATUS.PENDING || wi._pr) continue;
+    // Reconcile pending items AND failed items that have a matching PR
+    // (failed items may have been incorrectly marked during engine downtime)
+    if (wi._pr && wi.status !== WI_STATUS.FAILED) continue;
+    if (wi.status !== WI_STATUS.PENDING && wi.status !== WI_STATUS.FAILED) continue;
     if (onlyIds && !onlyIds.has(wi.id)) continue;
 
     let exactPr = allPrs.find(pr => (pr.prdItems || []).includes(wi.id));
@@ -849,6 +852,10 @@ function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
     if (exactPr) {
       wi.status = WI_STATUS.DONE;
       wi._pr = exactPr.id;
+      // Clear failure artifacts if reconciling a previously failed item
+      if (wi.failReason) delete wi.failReason;
+      if (wi.failedAt) delete wi.failedAt;
+      if (!wi.completedAt) wi.completedAt = new Date().toISOString();
       reconciled++;
     }
   }

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -221,16 +221,42 @@ const commands = {
           const hasError = output.includes('"is_error":true') || output.includes('"is_error": true');
           if (!hasResult && !hasError) continue;
 
-          const isSuccess = hasResult && !hasError;
-          const result = isSuccess ? DISPATCH_RESULT.SUCCESS : DISPATCH_RESULT.ERROR;
+          let isSuccess = hasResult && !hasError;
 
-          e.log('info', `Orphan recovery: ${agentId} (${item.id}) completed while engine was down — result: ${result}`);
-
-          // Extract PRs from output
+          // Extract PRs from output first — if PRs were created, the agent succeeded
+          // regardless of intermediate error lines in the log
           let prsCreated = 0;
           try {
             prsCreated = lifecycle.syncPrsFromOutput(output, agentId, item.meta, config);
           } catch (err) { e.log('warn', `Orphan PR sync: ${err.message}`); }
+
+          // If PRs were created or a matching PR exists, treat as success
+          if (!isSuccess && prsCreated > 0) {
+            e.log('info', `Orphan recovery: ${agentId} (${item.id}) has ${prsCreated} PR(s) — overriding to success`);
+            isSuccess = true;
+          }
+
+          // Fallback: check pull-requests.json for a matching PR by work item ID
+          if (!isSuccess && item.meta?.item?.id) {
+            try {
+              const projName = item.meta.project?.name;
+              if (projName) {
+                const prPath = path.join(MINIONS_DIR, 'projects', projName, 'pull-requests.json');
+                const prs = safeJson(prPath) || [];
+                const matchingPr = prs.find(pr =>
+                  (pr.prdItems || []).includes(item.meta.item.id) &&
+                  pr.status !== 'abandoned' && pr.status !== 'closed'
+                );
+                if (matchingPr) {
+                  e.log('info', `Orphan recovery: ${agentId} (${item.id}) has matching PR ${matchingPr.id} — overriding to success`);
+                  isSuccess = true;
+                }
+              }
+            } catch (err) { e.log('warn', `Orphan PR lookup: ${err.message}`); }
+          }
+
+          const result = isSuccess ? DISPATCH_RESULT.SUCCESS : DISPATCH_RESULT.ERROR;
+          e.log('info', `Orphan recovery: ${agentId} (${item.id}) completed while engine was down — result: ${result}`);
 
           // Update work item status
           if (item.meta?.item?.id) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1195,6 +1195,40 @@ async function testReconciliation() {
       shared.getPrLinks = originalGetPrLinks;
     }
   });
+
+  await test('reconcileItemsWithPrs reconciles failed items with matching PR', () => {
+    const items = [
+      { id: 'P001', status: 'failed', failReason: 'Completed while engine was down', failedAt: '2026-04-07T00:00:00Z' },
+      { id: 'P002', status: 'failed', failReason: 'Some other reason', failedAt: '2026-04-07T00:00:00Z' },
+    ];
+    const prs = [
+      { id: 'PR-100', prdItems: ['P001'], status: 'active' },
+      { id: 'PR-101', prdItems: ['P002'], status: 'active' },
+    ];
+    const count = reconcileItemsWithPrs(items, prs);
+    assert.strictEqual(count, 2);
+    assert.strictEqual(items[0].status, 'done');
+    assert.strictEqual(items[0]._pr, 'PR-100');
+    assert.strictEqual(items[0].failReason, undefined, 'failReason should be cleared');
+    assert.strictEqual(items[0].failedAt, undefined, 'failedAt should be cleared');
+    assert.ok(items[0].completedAt, 'completedAt should be set');
+    assert.strictEqual(items[1].status, 'done');
+    assert.strictEqual(items[1]._pr, 'PR-101');
+  });
+
+  await test('reconcileItemsWithPrs re-reconciles failed items even with existing _pr', () => {
+    const items = [
+      { id: 'P001', status: 'failed', _pr: 'PR-100', failReason: 'Completed while engine was down' },
+    ];
+    const prs = [
+      { id: 'PR-100', prdItems: ['P001'], status: 'active' },
+    ];
+    const count = reconcileItemsWithPrs(items, prs);
+    assert.strictEqual(count, 1);
+    assert.strictEqual(items[0].status, 'done');
+    assert.strictEqual(items[0]._pr, 'PR-100');
+    assert.strictEqual(items[0].failReason, undefined);
+  });
 }
 
 // ─── GitHub Helpers Tests ───────────────────────────────────────────────────


### PR DESCRIPTION
Closes yemi33/minions#376

## Summary
- **Orphan detection (cli.js):** After syncing PRs from output, checks if PRs were created or exist in pull-requests.json before marking as failed. Overrides to success if a matching PR is found.
- **reconcileItemsWithPrs (engine.js):** Now also reconciles `failed` items that have a matching PR, clearing `failReason`/`failedAt` artifacts and setting `completedAt`.
- **Tests:** Added 2 new unit tests covering failed-item reconciliation.

## Root Cause
The orphan detection used `output.includes('"is_error":true')` to scan the entire log, catching any intermediate error line — even when the agent ultimately succeeded and created a PR. Items were marked `failed` with `failReason: "Completed while engine was down"`, cascading failures to all dependents.

## Test plan
- [x] All 819 unit tests pass (817 existing + 2 new)
- [ ] Verify: stop engine, let agent complete with PR, restart engine → work item reconciled to done
- [ ] Verify: dependent items are not cascaded to failed when parent has matching PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)