### PR TITLE
fix(W-mnobpppnvt97): lock timeout retry with backoff to prevent tick cascade failures

### DIFF
--- a/engine/shared.js
+++ b/engine/shared.js
@@ -174,51 +174,70 @@ const LOCK_STALE_MS = 60000; // 60 seconds — force-remove locks older than thi
 
 function withFileLock(lockPath, fn, {
   timeoutMs = 5000,
-  retryDelayMs = 25
+  retryDelayMs = 25,
+  retries = 0,
+  retryBackoffMs = 1000
 } = {}) {
-  const start = Date.now();
-  let fd = null;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const dir = path.dirname(lockPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fd = fs.openSync(lockPath, 'wx');
-      break;
-    } catch (err) {
-      if (err.code !== 'EEXIST') throw err;
-      // Check for stale lock — if lock file is older than LOCK_STALE_MS, force-remove it
+  let lastErr = null;
+  const maxAttempts = 1 + Math.max(0, retries);
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      // Exponential backoff between retry attempts: retryBackoffMs * 2^(attempt-1)
+      const backoff = retryBackoffMs * Math.pow(2, attempt - 1);
+      sleepMs(backoff);
+    }
+    const start = Date.now();
+    let fd = null;
+    while (Date.now() - start < timeoutMs) {
       try {
-        const stat = fs.statSync(lockPath);
-        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-          try {
-            fs.unlinkSync(lockPath);
-          } catch (unlinkErr) {
-            // ENOENT: another process deleted the lock between stat and unlink — safe to retry
-            if (unlinkErr.code !== 'ENOENT') throw unlinkErr;
+        const dir = path.dirname(lockPath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        fd = fs.openSync(lockPath, 'wx');
+        break;
+      } catch (err) {
+        if (err.code !== 'EEXIST') throw err;
+        // Check for stale lock — if lock file is older than LOCK_STALE_MS, force-remove it
+        try {
+          const stat = fs.statSync(lockPath);
+          if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+            try {
+              fs.unlinkSync(lockPath);
+            } catch (unlinkErr) {
+              // ENOENT: another process deleted the lock between stat and unlink — safe to retry
+              if (unlinkErr.code !== 'ENOENT') throw unlinkErr;
+            }
+            continue; // lock just removed — retry immediately
           }
-          continue; // lock just removed — retry immediately
+        } catch (staleErr) {
+          // ENOENT from statSync: lock file disappeared between EEXIST and stat — retry will succeed
+          if (staleErr.code !== 'ENOENT') throw staleErr;
         }
-      } catch (staleErr) {
-        // ENOENT from statSync: lock file disappeared between EEXIST and stat — retry will succeed
-        if (staleErr.code !== 'ENOENT') throw staleErr;
+        sleepMs(retryDelayMs);
       }
-      sleepMs(retryDelayMs);
+    }
+    if (fd === null) {
+      lastErr = new Error(`Lock timeout: ${lockPath}`);
+      continue; // retry if attempts remain
+    }
+
+    try {
+      return fn();
+    } finally {
+      try { fs.closeSync(fd); } catch { /* cleanup */ }
+      try { fs.unlinkSync(lockPath); } catch { /* cleanup */ }
     }
   }
-  if (fd === null) throw new Error(`Lock timeout: ${lockPath}`);
-
-  try {
-    return fn();
-  } finally {
-    try { fs.closeSync(fd); } catch { /* cleanup */ }
-    try { fs.unlinkSync(lockPath); } catch { /* cleanup */ }
-  }
+  throw lastErr;
 }
 
 function mutateJsonFileLocked(filePath, mutateFn, {
-  defaultValue = {}
+  defaultValue = {},
+  lockRetries,
+  lockRetryBackoffMs
 } = {}) {
   const lockPath = `${filePath}.lock`;
+  const retries = lockRetries ?? ENGINE_DEFAULTS.lockRetries;
+  const retryBackoffMs = lockRetryBackoffMs ?? ENGINE_DEFAULTS.lockRetryBackoffMs;
   return withFileLock(lockPath, () => {
     let data = safeJson(filePath);
     if (data === null || typeof data !== 'object') data = Array.isArray(defaultValue) ? [...defaultValue] : { ...defaultValue };
@@ -229,7 +248,7 @@ function mutateJsonFileLocked(filePath, mutateFn, {
     const finalData = next === undefined ? data : next;
     safeWrite(filePath, finalData);
     return finalData;
-  });
+  }, { retries, retryBackoffMs });
 }
 
 /**
@@ -479,6 +498,8 @@ const ENGINE_DEFAULTS = {
   versionCheckInterval: 3600000, // 1 hour — how often to check npm for updates (ms)
   logFlushInterval: 5000, // 5s — how often to flush buffered log entries to disk
   logBufferSize: 50, // flush immediately when buffer exceeds this many entries
+  lockRetries: 2, // retry lock acquisition this many times after initial timeout (total attempts = 1 + lockRetries)
+  lockRetryBackoffMs: 500, // base backoff between lock retries (doubles each attempt: 500ms, 1s, 2s, ...)
 };
 
 // ─── Status & Type Constants ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add retry-with-exponential-backoff to `withFileLock` — after the initial 5s spin-wait window expires, back off and retry the full acquisition (configurable via `ENGINE_DEFAULTS.lockRetries` and `ENGINE_DEFAULTS.lockRetryBackoffMs`)
- `mutateJsonFileLocked` automatically inherits retry settings, so all callers (`mutateDispatch`, PR writes, metrics writes, etc.) benefit without code changes
- Default: 2 retries with 500ms base backoff (doubling), giving ~16.5s total acquisition window before throwing

## Root Cause
When the dashboard and engine contend on `dispatch.json.lock` simultaneously, the 5-second spin-wait window could expire. The resulting `Lock timeout` error propagated up through `mutateDispatch` → tick phase → `tickInner`, aborting the entire tick. Items left in partial state (e.g., `dispatched` without an active agent) cascaded as dependency failures.

## Test plan
- [x] All 817 unit tests pass
- [ ] Verify lock contention under load (dashboard + engine writing dispatch.json concurrently)
- [ ] Confirm retry logging visible in engine log when contention occurs

Closes yemi33/minions#375

🤖 Generated with [Claude Code](https://claude.com/claude-code)