### PR TITLE
fix: declare onAgentClose as async (closes #454)

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -562,7 +562,7 @@ async function spawnAgent(dispatchItem, config) {
     try { fs.appendFileSync(liveOutputPath, '[stderr] ' + chunk); } catch { /* optional */ }
   });
 
-  function onAgentClose(code) {
+  async function onAgentClose(code) {
     if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
     log('info', `Agent ${agentId} (${id}) exited with code ${code}`);
 


### PR DESCRIPTION
## Summary
- `onAgentClose` in `engine.js` was declared as a regular function but used `await` internally
- `runPostCompletionHooks` was returning an unhandled Promise, meaning post-completion hooks (PR sync, lifecycle, metrics) could silently fail
- Fix: add `async` to the function declaration (1-char change)

## Test plan
- [ ] Unit tests pass
- [ ] Engine starts and agents complete normally with hooks running

🤖 Generated with [Claude Code](https://claude.com/claude-code)