### PR TITLE
fix: guard prd/ directory existence in CI test

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8697,7 +8697,9 @@ async function testIsolationVerification() {
   });
 
   await test('no _test-* files in real prd/ after test run', () => {
-    const testFiles = fs.readdirSync(path.join(shared.MINIONS_DIR, 'prd')).filter(f => f.startsWith('_test-'));
+    const dir = path.join(shared.MINIONS_DIR, 'prd');
+    if (!fs.existsSync(dir)) return;
+    const testFiles = fs.readdirSync(dir).filter(f => f.startsWith('_test-'));
     assert.strictEqual(testFiles.length, 0, 'Found: ' + testFiles.join(', '));
   });
 


### PR DESCRIPTION
## Summary
- The test `no _test-* files in real prd/ after test run` calls `readdirSync` without checking if `prd/` exists first
- In CI (fresh clone), `prd/` is a runtime directory that doesn't exist, causing `ENOENT` and failing the build
- Added `existsSync` guard matching the pattern already used by the adjacent `prd/archive/` test

Fixes the build failure on PR-415 and all other PRs hitting this test.

## Test plan
- [x] `npm test` passes locally (830 passed, 0 failed)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)