### PR TITLE
fix(W-mnoyzczcr4ny): convert blocking spawnSync/execSync to async execAsync

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -24,7 +24,7 @@
 const fs = require('fs');
 const path = require('path');
 const shared = require('./engine/shared');
-const { exec, execSilent, runFile, ts, ENGINE_DEFAULTS: DEFAULTS,
+const { exec, execAsync, execSilent, runFile, ts, ENGINE_DEFAULTS: DEFAULTS,
   WI_STATUS, DONE_STATUSES, WORK_TYPE, PLAN_STATUS, PR_STATUS, DISPATCH_RESULT } = shared;
 const queries = require('./engine/queries');
 
@@ -141,6 +141,10 @@ const activeProcesses = new Map(); // dispatchId → { proc, agentId, startedAt 
 // tempAgents imported from engine/routing.js
 let engineRestartGraceUntil = 0; // timestamp — suppress orphan detection until this time
 
+// Per-tick cache of refs that failed to fetch — avoids repeating 30s ETIMEDOUT for same missing ref
+// Cleared at the start of each tick cycle (see tickInner)
+const _failedRefCache = new Set();
+
 // Resolve dependency plan item IDs to their PR branches
 function resolveDependencyBranches(depIds, sourcePlan, project, config) {
   const results = []; // [{ branch, prId }]
@@ -171,9 +175,9 @@ function resolveDependencyBranches(depIds, sourcePlan, project, config) {
 }
 
 // Find an existing worktree already checked out on a given branch
-function findExistingWorktree(repoDir, branchName) {
+async function findExistingWorktree(repoDir, branchName) {
   try {
-    const out = exec(`git worktree list --porcelain`, { cwd: repoDir, stdio: 'pipe', timeout: 10000 }).toString();
+    const out = await execAsync(`git worktree list --porcelain`, { cwd: repoDir, timeout: 10000 });
     const branchRef = `branch refs/heads/${branchName}`;
     const lines = out.split('\n');
     for (let i = 0; i < lines.length; i++) {
@@ -215,17 +219,17 @@ function removeStaleIndexLock(rootDir) {
   } catch (e) { log('warn', 'git: ' + e.message); }
 }
 
-function runWorktreeAdd(rootDir, worktreePath, args, gitOpts, worktreeCreateRetries) {
+async function runWorktreeAdd(rootDir, worktreePath, args, gitOpts, worktreeCreateRetries) {
   let lastErr = null;
   const retries = Math.max(0, Number(worktreeCreateRetries) || 0);
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       if (attempt > 0) {
-        try { exec('git worktree prune', { ...gitOpts, cwd: rootDir, timeout: 15000 }); } catch (e) { log('warn', 'git: ' + e.message); }
+        try { await execAsync('git worktree prune', { ...gitOpts, cwd: rootDir, timeout: 15000 }); } catch (e) { log('warn', 'git: ' + e.message); }
         removeStaleIndexLock(rootDir);
         log('warn', `Retrying git worktree add (attempt ${attempt + 1}/${retries + 1}) for ${path.basename(worktreePath)}`);
       }
-      exec(`git worktree add "${worktreePath}" ${args}`, { ...gitOpts, cwd: rootDir });
+      await execAsync(`git worktree add "${worktreePath}" ${args}`, { ...gitOpts, cwd: rootDir });
       return;
     } catch (err) {
       lastErr = err;
@@ -235,14 +239,14 @@ function runWorktreeAdd(rootDir, worktreePath, args, gitOpts, worktreeCreateRetr
   if (lastErr) throw lastErr;
 }
 
-function recoverPartialWorktree(rootDir, worktreePath, branchName, gitOpts) {
+async function recoverPartialWorktree(rootDir, worktreePath, branchName, gitOpts) {
   if (!branchName) return false;
-  const existingWt = findExistingWorktree(rootDir, branchName);
+  const existingWt = await findExistingWorktree(rootDir, branchName);
   if (existingWt && fs.existsSync(existingWt)) return true;
   if (!fs.existsSync(worktreePath)) return false;
   try {
-    exec(`git -C "${worktreePath}" rev-parse --is-inside-work-tree`, { ...gitOpts, timeout: 10000 });
-    exec(`git -C "${worktreePath}" rev-parse --abbrev-ref HEAD`, { ...gitOpts, timeout: 10000 });
+    await execAsync(`git -C "${worktreePath}" rev-parse --is-inside-work-tree`, { ...gitOpts, timeout: 10000 });
+    await execAsync(`git -C "${worktreePath}" rev-parse --abbrev-ref HEAD`, { ...gitOpts, timeout: 10000 });
     log('warn', `Recovered partially-created worktree for ${branchName} at ${worktreePath}`);
     return true;
   } catch {
@@ -250,7 +254,7 @@ function recoverPartialWorktree(rootDir, worktreePath, branchName, gitOpts) {
   }
 }
 
-function spawnAgent(dispatchItem, config) {
+async function spawnAgent(dispatchItem, config) {
   const { id, agent: agentId, prompt: taskPrompt, type, meta } = dispatchItem;
   const claudeConfig = config.claude || {};
   const engineConfig = config.engine || {};
@@ -279,12 +283,12 @@ function spawnAgent(dispatchItem, config) {
     worktreePath = path.resolve(rootDir, engineConfig.worktreeRoot || '../worktrees', wtDirName);
 
     // If branch is already checked out in an existing worktree, reuse it
-    const existingWt = findExistingWorktree(rootDir, branchName);
+    const existingWt = await findExistingWorktree(rootDir, branchName);
     if (existingWt) {
       worktreePath = existingWt;
       log('info', `Reusing existing worktree for ${branchName}: ${existingWt}`);
-      try { exec(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
-      try { exec(`git pull origin "${branchName}"`, { ..._gitOpts, cwd: existingWt }); } catch (e) { log('warn', 'git: ' + e.message); }
+      try { await execAsync(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
+      try { await execAsync(`git pull origin "${branchName}"`, { ..._gitOpts, cwd: existingWt }); } catch (e) { log('warn', 'git: ' + e.message); }
     } else if (['meeting', 'ask', 'explore', 'plan-to-prd', 'plan'].includes(type)) {
       // Read-only tasks — no worktree needed, run in rootDir
       log('info', `${type}: read-only task, no worktree needed — running in rootDir`);
@@ -295,18 +299,18 @@ function spawnAgent(dispatchItem, config) {
         if (!fs.existsSync(worktreePath)) {
           const isSharedBranch = meta?.branchStrategy === 'shared-branch' || meta?.useExistingBranch;
           // Prune stale worktree entries before creating (handles leftover entries from crashed runs)
-          try { exec(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
+          try { await execAsync(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
           // Remove stale index.lock before creating worktree (Windows crashes can leave this behind)
           removeStaleIndexLock(rootDir);
 
           if (isSharedBranch) {
             log('info', `Creating worktree for shared branch: ${worktreePath} on ${branchName}`);
-            try { exec(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
+            try { await execAsync(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
             try {
-              runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
+              await runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
             } catch (eShared) {
               if (eShared.message?.includes('already used by worktree') || eShared.message?.includes('already checked out')) {
-                const existingWtPath = findExistingWorktree(rootDir, branchName);
+                const existingWtPath = await findExistingWorktree(rootDir, branchName);
                 if (existingWtPath && fs.existsSync(existingWtPath)) {
                   log('info', `Shared branch ${branchName} already checked out at ${existingWtPath} — reusing`);
                   worktreePath = existingWtPath;
@@ -315,42 +319,42 @@ function spawnAgent(dispatchItem, config) {
                 // Branch doesn't exist yet (first item in plan) — create it from main
                 const mainRef = sanitizeBranch(shared.resolveMainBranch(rootDir, project.mainBranch));
                 log('info', `Shared branch ${branchName} not found — creating from ${mainRef}`);
-                runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, worktreeCreateRetries);
+                await runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, worktreeCreateRetries);
               } else { throw eShared; }
             }
           } else {
             log('info', `Creating worktree: ${worktreePath} on branch ${branchName}`);
             const mainRef = sanitizeBranch(shared.resolveMainBranch(rootDir, project.mainBranch));
             try {
-              runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, worktreeCreateRetries);
+              await runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, worktreeCreateRetries);
             } catch (e1) {
               const branchExists = e1.message?.includes('already exists');
               log('warn', `Worktree -b failed for ${branchName}: ${e1.message?.split('\n')[0]}`);
               if (!branchExists) {
                 // Transient error (lock, timeout) — prune, clean, and retry -b once more
                 log('info', `Retrying -b create after prune for ${branchName}`);
-                try { exec(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 15000 }); } catch { /* optional */ }
+                try { await execAsync(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 15000 }); } catch { /* optional */ }
                 removeStaleIndexLock(rootDir);
                 // Clean up partial worktree directory from failed attempt
                 try { if (fs.existsSync(worktreePath)) fs.rmSync(worktreePath, { recursive: true, force: true }); } catch { /* optional */ }
                 try {
-                  runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, 0);
+                  await runWorktreeAdd(rootDir, worktreePath, `-b "${branchName}" ${mainRef}`, _worktreeGitOpts, 0);
                 } catch (e1b) {
                   log('error', `Worktree -b retry also failed for ${branchName}: ${e1b.message?.split('\n')[0]}`);
                   throw e1b;
                 }
               } else {
                 // Branch already exists — try checkout without -b
-                try { exec(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
+                try { await execAsync(`git fetch origin "${branchName}"`, { ..._gitOpts, cwd: rootDir }); } catch (e) { log('warn', 'git: ' + e.message); }
                 try {
-                  runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
+                  await runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
                   log('info', `Reusing existing branch: ${branchName}`);
                 } catch (e2) {
                   // "already checked out" or "already used by worktree" — find and reuse or recover
                   const alreadyUsed = e2.message?.includes('already checked out') || e2.message?.includes('already used by worktree')
                     || e1.message?.includes('already checked out') || e1.message?.includes('already used by worktree');
                   if (alreadyUsed) {
-                    const existingWtPath = findExistingWorktree(rootDir, branchName);
+                    const existingWtPath = await findExistingWorktree(rootDir, branchName);
                     if (existingWtPath && fs.existsSync(existingWtPath)) {
                       // Bug fix: read dispatch under file lock so check-and-act is atomic
                       let activelyUsed = false;
@@ -369,12 +373,12 @@ function spawnAgent(dispatchItem, config) {
                       worktreePath = existingWtPath;
                     } else if (existingWtPath && !fs.existsSync(existingWtPath)) {
                       log('warn', `Branch ${branchName} tracked in missing dir ${existingWtPath} — pruning and recreating`);
-                      try { exec(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
-                      runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
+                      try { await execAsync(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
+                      await runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
                       log('info', `Recovered worktree for ${branchName} after stale entry prune`);
                     } else {
-                      try { exec(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
-                      runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
+                      try { await execAsync(`git worktree prune`, { ..._gitOpts, cwd: rootDir, timeout: 10000 }); } catch (e) { log('warn', 'git: ' + e.message); }
+                      await runWorktreeAdd(rootDir, worktreePath, `"${branchName}"`, _worktreeGitOpts, worktreeCreateRetries);
                     }
                   } else {
                     throw e2;
@@ -385,10 +389,10 @@ function spawnAgent(dispatchItem, config) {
           }
         } else if (meta?.branchStrategy === 'shared-branch') {
           log('info', `Pulling latest on shared branch ${branchName}`);
-          try { exec(`git pull origin "${branchName}"`, { ..._gitOpts, cwd: worktreePath }); } catch (e) { log('warn', 'git: ' + e.message); }
+          try { await execAsync(`git pull origin "${branchName}"`, { ..._gitOpts, cwd: worktreePath }); } catch (e) { log('warn', 'git: ' + e.message); }
         }
       } catch (err) {
-        if (recoverPartialWorktree(rootDir, worktreePath, branchName, _gitOpts)) {
+        if (await recoverPartialWorktree(rootDir, worktreePath, branchName, _gitOpts)) {
           cwd = worktreePath;
           log('warn', `Proceeding with recovered worktree after add failure for ${branchName}`);
         } else {
@@ -407,11 +411,17 @@ function spawnAgent(dispatchItem, config) {
         try {
           const depBranches = resolveDependencyBranches(depIds, meta?.item?.sourcePlan, project, config);
           for (const { branch: depBranch, prId } of depBranches) {
+            // Skip refs already known to be missing this tick (avoids repeated 30s ETIMEDOUT)
+            if (_failedRefCache.has(depBranch)) {
+              log('warn', `Skipping dependency ${depBranch} — already failed to fetch this tick`);
+              continue;
+            }
             try {
-              exec(`git fetch origin "${depBranch}"`, { ..._gitOpts, cwd: rootDir });
-              exec(`git merge "origin/${depBranch}" --no-edit`, { ..._gitOpts, cwd: worktreePath });
+              await execAsync(`git fetch origin "${depBranch}"`, { ..._gitOpts, cwd: rootDir });
+              await execAsync(`git merge "origin/${depBranch}" --no-edit`, { ..._gitOpts, cwd: worktreePath });
               log('info', `Merged dependency branch ${depBranch} (${prId}) into worktree ${branchName}`);
             } catch (mergeErr) {
+              _failedRefCache.add(depBranch);
               log('warn', `Failed to merge dependency ${depBranch} into ${branchName}: ${mergeErr.message}`);
             }
           }
@@ -704,7 +714,7 @@ function spawnAgent(dispatchItem, config) {
     }
 
     // Parse output and run all post-completion hooks
-    const { resultSummary, autoRecovered } = runPostCompletionHooks(dispatchItem, agentId, code, stdout, config);
+    const { resultSummary, autoRecovered } = await runPostCompletionHooks(dispatchItem, agentId, code, stdout, config);
 
     // Move from active to completed in dispatch (single source of truth for agent status)
     // autoRecovered: agent failed (e.g. heartbeat timeout) but created PRs — treat as success
@@ -2351,6 +2361,7 @@ async function tickInner() {
 
   const config = getConfig();
   tickCount++;
+  _failedRefCache.clear(); // Reset per-tick failed-ref cache
 
   // Helper: run a phase, log + continue on error
   const safe = (label, fn) => { try { fn(); } catch (e) { log('warn', `${label}: ${e.message}`); } };
@@ -2563,7 +2574,7 @@ async function tickInner() {
   for (const item of toDispatch) {
     if (!dispatched.has(item.id)) {
       let proc;
-      try { proc = spawnAgent(item, config); } catch (spawnErr) {
+      try { proc = await spawnAgent(item, config); } catch (spawnErr) {
         log('error', `spawnAgent exception for ${item.id}: ${spawnErr.message}`);
         proc = null;
       }

--- a/engine/ado.js
+++ b/engine/ado.js
@@ -5,7 +5,7 @@
 
 const path = require('path');
 const shared = require('./shared');
-const { exec, getAdoOrgBase, addPrLink, log, ts, dateStamp, PR_STATUS } = shared;
+const { exec, execAsync, getAdoOrgBase, addPrLink, log, ts, dateStamp, PR_STATUS } = shared;
 const { getPrs } = require('./queries');
 const { mutateJsonFileLocked } = shared;
 
@@ -21,7 +21,7 @@ function engine() {
 let _adoTokenCache = { token: null, expiresAt: 0 };
 let _adoTokenFailedUntil = 0; // backoff: skip azureauth calls until this timestamp
 
-function getAdoToken() {
+async function getAdoToken() {
   if (_adoTokenCache.token && Date.now() < _adoTokenCache.expiresAt) {
     return _adoTokenCache.token;
   }
@@ -30,8 +30,9 @@ function getAdoToken() {
   try {
     // azureauth supports multiple --mode flags as an ordered fallback chain:
     // tries IWA (Integrated Windows Auth) first, falls back to broker if unavailable.
-    const token = exec('azureauth ado token --mode iwa --mode broker --output token --timeout 1', {
-      timeout: 15000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true    }).trim();
+    // Uses execAsync to avoid blocking the event loop on Windows (spawnSync ETIMEDOUT).
+    const token = (await execAsync('azureauth ado token --mode iwa --mode broker --output token --timeout 1', {
+      timeout: 15000, encoding: 'utf-8', windowsHide: true    })).trim();
     if (token && token.startsWith('eyJ')) {
       _adoTokenCache = { token, expiresAt: Date.now() + 30 * 60 * 1000 };
       _adoTokenFailedUntil = 0;
@@ -56,7 +57,7 @@ async function adoFetch(url, token, _retryCount = 0) {
     // Invalidate cached token — it's likely expired
     _adoTokenCache = { token: null, expiresAt: 0 };
     if (_retryCount < MAX_RETRIES) {
-      const freshToken = getAdoToken();
+      const freshToken = await getAdoToken();
       if (freshToken) {
         log('info', 'ADO token expired mid-session — refreshed and retrying');
         return adoFetch(url, freshToken, _retryCount + 1);
@@ -132,7 +133,7 @@ async function forEachActivePr(config, token, callback) {
 // ─── PR Status Polling ───────────────────────────────────────────────────────
 
 async function pollPrStatus(config) {
-  const token = getAdoToken();
+  const token = await getAdoToken();
   if (!token) {
     log('warn', 'Skipping PR status poll — no ADO token available');
     return;
@@ -287,7 +288,7 @@ async function pollPrStatus(config) {
 // ─── Poll Human Comments on PRs ──────────────────────────────────────────────
 
 async function pollPrHumanComments(config) {
-  const token = getAdoToken();
+  const token = await getAdoToken();
   if (!token) return;
 
   const totalUpdated = await forEachActivePr(config, token, async (project, pr, prNum, orgBase) => {
@@ -361,7 +362,7 @@ async function pollPrHumanComments(config) {
  * in pull-requests.json, and add them. Matches PRs to work items by branch name.
  */
 async function reconcilePrs(config) {
-  const token = getAdoToken();
+  const token = await getAdoToken();
   if (!token) {
     log('warn', 'Skipping PR reconciliation — no ADO token available');
     return;
@@ -486,19 +487,19 @@ async function reconcilePrs(config) {
 }
 
 /**
- * Fetch live review status for a single PR from ADO (synchronous).
+ * Fetch live review status for a single PR from ADO (async).
  * Returns 'approved', 'changes-requested', 'waiting', or 'pending'.
  * Returns null if the check fails (token unavailable, API error).
  * Used as a pre-dispatch gate to avoid dispatching reviews for already-approved PRs.
  */
-function checkLiveReviewStatus(pr, project) {
+async function checkLiveReviewStatus(pr, project) {
   try {
-    const token = getAdoToken();
+    const token = await getAdoToken();
     if (!token) return null;
     const orgBase = shared.getAdoOrgBase(project);
     const prNum = (pr.id || '').replace(/^PR-/, '');
     const url = `${orgBase}/${project.adoProject}/_apis/git/repositories/${project.repositoryId}/pullrequests/${prNum}?api-version=7.1`;
-    const result = exec(`curl -s --max-time 4 -H "Authorization: Bearer ${token}" "${url}"`, { encoding: 'utf-8', timeout: 5000, windowsHide: true });
+    const result = await execAsync(`curl -s --max-time 4 -H "Authorization: Bearer ${token}" "${url}"`, { encoding: 'utf-8', timeout: 5000, windowsHide: true });
     const prData = JSON.parse(result);
     const votes = (prData.reviewers || []).map(r => r.vote).filter(v => v !== undefined);
     if (votes.length === 0) return 'pending';

--- a/engine/github.js
+++ b/engine/github.js
@@ -5,7 +5,7 @@
  */
 
 const shared = require('./shared');
-const { exec, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, mutateJsonFileLocked, MINIONS_DIR, addPrLink, getPrLinks, log, ts, dateStamp, PR_STATUS } = shared;
+const { exec, execAsync, getProjects, projectPrPath, projectWorkItemsPath, safeJson, safeWrite, mutateJsonFileLocked, MINIONS_DIR, addPrLink, getPrLinks, log, ts, dateStamp, PR_STATUS } = shared;
 const { getPrs } = require('./queries');
 const path = require('path');
 
@@ -69,10 +69,10 @@ function resetSlugBackoff(slug) {
 }
 
 /** Run a `gh api` call and parse JSON result. Returns null on failure. */
-function ghApi(endpoint, slug) {
+async function ghApi(endpoint, slug) {
   try {
     const cmd = `gh api "repos/${slug}${endpoint}"`;
-    const result = exec(cmd, { timeout: 30000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    const result = await execAsync(cmd, { timeout: 30000, encoding: 'utf-8' });
     return JSON.parse(result);
   } catch (e) {
     log('warn', `GitHub API error (${endpoint}): ${e.message}`);
@@ -84,8 +84,8 @@ function ghApi(endpoint, slug) {
  * Run a `gh api` call with per-slug backoff tracking. Returns null on failure.
  * On success, resets the slug's backoff. On failure, increments it.
  */
-function ghApiWithBackoff(endpoint, slug) {
-  const result = ghApi(endpoint, slug);
+async function ghApiWithBackoff(endpoint, slug) {
+  const result = await ghApi(endpoint, slug);
   if (result === null) {
     recordSlugFailure(slug);
   } else {
@@ -112,7 +112,7 @@ async function forEachActiveGhPr(config, callback) {
     if (activePrs.length === 0) continue;
 
     // Probe repo accessibility before iterating PRs — avoids N warnings per inaccessible repo
-    const probe = ghApi('', slug);
+    const probe = await ghApi('', slug);
     if (probe === null) {
       recordSlugFailure(slug);
       continue;
@@ -171,7 +171,7 @@ async function forEachActiveGhPr(config, callback) {
       if (updated) {
         // Also update title/author/branch if still placeholder
         if (pr.title.includes('polling...') || pr.agent === 'human') {
-          const prData = ghApi(`/pulls/${prNum}`, slug);
+          const prData = await ghApi(`/pulls/${prNum}`, slug);
           if (prData) {
             if (pr.title.includes('polling...')) pr.title = (prData.title || pr.title).slice(0, 120);
             if (pr.agent === 'human' && prData.user?.login) pr.agent = prData.user.login;
@@ -203,7 +203,7 @@ async function forEachActiveGhPr(config, callback) {
 
 async function pollPrStatus(config) {
   const totalUpdated = await forEachActiveGhPr(config, async (project, pr, prNum, slug) => {
-    const prData = ghApi(`/pulls/${prNum}`, slug);
+    const prData = await ghApi(`/pulls/${prNum}`, slug);
     if (!prData) return false;
 
     let updated = false;
@@ -243,7 +243,7 @@ async function pollPrStatus(config) {
     }
 
     // Review status from GitHub reviews
-    const reviews = ghApi(`/pulls/${prNum}/reviews`, slug);
+    const reviews = await ghApi(`/pulls/${prNum}/reviews`, slug);
     if (reviews && Array.isArray(reviews)) {
       // Get latest review per user
       const latestByUser = new Map();
@@ -306,7 +306,7 @@ async function pollPrStatus(config) {
 
     // Check status / checks
     if (prData.state === 'open' && prData.head?.sha) {
-      const checksData = ghApi(`/commits/${prData.head.sha}/check-runs`, slug);
+      const checksData = await ghApi(`/commits/${prData.head.sha}/check-runs`, slug);
       if (checksData && checksData.check_runs) {
         const runs = checksData.check_runs;
         let buildStatus = 'none';
@@ -352,11 +352,11 @@ async function pollPrStatus(config) {
 async function pollPrHumanComments(config) {
   const totalUpdated = await forEachActiveGhPr(config, async (project, pr, prNum, slug) => {
     // Get issue comments (general PR comments)
-    const comments = ghApi(`/issues/${prNum}/comments`, slug);
+    const comments = await ghApi(`/issues/${prNum}/comments`, slug);
     if (!comments || !Array.isArray(comments)) return false;
 
     // Also get review comments (inline code comments)
-    const reviewComments = ghApi(`/pulls/${prNum}/comments`, slug);
+    const reviewComments = await ghApi(`/pulls/${prNum}/comments`, slug);
     const allComments = [
       ...(comments || []).map(c => ({ ...c, _type: 'issue' })),
       ...(Array.isArray(reviewComments) ? reviewComments : []).map(c => ({ ...c, _type: 'review' }))
@@ -438,7 +438,7 @@ async function reconcilePrs(config) {
     if (isSlugInBackoff(slug)) continue;
 
     // Fetch open PRs
-    const prsData = ghApi('/pulls?state=open&per_page=100', slug);
+    const prsData = await ghApi('/pulls?state=open&per_page=100', slug);
     if (!prsData || !Array.isArray(prsData)) {
       recordSlugFailure(slug);
       continue;
@@ -541,12 +541,12 @@ async function reconcilePrs(config) {
  * Fetch live review status for a single PR from GitHub. Returns 'approved', 'changes-requested',
  * 'waiting', or 'pending'. Returns null if the check fails.
  */
-function checkLiveReviewStatus(pr, project) {
+async function checkLiveReviewStatus(pr, project) {
   try {
     const slug = getRepoSlug(project);
     if (!slug) return null;
     const prNum = (pr.id || '').replace(/^PR-/, '');
-    const reviews = ghApi(`/pulls/${prNum}/reviews`, slug);
+    const reviews = await ghApi(`/pulls/${prNum}/reviews`, slug);
     if (!reviews || !Array.isArray(reviews)) return null;
     const latestByUser = new Map();
     for (const r of reviews) {

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -689,7 +689,7 @@ function syncPrsFromOutput(output, agentId, meta, config) {
 
 // ─── Post-Completion Hooks ──────────────────────────────────────────────────
 
-function updatePrAfterReview(agentId, pr, project, config) {
+async function updatePrAfterReview(agentId, pr, project, config) {
 
   if (!pr?.id) return;
 
@@ -707,7 +707,7 @@ function updatePrAfterReview(agentId, pr, project, config) {
       const checkFn = host === 'github'
         ? require('./github').checkLiveReviewStatus
         : require('./ado').checkLiveReviewStatus;
-      const liveStatus = checkFn(pr, projectObj);
+      const liveStatus = await checkFn(pr, projectObj);
       // Use live status only if it's a decisive verdict (not 'pending' — review may not have propagated yet)
       if (liveStatus && liveStatus !== 'pending') postReviewStatus = liveStatus;
     }
@@ -1142,7 +1142,7 @@ function handleDecompositionResult(stdout, meta, config) {
   return 0;
 }
 
-function runPostCompletionHooks(dispatchItem, agentId, code, stdout, config) {
+async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, config) {
 
   const type = dispatchItem.type;
   const meta = dispatchItem.meta;
@@ -1319,7 +1319,7 @@ function runPostCompletionHooks(dispatchItem, agentId, code, stdout, config) {
     }
   }
 
-  if (type === WORK_TYPE.REVIEW) updatePrAfterReview(agentId, meta?.pr, meta?.project, config);
+  if (type === WORK_TYPE.REVIEW) await updatePrAfterReview(agentId, meta?.pr, meta?.project, config);
   if (type === WORK_TYPE.FIX) updatePrAfterFix(meta?.pr, meta?.project, meta?.source);
   checkForLearnings(agentId, config.agents[agentId], dispatchItem.task);
   if (effectiveSuccess) {

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -304,7 +304,7 @@ function writeToInbox(agentId, slug, content, _inboxDir) {
 // ── Process Spawning ────────────────────────────────────────────────────────
 // All child process calls go through these to ensure windowsHide: true
 
-const { execSync: _execSync, spawnSync: _spawnSync, spawn: _spawn } = require('child_process');
+const { execSync: _execSync, spawnSync: _spawnSync, spawn: _spawn, exec: _cbExec } = require('child_process');
 
 function exec(cmd, opts = {}) {
   return _execSync(cmd, { windowsHide: true, ...opts });
@@ -320,6 +320,31 @@ function runFile(file, args, opts = {}) {
 
 function execSilent(cmd, opts = {}) {
   return _execSync(cmd, { stdio: 'pipe', windowsHide: true, ...opts });
+}
+
+/**
+ * Async version of exec() — runs a shell command without blocking the event loop.
+ * Returns a Promise that resolves with { stdout, stderr } or rejects on error/timeout.
+ * Drop-in replacement for sync `exec()` in async contexts.
+ *
+ * @param {string} cmd - Shell command to run
+ * @param {object} opts - Options (same as child_process.exec: timeout, cwd, encoding, env, etc.)
+ * @returns {Promise<string>} stdout (trimmed if encoding is set)
+ */
+function execAsync(cmd, opts = {}) {
+  const { timeout, ...rest } = opts;
+  return new Promise((resolve, reject) => {
+    const child = _cbExec(cmd, { windowsHide: true, encoding: 'utf8', ...rest, timeout: timeout || 30000 }, (err, stdout, stderr) => {
+      if (err) {
+        err.stderr = stderr;
+        err.stdout = stdout;
+        return reject(err);
+      }
+      resolve(stdout);
+    });
+    // Safety: ensure child is killed if parent process exits
+    child.unref && child.unref();
+  });
 }
 
 /**
@@ -787,6 +812,7 @@ module.exports = {
   uniquePath,
   writeToInbox,
   exec,
+  execAsync,
   execSilent,
   resolveMainBranch,
   run,

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -149,8 +149,8 @@ function checkTimeouts(config) {
 
         completeDispatch(item.id, isSuccess ? DISPATCH_RESULT.SUCCESS : DISPATCH_RESULT.ERROR, 'Completed (detected from output)');
 
-        // Run post-completion hooks via shared helper
-        runPostCompletionHooks(item, item.agent, isSuccess ? 0 : 1, liveLog, config);
+        // Run post-completion hooks via shared helper (async — fire and forget in timeout context)
+        runPostCompletionHooks(item, item.agent, isSuccess ? 0 : 1, liveLog, config).catch(e => log('warn', 'post-completion hooks: ' + e.message));
 
         if (hasProcess) {
           shared.killImmediate(activeProcesses.get(item.id)?.proc);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8225,7 +8225,7 @@ async function testAutoRecoveryAndAtomicity() {
   });
 
   await test('engine.js uses autoRecovered to upgrade completeDispatch result', () => {
-    assert.ok(engineSrc.includes('const { resultSummary, autoRecovered } = runPostCompletionHooks'),
+    assert.ok(engineSrc.includes('const { resultSummary, autoRecovered } = await runPostCompletionHooks'),
       'engine.js must destructure autoRecovered from runPostCompletionHooks');
     assert.ok(engineSrc.includes('code === 0 || autoRecovered'),
       'engine.js must use autoRecovered to determine effectiveResult for completeDispatch');
@@ -8349,7 +8349,7 @@ async function testAutoRecoveryAndAtomicity() {
   const lifecycle = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
   const shared = require(path.join(MINIONS_DIR, 'engine', 'shared'));
 
-  await test('runPostCompletionHooks returns autoRecovered=true when failed agent created PR', () => {
+  await test('runPostCompletionHooks returns autoRecovered=true when failed agent created PR', async () => {
     const tmpDir = createTmpDir();
     const prFile = path.join(tmpDir, 'pull-requests.json');
     shared.safeWrite(prFile, []);
@@ -8370,7 +8370,7 @@ async function testAutoRecoveryAndAtomicity() {
       };
 
       // code=1 simulates heartbeat timeout kill
-      const result = lifecycle.runPostCompletionHooks(dispatchItem, 'agent1', 1, output, mockConfig);
+      const result = await lifecycle.runPostCompletionHooks(dispatchItem, 'agent1', 1, output, mockConfig);
       assert.strictEqual(result.autoRecovered, true,
         'autoRecovered should be true when failed implement agent created PR');
 
@@ -8383,7 +8383,7 @@ async function testAutoRecoveryAndAtomicity() {
     }
   });
 
-  await test('runPostCompletionHooks does NOT auto-recover non-implement types', () => {
+  await test('runPostCompletionHooks does NOT auto-recover non-implement types', async () => {
     const tmpDir = createTmpDir();
     const prFile = path.join(tmpDir, 'pull-requests.json');
     shared.safeWrite(prFile, []);
@@ -8405,7 +8405,7 @@ async function testAutoRecoveryAndAtomicity() {
                 pr: { id: 'PR-55', number: 55 } }
       };
 
-      const result = lifecycle.runPostCompletionHooks(dispatchItem, 'reviewer', 1, output, mockConfig);
+      const result = await lifecycle.runPostCompletionHooks(dispatchItem, 'reviewer', 1, output, mockConfig);
       assert.strictEqual(result.autoRecovered, false,
         'autoRecovered should be false for review type even with PR in output');
     } finally {
@@ -8414,7 +8414,7 @@ async function testAutoRecoveryAndAtomicity() {
     }
   });
 
-  await test('runPostCompletionHooks returns autoRecovered=false on normal success', () => {
+  await test('runPostCompletionHooks returns autoRecovered=false on normal success', async () => {
     const tmpDir = createTmpDir();
     const prFile = path.join(tmpDir, 'pull-requests.json');
     shared.safeWrite(prFile, []);
@@ -8435,7 +8435,7 @@ async function testAutoRecoveryAndAtomicity() {
       };
 
       // code=0 means normal success — autoRecovered should be false
-      const result = lifecycle.runPostCompletionHooks(dispatchItem, 'agent1', 0, output, mockConfig);
+      const result = await lifecycle.runPostCompletionHooks(dispatchItem, 'agent1', 0, output, mockConfig);
       assert.strictEqual(result.autoRecovered, false,
         'autoRecovered should be false when agent succeeded normally (code=0)');
     } finally {


### PR DESCRIPTION
## Summary
- Adds `execAsync()` to `shared.js` as an async drop-in replacement for the blocking `exec()` wrapper
- Converts all git operations in `spawnAgent()` (worktree creation, fetch, pull, merge) from sync `exec()` to `await execAsync()`, preventing ETIMEDOUT from blocking the entire tick loop
- Converts `getAdoToken()`, `ghApi()`, and `checkLiveReviewStatus()` to async to unblock ADO token refresh and GitHub API calls
- Adds per-tick failed-ref cache (`_failedRefCache`) to skip re-fetching known-missing dependency branches, avoiding repeated 30s timeouts on the same ref
- Propagates async through `runPostCompletionHooks` → `updatePrAfterReview` call chain
- Updates 4 unit tests to handle the now-async `runPostCompletionHooks`

Fixes #436

## Test plan
- [x] `npm test` passes (829 passed, 1 pre-existing failure unrelated to this change)
- [ ] Manual smoke test: engine starts and dispatches agents normally
- [ ] Verify worktree creation doesn't block tick loop under ETIMEDOUT conditions
- [ ] Verify ADO token refresh failure doesn't stall other tick phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)