### PR TITLE
fix: reconcile failed work items with attached PRs

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -878,6 +878,16 @@ function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
     if (wi.status !== WI_STATUS.PENDING && wi.status !== WI_STATUS.FAILED) continue;
     if (onlyIds && !onlyIds.has(wi.id)) continue;
 
+    // Short-circuit: failed item already has a PR attached — mark done directly (#407)
+    if (wi.status === WI_STATUS.FAILED && wi._pr) {
+      wi.status = WI_STATUS.DONE;
+      if (wi.failReason) delete wi.failReason;
+      if (wi.failedAt) delete wi.failedAt;
+      if (!wi.completedAt) wi.completedAt = ts();
+      reconciled++;
+      continue;
+    }
+
     let exactPr = allPrs.find(pr => (pr.prdItems || []).includes(wi.id));
     if (!exactPr) {
       const linkedPrId = Object.keys(prLinks).find(prId => prLinks[prId] === wi.id);
@@ -893,7 +903,7 @@ function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
       // Clear failure artifacts if reconciling a previously failed item
       if (wi.failReason) delete wi.failReason;
       if (wi.failedAt) delete wi.failedAt;
-      if (!wi.completedAt) wi.completedAt = new Date().toISOString();
+      if (!wi.completedAt) wi.completedAt = ts();
       reconciled++;
     }
   }

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -431,7 +431,30 @@ function runCleanup(config, verbose = false) {
     }
   } catch (e) { log('warn', 'KB watchdog check: ' + e.message); }
 
-  // 6. Migrate legacy work-item statuses to canonical 'done'
+  // 6a. Reconcile failed work items that have an attached PR (#407)
+  // If a work item is 'failed' but already has _pr, it should be 'done'.
+  for (const project of projects) {
+    try {
+      const wiPath = projectWorkItemsPath(project);
+      const items = safeJson(wiPath) || [];
+      let reconciled = 0;
+      for (const item of items) {
+        if (item.status === shared.WI_STATUS.FAILED && item._pr) {
+          item.status = shared.WI_STATUS.DONE;
+          if (item.failReason) delete item.failReason;
+          if (item.failedAt) delete item.failedAt;
+          if (!item.completedAt) item.completedAt = shared.ts();
+          reconciled++;
+        }
+      }
+      if (reconciled > 0) {
+        safeWrite(wiPath, items);
+        log('info', `Reconciled ${reconciled} failed-with-PR item(s) → done in ${project.name}`);
+      }
+    } catch (e) { log('warn', 'reconcile failed-with-PR: ' + e.message); }
+  }
+
+  // 6b. Migrate legacy work-item statuses to canonical 'done'
   // in-pr, implemented, complete → done (one-time correction per item)
   const LEGACY_DONE_ALIASES = new Set(['in-pr', 'implemented', 'complete']);
   for (const project of projects) {

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1371,7 +1371,8 @@ function syncPrdFromPrs(config) {
     for (const project of allProjects) {
       const wiPath = shared.projectWorkItemsPath(project);
       const items = safeJson(wiPath) || [];
-      const hasReconcilable = items.some(wi => (wi.status === WI_STATUS.PENDING || wi.status === WI_STATUS.FAILED) && !wi._pr);
+      const hasReconcilable = items.some(wi =>
+        (wi.status === WI_STATUS.PENDING && !wi._pr) || wi.status === WI_STATUS.FAILED);
       if (!hasReconcilable) continue;
       let reconciled = 0;
       const reconciledItems = mutateJsonFileLocked(wiPath, data => {
@@ -1388,7 +1389,7 @@ function syncPrdFromPrs(config) {
       }
     }
     if (totalReconciled > 0) {
-      log('info', `PR sync: reconciled ${totalReconciled} pending work item(s) to done`);
+      log('info', `PR sync: reconciled ${totalReconciled} work item(s) to done`);
     }
   } catch (err) {
     // Non-fatal — log and continue

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2502,6 +2502,25 @@ async function testLegacyStatusMigration() {
     assert.ok(src.includes("item.status = shared.WI_STATUS.DONE") || src.includes("item.status = 'done'"), 'Should migrate work items to done');
     assert.ok(src.includes("feat.status = shared.WI_STATUS.DONE") || src.includes("feat.status = 'done'"), 'Should migrate PRD items to done');
   });
+
+  await test('cleanup.js reconciles failed items with attached PR to done (#407)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+    assert.ok(src.includes('WI_STATUS.FAILED && item._pr'),
+      'cleanup should check for failed items with _pr');
+    assert.ok(src.includes('Reconciled') && src.includes('failed-with-PR'),
+      'cleanup should log reconciliation of failed-with-PR items');
+  });
+
+  await test('syncPrdFromPrs filter includes failed items with _pr (#407)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fnBody = src.slice(
+      src.indexOf('function syncPrdFromPrs('),
+      src.indexOf('\nfunction', src.indexOf('function syncPrdFromPrs(') + 1)
+    );
+    // The hasReconcilable filter must include failed items regardless of _pr
+    assert.ok(fnBody.includes('wi.status === WI_STATUS.FAILED)'),
+      'syncPrdFromPrs filter must include all failed items (not just those without _pr)');
+  });
 }
 
 // ─── engine/preflight.js Tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #407

- **Bug:** Work items with status `failed` but an attached PR (`_pr` field) showed conflicting UX — failed status alongside a valid PR link
- **Root cause:** `syncPrdFromPrs` filter excluded failed items with `_pr` set (`!wi._pr`), so they were never reconciled to done
- **Fix:** Three complementary reconciliation paths ensure failed+PR items are always marked done:
  1. `reconcileItemsWithPrs` short-circuits failed items with `_pr` directly to done (no PR search needed)
  2. `syncPrdFromPrs` filter now includes all failed items regardless of `_pr`
  3. `cleanup.js` adds a safety-net pass every 10 ticks to catch any remaining inconsistencies

## Test plan

- [x] Existing `reconcileItemsWithPrs re-reconciles failed items even with existing _pr` test passes
- [x] New source-pattern test verifies cleanup.js handles failed-with-PR case
- [x] New source-pattern test verifies syncPrdFromPrs filter includes failed items with _pr
- [x] All 837 tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)