### PR TITLE
feat(P-r2b5x8d4): Replace direct safeJson reads of work-items.json with getWorkItems()

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -149,16 +149,8 @@ function resolveDependencyBranches(depIds, sourcePlan, project, config) {
   const projects = shared.getProjects(config);
 
   // Find work items for each dependency plan item
-  const depWorkItems = [];
-  for (const p of projects) {
-    const wiPath = shared.projectWorkItemsPath(p);
-    const items = safeJson(wiPath) || [];
-    for (const wi of items) {
-      if (depIds.includes(wi.id)) {
-        depWorkItems.push(wi);
-      }
-    }
-  }
+  const allItems = queries.getWorkItems(config);
+  const depWorkItems = allItems.filter(wi => depIds.includes(wi.id));
 
   // Find PR branches for each dependency work item
   for (const p of projects) {
@@ -811,13 +803,7 @@ function areDependenciesMet(item, config) {
   const projects = getProjects(config);
 
   // Collect work items from ALL projects (dependencies can be cross-project)
-  let allWorkItems = [];
-  for (const p of projects) {
-    try {
-      const wi = safeJson(projectWorkItemsPath(p)) || [];
-      allWorkItems = allWorkItems.concat(wi);
-    } catch (e) { log('warn', 'read project work items for deps: ' + e.message); }
-  }
+  const allWorkItems = queries.getWorkItems(config);
   // PRD item statuses that count as "done" for dep resolution
   const PRD_MET_STATUSES = DONE_STATUSES;
 
@@ -1159,13 +1145,7 @@ function materializePlansAsWorkItems(config) {
     const statusFilter = ['missing', 'planned'];
     // Also materialize in-pr/done items that never got a work item (race with PR status sync)
     const allExistingWiIds = new Set();
-    for (const p of allProjects) {
-      for (const w of (safeJson(projectWorkItemsPath(p)) || [])) {
-        if (w.id) allExistingWiIds.add(w.id);
-      }
-    }
-    // Also check central work-items.json
-    for (const w of (safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [])) {
+    for (const w of queries.getWorkItems()) {
       if (w.id) allExistingWiIds.add(w.id);
     }
     const items = plan.missing_features.filter(f =>
@@ -2258,10 +2238,9 @@ function discoverWork(config) {
   }
 
   // Gate reviews and fixes: do not dispatch until all implement items are complete
-  const hasIncompleteImplements = projects.some(project => {
-    const items = safeJson(projectWorkItemsPath(project)) || [];
-    return items.some(i => ['queued', 'pending', 'dispatched'].includes(i.status) && (i.type || '').startsWith('implement'));
-  });
+  const hasIncompleteImplements = queries.getWorkItems(config).some(i =>
+    ['queued', 'pending', 'dispatched'].includes(i.status) && (i.type || '').startsWith('implement')
+  );
   if (hasIncompleteImplements) {
     if (allReviews.length > 0) {
       log('info', `Gating ${allReviews.length} reviews — implement items still in progress`);

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -308,15 +308,9 @@ function runCleanup(config, verbose = false) {
     // Collect all work item IDs across all sources
     const allWiIds = new Set();
     try {
-      const central = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
-      central.forEach(w => allWiIds.add(w.id));
-    } catch (e) { log('warn', 'read central work items for orphan check: ' + e.message); }
-    for (const project of projects) {
-      try {
-        const projItems = safeJson(projectWorkItemsPath(project)) || [];
-        projItems.forEach(w => allWiIds.add(w.id));
-      } catch (e) { log('warn', 'read project work items for orphan check: ' + e.message); }
-    }
+      const allItems = queries.getWorkItems();
+      allItems.forEach(w => allWiIds.add(w.id));
+    } catch (e) { log('warn', 'read work items for orphan check: ' + e.message); }
 
     let changed = false;
     for (const queue of ['pending', 'active']) {

--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -123,14 +123,8 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
     if (processWorkItemFailure && result === DISPATCH_RESULT.ERROR && item.meta?.item?.id) {
       let retries = (item.meta.item._retryCount || 0);
       try {
-        const wiPath = lifecycle().resolveWorkItemPath(item.meta);
-        if (wiPath) {
-          const items = safeJson(wiPath);
-          if (items && Array.isArray(items)) {
-            const wi = items.find(i => i.id === item.meta.item.id);
-            if (wi) retries = wi._retryCount || 0;
-          }
-        }
+        const wi = queries.getWorkItems().find(i => i.id === item.meta.item.id);
+        if (wi) retries = wi._retryCount || 0;
       } catch (e) { log('warn', 'read retry count: ' + e.message); }
       const maxRetries = ENGINE_DEFAULTS.maxRetries;
       if (retryableFailure && retries < maxRetries) {
@@ -175,13 +169,8 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
           const config = getConfig();
           const failedId = item.meta.item.id;
           const blockedItems = [];
-          for (const p of getProjects(config)) {
-            const items = safeJson(projectWorkItemsPath(p)) || [];
-            items.filter(w => w.status === WI_STATUS.PENDING && (w.depends_on || []).includes(failedId))
-              .forEach(w => blockedItems.push(`- \`${w.id}\` — ${w.title}`));
-          }
-          const centralItems = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
-          centralItems.filter(w => w.status === WI_STATUS.PENDING && (w.depends_on || []).includes(failedId))
+          const allItems = queries.getWorkItems(config);
+          allItems.filter(w => w.status === WI_STATUS.PENDING && (w.depends_on || []).includes(failedId))
             .forEach(w => blockedItems.push(`- \`${w.id}\` — ${w.title}`));
 
           writeInboxAlert(`failed-${failedId}`,

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -30,20 +30,7 @@ function checkPlanCompletion(meta, config) {
   const projects = shared.getProjects(config);
 
   // Collect work items from ALL projects + central (PRD items can be in either)
-  let allWorkItems = [];
-  for (const p of projects) {
-    try {
-      const wi = safeJson(shared.projectWorkItemsPath(p)) || [];
-      allWorkItems = allWorkItems.concat(wi);
-    } catch { /* optional */ }
-  }
-  // Also check central work-items.json (for no-project setups)
-  try {
-    const central = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
-    for (const w of central) {
-      if (!allWorkItems.some(existing => existing.id === w.id)) allWorkItems.push(w);
-    }
-  } catch { /* optional */ }
+  const allWorkItems = queries.getWorkItems(config);
   const planItems = allWorkItems.filter(w => w.sourcePlan === planFile && w.itemType !== 'pr' && w.itemType !== 'verify');
   if (planItems.length === 0) return;
 
@@ -329,19 +316,7 @@ function archivePlan(planFile, plan, projects, config) {
     if (plan.feature_branch) branchSlugs.add(shared.sanitizeBranch(plan.feature_branch).toLowerCase());
 
     // Collect work items for this plan
-    let allWorkItems = [];
-    for (const p of projects) {
-      try {
-        const wi = safeJson(shared.projectWorkItemsPath(p)) || [];
-        allWorkItems = allWorkItems.concat(wi);
-      } catch { /* optional */ }
-    }
-    try {
-      const central = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
-      for (const w of central) {
-        if (!allWorkItems.some(existing => existing.id === w.id)) allWorkItems.push(w);
-      }
-    } catch { /* optional */ }
+    const allWorkItems = queries.getWorkItems(config);
     const planItems = allWorkItems.filter(w => w.sourcePlan === planFile);
     const doneItems = planItems.filter(w => DONE_STATUSES.has(w.status));
 

--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -133,7 +133,7 @@ function resolveTaskContext(item, config) {
       try {
         const plans = fs.readdirSync(path.join(MINIONS_DIR, 'plans')).filter(f => f.endsWith('.md') || f.endsWith('.json'));
         // Check work-items to find which plan file this agent created
-        const workItems = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
+        const workItems = queries.getWorkItems();
         const agentPlanItems = workItems.filter(w =>
           w.type === WORK_TYPE.PLAN && w.dispatched_to === agent.id && w.status === WI_STATUS.DONE && w._planFileName
         ).sort((a, b) => (b.completedAt || '').localeCompare(a.completedAt || ''));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3066,8 +3066,8 @@ async function testAreDependenciesMet() {
   });
 
   await test('areDependenciesMet collects work items from ALL projects', () => {
-    assert.ok(src.includes('allWorkItems = allWorkItems.concat(wi)'),
-      'Should collect work items across all projects for cross-project deps');
+    assert.ok(src.includes('queries.getWorkItems(config)'),
+      'Should collect work items across all projects for cross-project deps via getWorkItems()');
   });
 }
 


### PR DESCRIPTION
## Summary
- Replaces all read-only `safeJson()` calls targeting `work-items.json` with `getWorkItems()` from `queries.js`
- Converts 8 sites across `engine.js`, `engine/cleanup.js`, `engine/dispatch.js`, `engine/lifecycle.js`, and `engine/playbook.js`
- Eliminates 63 lines of manual per-project iteration by using the standard accessor that handles cross-project aggregation
- Updates source-pattern test assertion to match the new implementation

## Test plan
- [x] `npm test` passes — 835 passed, 0 failed
- [ ] Verify dependency resolution works in integration (cross-project deps)
- [ ] Verify review/fix gating still operates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)