### PR TITLE
fix: display assigned agent on dispatched work items

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -794,6 +794,32 @@ function spawnAgent(dispatchItem, config) {
     return dispatch;
   });
 
+  // Atomically stamp dispatched_to/dispatched_at on the originating work item (#402)
+  // The discover phase sets these via safeWrite which can race with concurrent writes;
+  // this locked write ensures the fields are persisted reliably.
+  if (meta?.item?.id) {
+    try {
+      let wiPath = null;
+      if (meta.source === 'central-work-item' || meta.source === 'central-work-item-fanout') {
+        wiPath = path.join(MINIONS_DIR, 'work-items.json');
+      } else if (meta.source === 'work-item' && meta.project?.name) {
+        wiPath = projectWorkItemsPath({ name: meta.project.name, localPath: meta.project.localPath });
+      }
+      if (wiPath) {
+        mutateJsonFileLocked(wiPath, (items) => {
+          if (!Array.isArray(items)) return items;
+          const wi = items.find(i => i.id === meta.item.id);
+          if (wi) {
+            wi.dispatched_to = wi.dispatched_to || agentId;
+            wi.dispatched_at = wi.dispatched_at || startedAt;
+            if (wi.status !== WI_STATUS.DISPATCHED) wi.status = WI_STATUS.DISPATCHED;
+          }
+          return items;
+        }, { defaultValue: [] });
+      }
+    } catch (e) { log('warn', `stamp dispatched_to on work item ${meta.item.id}: ${e.message}`); }
+  }
+
   return proc;
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2186,6 +2186,20 @@ async function testStateIntegrity() {
       'dispatch loop must re-queue work item with retry metadata on spawn failure');
   });
 
+  await test('spawnAgent atomically stamps dispatched_to on work item (#402)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    // Find the section near "Move pending -> active" where the stamp should be
+    const anchorIdx = src.indexOf('Move pending -> active');
+    assert.ok(anchorIdx > 0, 'expected Move pending -> active comment in engine.js');
+    const section = src.slice(anchorIdx, anchorIdx + 2000);
+    assert.ok(section.includes('mutateJsonFileLocked(wiPath'),
+      'spawnAgent must use mutateJsonFileLocked to atomically write dispatched_to after pending→active');
+    assert.ok(section.includes('wi.dispatched_to = wi.dispatched_to || agentId'),
+      'spawnAgent must stamp dispatched_to with agent ID');
+    assert.ok(section.includes('wi.dispatched_at = wi.dispatched_at || startedAt'),
+      'spawnAgent must stamp dispatched_at with start time');
+  });
+
   await test('Log rotation uses batch threshold (>= 2500 → 2000)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
     assert.ok(src.includes('logData.length >= 2500'),


### PR DESCRIPTION
## Summary

- Atomically stamp `dispatched_to` and `dispatched_at` on originating work items when `spawnAgent()` moves a dispatch entry from pending to active
- Uses `mutateJsonFileLocked` for atomic read-modify-write, fixing the race condition where the discover phase's `safeWrite` could be overwritten by concurrent writes
- Adds source-pattern unit test verifying the atomic stamp is present

Closes yemi33/minions#402

## Test plan

- [x] All 836 unit tests pass (0 failures)
- [ ] Verify dispatched work items show agent name in dashboard work items view
- [ ] Verify retry/re-queue correctly clears dispatched_to fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)