### PR TITLE
fix: await checkLiveReviewStatus in pre-dispatch vote check (closes #462)

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1396,7 +1396,7 @@ function discoverFromPrs(config, project) {
       // Pre-dispatch live vote check — cached reviewStatus may be stale (poll lag ~6 min)
       try {
         const checkFn = project.repoHost === 'github' ? ghCheckLiveReview : adoCheckLiveReview;
-        const liveStatus = checkFn(pr, project);
+        const liveStatus = await checkFn(pr, project);
         if (liveStatus && liveStatus !== 'pending') {
           log('info', `Pre-dispatch vote check: ${pr.id} is ${liveStatus} (cached was pending) — skipping review`);
           pr.reviewStatus = liveStatus;


### PR DESCRIPTION
## Summary
- `checkLiveReviewStatus` is async but was called without `await` at engine.js pre-dispatch vote check
- `liveStatus` was always a Promise (truthy), causing the early-return branch to fire for every PR, skipping dispatch and serializing `reviewStatus` as `{}`
- Fix: add `await`

🤖 Generated with [Claude Code](https://claude.com/claude-code)