### PR TITLE
fix: GitHub PR poll backoff for inaccessible repos

### DIFF
--- a/engine/github.js
+++ b/engine/github.js
@@ -30,6 +30,44 @@ function getRepoSlug(project) {
   return `${org}/${repo}`;
 }
 
+// ─── Per-Repo Poll Backoff ──────────────────────────────────────────────────
+// Tracks consecutive poll failures per repo slug to avoid spamming logs when
+// a repo is inaccessible. Backoff doubles each failure: 2min, 4min, 8min, 16min, max 30min.
+const _ghPollBackoff = new Map(); // slug → { failures, backoffUntil }
+const GH_POLL_BACKOFF_BASE_MS = 2 * 60 * 1000; // 2 minutes (one poll cycle)
+const GH_POLL_BACKOFF_MAX_MS = 30 * 60 * 1000;  // 30 minutes cap
+
+/** Check if a repo slug is currently in backoff. Returns true if should skip. */
+function isSlugInBackoff(slug) {
+  const entry = _ghPollBackoff.get(slug);
+  if (!entry) return false;
+  return Date.now() < entry.backoffUntil;
+}
+
+/** Record a poll failure for a repo slug, applying exponential backoff. */
+function recordSlugFailure(slug) {
+  const existing = _ghPollBackoff.get(slug);
+  const failures = (existing?.failures || 0) + 1;
+  const backoffMs = Math.min(GH_POLL_BACKOFF_BASE_MS * Math.pow(2, failures - 1), GH_POLL_BACKOFF_MAX_MS);
+  _ghPollBackoff.set(slug, { failures, backoffUntil: Date.now() + backoffMs });
+  if (failures === 1) {
+    log('warn', `GitHub poll: repo ${slug} failed — will retry in ${Math.round(backoffMs / 1000)}s`);
+  } else {
+    log('warn', `GitHub poll: repo ${slug} failed ${failures} times — backoff ${Math.round(backoffMs / 1000)}s`);
+  }
+}
+
+/** Reset backoff for a repo slug after a successful poll. */
+function resetSlugBackoff(slug) {
+  if (_ghPollBackoff.has(slug)) {
+    const entry = _ghPollBackoff.get(slug);
+    if (entry.failures > 0) {
+      log('info', `GitHub poll: repo ${slug} recovered after ${entry.failures} failure(s)`);
+    }
+    _ghPollBackoff.delete(slug);
+  }
+}
+
 /** Run a `gh api` call and parse JSON result. Returns null on failure. */
 function ghApi(endpoint, slug) {
   try {
@@ -42,6 +80,20 @@ function ghApi(endpoint, slug) {
   }
 }
 
+/**
+ * Run a `gh api` call with per-slug backoff tracking. Returns null on failure.
+ * On success, resets the slug's backoff. On failure, increments it.
+ */
+function ghApiWithBackoff(endpoint, slug) {
+  const result = ghApi(endpoint, slug);
+  if (result === null) {
+    recordSlugFailure(slug);
+  } else {
+    resetSlugBackoff(slug);
+  }
+  return result;
+}
+
 // ─── Shared PR Polling Loop ─────────────────────────────────────────────────
 
 async function forEachActiveGhPr(config, callback) {
@@ -52,9 +104,20 @@ async function forEachActiveGhPr(config, callback) {
     const slug = getRepoSlug(project);
     if (!slug) continue;
 
+    // Skip projects in backoff (inaccessible repo)
+    if (isSlugInBackoff(slug)) continue;
+
     const prs = getPrs(project);
     const activePrs = prs.filter(pr => pr.status === PR_STATUS.ACTIVE);
     if (activePrs.length === 0) continue;
+
+    // Probe repo accessibility before iterating PRs — avoids N warnings per inaccessible repo
+    const probe = ghApi('', slug);
+    if (probe === null) {
+      recordSlugFailure(slug);
+      continue;
+    }
+    resetSlugBackoff(slug);
 
     let projectUpdated = 0;
 
@@ -101,6 +164,7 @@ async function forEachActiveGhPr(config, callback) {
     const ghMatch = pr.url.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
     if (!ghMatch) continue;
     const slug = ghMatch[1];
+    if (isSlugInBackoff(slug)) continue;
     const prNum = ghMatch[2];
     try {
       const updated = await callback(null, pr, prNum, slug);
@@ -370,9 +434,16 @@ async function reconcilePrs(config) {
     const slug = getRepoSlug(project);
     if (!slug) continue;
 
+    // Skip projects in backoff (inaccessible repo)
+    if (isSlugInBackoff(slug)) continue;
+
     // Fetch open PRs
     const prsData = ghApi('/pulls?state=open&per_page=100', slug);
-    if (!prsData || !Array.isArray(prsData)) continue;
+    if (!prsData || !Array.isArray(prsData)) {
+      recordSlugFailure(slug);
+      continue;
+    }
+    resetSlugBackoff(slug);
 
     const ghPrs = prsData.filter(pr => {
       const branch = pr.head?.ref || '';
@@ -498,5 +569,10 @@ module.exports = {
   pollPrHumanComments,
   reconcilePrs,
   checkLiveReviewStatus,
+  // Exported for testing
+  isSlugInBackoff,
+  recordSlugFailure,
+  resetSlugBackoff,
+  _ghPollBackoff,
 };
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7690,6 +7690,80 @@ async function testPrDuplicateRaceFix() {
     assert.ok(reconcileFn[0].includes('P-[a-z0-9]'), 'must match P- IDs');
   });
 
+  // ── GitHub poll backoff tests ──
+  await test('github.js exports backoff helpers for per-repo exponential backoff', () => {
+    const gh = require(path.join(MINIONS_DIR, 'engine', 'github.js'));
+    assert.ok(typeof gh.isSlugInBackoff === 'function', 'isSlugInBackoff must be exported');
+    assert.ok(typeof gh.recordSlugFailure === 'function', 'recordSlugFailure must be exported');
+    assert.ok(typeof gh.resetSlugBackoff === 'function', 'resetSlugBackoff must be exported');
+    assert.ok(gh._ghPollBackoff instanceof Map, '_ghPollBackoff must be a Map');
+  });
+
+  await test('github.js isSlugInBackoff returns false for unknown slugs', () => {
+    const gh = require(path.join(MINIONS_DIR, 'engine', 'github.js'));
+    assert.strictEqual(gh.isSlugInBackoff('nonexistent/repo'), false);
+  });
+
+  await test('github.js recordSlugFailure puts slug into backoff', () => {
+    const gh = require(path.join(MINIONS_DIR, 'engine', 'github.js'));
+    const testSlug = '_test/backoff-record';
+    gh._ghPollBackoff.delete(testSlug);
+    gh.recordSlugFailure(testSlug);
+    assert.strictEqual(gh.isSlugInBackoff(testSlug), true, 'slug should be in backoff after failure');
+    const entry = gh._ghPollBackoff.get(testSlug);
+    assert.strictEqual(entry.failures, 1, 'first failure should set failures=1');
+    assert.ok(entry.backoffUntil > Date.now(), 'backoffUntil should be in the future');
+    gh._ghPollBackoff.delete(testSlug); // cleanup
+  });
+
+  await test('github.js recordSlugFailure applies exponential backoff', () => {
+    const gh = require(path.join(MINIONS_DIR, 'engine', 'github.js'));
+    const testSlug = '_test/backoff-exponential';
+    gh._ghPollBackoff.delete(testSlug);
+    gh.recordSlugFailure(testSlug);
+    const first = gh._ghPollBackoff.get(testSlug);
+    gh.recordSlugFailure(testSlug);
+    const second = gh._ghPollBackoff.get(testSlug);
+    assert.strictEqual(second.failures, 2, 'second failure should set failures=2');
+    // Second backoff should be longer than first (2^1 vs 2^0 multiplier)
+    const firstDuration = first.backoffUntil - Date.now();
+    const secondDuration = second.backoffUntil - Date.now();
+    assert.ok(secondDuration > firstDuration, 'backoff duration should increase with failures');
+    gh._ghPollBackoff.delete(testSlug); // cleanup
+  });
+
+  await test('github.js resetSlugBackoff clears backoff state', () => {
+    const gh = require(path.join(MINIONS_DIR, 'engine', 'github.js'));
+    const testSlug = '_test/backoff-reset';
+    gh.recordSlugFailure(testSlug);
+    assert.strictEqual(gh.isSlugInBackoff(testSlug), true);
+    gh.resetSlugBackoff(testSlug);
+    assert.strictEqual(gh.isSlugInBackoff(testSlug), false, 'slug should not be in backoff after reset');
+    assert.strictEqual(gh._ghPollBackoff.has(testSlug), false, 'entry should be deleted');
+  });
+
+  await test('github.js forEachActiveGhPr skips projects in backoff', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes('isSlugInBackoff(slug)'), 'forEachActiveGhPr must check isSlugInBackoff');
+    assert.ok(src.includes('recordSlugFailure(slug)'), 'must call recordSlugFailure on probe failure');
+    assert.ok(src.includes('resetSlugBackoff(slug)'), 'must call resetSlugBackoff on probe success');
+  });
+
+  await test('github.js reconcilePrs skips projects in backoff', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'github.js'), 'utf8');
+    const reconcileFn = src.match(/async function reconcilePrs[\s\S]*?^}/m);
+    assert.ok(reconcileFn, 'reconcilePrs must exist');
+    assert.ok(reconcileFn[0].includes('isSlugInBackoff'), 'reconcilePrs must check backoff');
+    assert.ok(reconcileFn[0].includes('recordSlugFailure'), 'reconcilePrs must record failures');
+    assert.ok(reconcileFn[0].includes('resetSlugBackoff'), 'reconcilePrs must reset on success');
+  });
+
+  await test('github.js backoff has 30-minute cap', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes('30 * 60 * 1000'), 'backoff must have 30-minute cap');
+    assert.ok(src.includes('GH_POLL_BACKOFF_MAX_MS'), 'must use named constant for max backoff');
+  });
+
   await test('ado.js reconcilePrs branch regex matches all work item ID prefixes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
     const reconcileFn = src.match(/async function reconcilePrs[\s\S]*?^}/m);


### PR DESCRIPTION
Closes yemi33/minions#377

## Summary
- Add per-repo exponential backoff to GitHub PR polling when a repo is inaccessible
- Probe repo accessibility before iterating PRs — avoids N warnings per inaccessible repo per poll cycle
- Backoff doubles each failure: 2min → 4min → 8min → 16min → 30min cap
- Resets automatically when repo becomes accessible again
- Applied to `pollPrStatus`, `pollPrHumanComments`, and `reconcilePrs`
- Central PR polling (from `pull-requests.json`) also skips slugs in backoff

## Test plan
- [x] 8 new unit tests covering backoff helpers and source-pattern verification
- [x] All 825 tests pass (0 failures)
- [ ] Manual: configure a project with inaccessible repo, verify log spam stops after first failure
- [ ] Manual: make repo accessible again, verify polling resumes and logs recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)