### PR TITLE
feat(P-n1r8f5v3): add DEFAULT_AGENT_METRICS constant to shared.js

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -9,7 +9,7 @@ const os = require('os');
 const shared = require('./shared');
 const { safeRead, safeJson, safeWrite, mutateJsonFileLocked, mutateWorkItems, execSilent, projectPrPath, getPrLinks, addPrLink,
   log, ts, dateStamp, WI_STATUS, DONE_STATUSES, WORK_TYPE, PLAN_STATUS, PR_STATUS, DISPATCH_RESULT,
-  ENGINE_DEFAULTS } = shared;
+  ENGINE_DEFAULTS, DEFAULT_AGENT_METRICS } = shared;
 const { trackEngineUsage } = require('./llm');
 const queries = require('./queries');
 const { getConfig, getInboxFiles, getNotes, getPrs, getDispatch,
@@ -734,8 +734,8 @@ async function updatePrAfterReview(agentId, pr, project, config) {
   const authorAgentId = (pr.agent || '').toLowerCase();
   if (authorAgentId && config.agents?.[authorAgentId]) {
     shared.mutateJsonFileLocked(path.join(ENGINE_DIR, 'metrics.json'), (metrics) => {
-      if (!metrics[authorAgentId]) metrics[authorAgentId] = { tasksCompleted:0, tasksErrored:0, prsCreated:0, prsApproved:0, prsRejected:0, reviewsDone:0, lastTask:null, lastCompleted:null };
-      if (!metrics[agentId]) metrics[agentId] = { tasksCompleted:0, tasksErrored:0, prsCreated:0, prsApproved:0, prsRejected:0, reviewsDone:0, lastTask:null, lastCompleted:null };
+      if (!metrics[authorAgentId]) metrics[authorAgentId] = { ...DEFAULT_AGENT_METRICS };
+      if (!metrics[agentId]) metrics[agentId] = { ...DEFAULT_AGENT_METRICS };
       metrics[agentId].reviewsDone = (metrics[agentId].reviewsDone || 0) + 1;
       return metrics;
     }, { defaultValue: {} });
@@ -847,7 +847,7 @@ async function handlePostMerge(pr, project, config, newStatus) {
   if (agentId && config.agents?.[agentId]) {
     const metricsPath = path.join(ENGINE_DIR, 'metrics.json');
     mutateJsonFileLocked(metricsPath, (metrics) => {
-      if (!metrics[agentId]) metrics[agentId] = { tasksCompleted:0, tasksErrored:0, prsCreated:0, prsApproved:0, prsRejected:0, prsMerged:0, reviewsDone:0, lastTask:null, lastCompleted:null };
+      if (!metrics[agentId]) metrics[agentId] = { ...DEFAULT_AGENT_METRICS };
       metrics[agentId].prsMerged = (metrics[agentId].prsMerged || 0) + 1;
       return metrics;
     });
@@ -1010,8 +1010,7 @@ function updateMetrics(agentId, dispatchItem, result, taskUsage, prsCreatedCount
   mutateJsonFileLocked(metricsPath, metrics => {
     metrics = metrics || {};
     if (!metrics[agentId]) {
-      metrics[agentId] = { tasksCompleted: 0, tasksErrored: 0, prsCreated: 0, prsApproved: 0, prsRejected: 0,
-        reviewsDone: 0, lastTask: null, lastCompleted: null, totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, totalCacheRead: 0 };
+      metrics[agentId] = { ...DEFAULT_AGENT_METRICS };
     }
     const m = metrics[agentId];
     m.lastTask = dispatchItem.task;

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -562,6 +562,14 @@ const MEETING_STATUS = {
   COMPLETED: 'completed', ARCHIVED: 'archived',
 };
 
+const DEFAULT_AGENT_METRICS = {
+  tasksCompleted: 0, tasksErrored: 0,
+  prsCreated: 0, prsApproved: 0, prsRejected: 0, prsMerged: 0,
+  reviewsDone: 0,
+  lastTask: null, lastCompleted: null,
+  totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, totalCacheRead: 0,
+};
+
 const DEFAULT_AGENTS = {
   ripley:  { name: 'Ripley',  emoji: '\u{1F3D7}\uFE0F',  role: 'Lead / Explorer', skills: ['architecture', 'codebase-exploration', 'design-review'] },
   dallas:  { name: 'Dallas',  emoji: '\u{1F527}',  role: 'Engineer', skills: ['implementation', 'typescript', 'docker', 'testing'] },
@@ -825,6 +833,7 @@ module.exports = {
   ENGINE_DEFAULTS,
   WI_STATUS, DONE_STATUSES, WORK_TYPE, PLAN_STATUS, PR_STATUS, DISPATCH_RESULT,
   PIPELINE_STATUS, STAGE_TYPE, MEETING_STATUS,
+  DEFAULT_AGENT_METRICS,
   DEFAULT_AGENTS,
   DEFAULT_CLAUDE,
   getProjects,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -469,6 +469,28 @@ async function testEngineDefaults() {
     assert.ok(shared.DEFAULT_CLAUDE.allowedTools);
   });
 
+  await test('DEFAULT_AGENT_METRICS has all required metric fields', () => {
+    const m = shared.DEFAULT_AGENT_METRICS;
+    assert.ok(m !== undefined, 'DEFAULT_AGENT_METRICS must be exported');
+    const expectedFields = ['tasksCompleted', 'tasksErrored', 'prsCreated', 'prsApproved',
+      'prsRejected', 'prsMerged', 'reviewsDone', 'lastTask', 'lastCompleted',
+      'totalCostUsd', 'totalInputTokens', 'totalOutputTokens', 'totalCacheRead'];
+    for (const field of expectedFields) {
+      assert.ok(field in m, `DEFAULT_AGENT_METRICS missing field: ${field}`);
+    }
+    // Numeric fields default to 0, nullable fields default to null
+    assert.strictEqual(m.tasksCompleted, 0);
+    assert.strictEqual(m.lastTask, null);
+    assert.strictEqual(m.lastCompleted, null);
+  });
+
+  await test('DEFAULT_AGENT_METRICS spread creates independent copy', () => {
+    const a = { ...shared.DEFAULT_AGENT_METRICS };
+    const b = { ...shared.DEFAULT_AGENT_METRICS };
+    a.tasksCompleted = 5;
+    assert.strictEqual(b.tasksCompleted, 0, 'Spread must create independent copy');
+  });
+
   await test('KB_CATEGORIES has expected categories', () => {
     assert.ok(shared.KB_CATEGORIES.includes('architecture'));
     assert.ok(shared.KB_CATEGORIES.includes('conventions'));


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_AGENT_METRICS` constant to `engine/shared.js` with all metric fields (tasksCompleted, tasksErrored, prsCreated, prsApproved, prsRejected, prsMerged, reviewsDone, lastTask, lastCompleted, totalCostUsd, totalInputTokens, totalOutputTokens, totalCacheRead)
- Replaces 4 inline hardcoded metric object literals in `engine/lifecycle.js` with `{ ...DEFAULT_AGENT_METRICS }`
- Adds 2 unit tests verifying constant shape and independent copy behavior

## Test plan
- [x] All 859 unit tests pass (0 failed, 2 skipped)
- [x] No hardcoded metric object literals remain in lifecycle.js
- [x] New tests verify DEFAULT_AGENT_METRICS shape and spread independence

🤖 Generated with [Claude Code](https://claude.com/claude-code)