### PR TITLE
fix(W-mnp7e5qrk09h): defer dispatched status until spawn + _any_ routing token

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1547,7 +1547,7 @@ function discoverFromWorkItems(config, project) {
   const items = safeJson(projectWorkItemsPath(project)) || [];
   const cooldownMs = (src.cooldownMinutes || 0) * 60 * 1000;
   const newWork = [];
-  const prdSyncQueue = [];
+  // PRD sync for dispatched status deferred to spawnAgent success (#480)
   const skipped = { gated: 0, noAgent: 0 };
   let needsWrite = false;
   const selfHealKeys = new Set(); // Collect keys for batched self-heal (1 lock instead of N)
@@ -1594,10 +1594,11 @@ function discoverFromWorkItems(config, project) {
       needsWrite = true;
     }
     if (isAlreadyDispatched(key)) {
-      if (item.status === WI_STATUS.PENDING) { item.status = WI_STATUS.DISPATCHED; needsWrite = true; }
-      if (!item.dispatched_to) {
-        const existing = getDispatch().active?.find(d => d.meta?.dispatchKey === key);
-        if (existing?.agent) { item.dispatched_to = existing.agent; needsWrite = true; }
+      // Only self-heal to DISPATCHED if actually in dispatch.active (agent spawned) (#480)
+      const existingActive = getDispatch().active?.find(d => d.meta?.dispatchKey === key);
+      if (existingActive) {
+        if (item.status === WI_STATUS.PENDING) { item.status = WI_STATUS.DISPATCHED; needsWrite = true; }
+        if (!item.dispatched_to && existingActive.agent) { item.dispatched_to = existingActive.agent; needsWrite = true; }
       }
       if (item._pendingReason !== 'already_dispatched') { item._pendingReason = 'already_dispatched'; needsWrite = true; }
       skipped.gated++; continue;
@@ -1682,12 +1683,11 @@ function discoverFromWorkItems(config, project) {
       continue;
     }
 
-    // Mark item as dispatched BEFORE adding to newWork (prevents race on next tick)
-    item.status = WI_STATUS.DISPATCHED;
-    item.dispatched_at = ts();
-    item.dispatched_to = agentId;
+    // Don't mark dispatched here — item stays pending until spawnAgent succeeds.
+    // spawnAgent() atomically stamps dispatched_to/dispatched_at/status via locked write (#480).
+    // isAlreadyDispatched(key) prevents re-discovery on subsequent ticks.
     delete item._pendingReason;
-    prdSyncQueue.push({ id: item.id, sourcePlan: item.sourcePlan });
+    needsWrite = true;
 
     newWork.push({
       type: workType,
@@ -1729,12 +1729,9 @@ function discoverFromWorkItems(config, project) {
     }
   }
 
-  // Write back updated statuses (always, since we mark items dispatched before newWork check)
-  if (newWork.length > 0 || needsWrite) {
+  // Write back updated statuses (pendingReason clears, checkpoint counts, decompose flags, etc.)
+  if (needsWrite) {
     mutateWorkItems(projectWorkItemsPath(project), () => items);
-    if (newWork.length > 0) {
-      for (const s of prdSyncQueue) syncPrdItemStatus(s.id, 'dispatched', s.sourcePlan);
-    }
   }
 
   const skipTotal = skipped.gated + skipped.noAgent;
@@ -2021,13 +2018,14 @@ function discoverCentralWorkItems(config) {
     const key = `central-work-${item.id}`;
     // Self-heal: if already dispatched but work item is still pending, fix the status
     if (isAlreadyDispatched(key)) {
-      const m = {};
-      if (item.status === WI_STATUS.PENDING) { m.status = WI_STATUS.DISPATCHED; }
-      if (!item.dispatched_to) {
-        const existing = getDispatch().active?.find(d => d.meta?.dispatchKey === key);
-        if (existing?.agent) { m.dispatched_to = existing.agent; }
+      // Only self-heal to DISPATCHED if actually in dispatch.active (agent spawned) (#480)
+      const existingActive = getDispatch().active?.find(d => d.meta?.dispatchKey === key);
+      if (existingActive) {
+        const m = {};
+        if (item.status === WI_STATUS.PENDING) { m.status = WI_STATUS.DISPATCHED; }
+        if (!item.dispatched_to && existingActive.agent) { m.dispatched_to = existingActive.agent; }
+        if (Object.keys(m).length > 0) mutations.set(item.id, m);
       }
-      if (Object.keys(m).length > 0) mutations.set(item.id, m);
       continue;
     }
     if (isOnCooldown(key, 0)) continue;
@@ -2100,15 +2098,13 @@ function discoverCentralWorkItems(config) {
         });
       }
 
+      // Don't mark dispatched here — spawnAgent stamps status atomically (#480)
       mutations.set(item.id, {
-        status: WI_STATUS.DISPATCHED,
-        dispatched_at: ts(),
-        dispatched_to: idleAgents.map(a => a.id).join(', '),
         scope: 'fan-out',
         fanOutAgents: idleAgents.map(a => a.id),
       });
       setCooldown(key);
-      log('info', `Fan-out: ${item.id} dispatched to ${idleAgents.length} agents: ${idleAgents.map(a => a.name).join(', ')}`);
+      log('info', `Fan-out: ${item.id} queued for ${idleAgents.length} agents: ${idleAgents.map(a => a.name).join(', ')}`);
 
     } else {
       // ─── Normal: single agent dispatch ──────────────────────────────
@@ -2206,12 +2202,7 @@ function discoverCentralWorkItems(config) {
         continue;
       }
 
-      const dispatchMutation = {
-        status: WI_STATUS.DISPATCHED,
-        dispatched_at: ts(),
-        dispatched_to: agentId,
-      };
-      mutations.set(item.id, Object.assign(mutations.get(item.id) || {}, dispatchMutation));
+      // Don't mark dispatched here — spawnAgent stamps status atomically (#480)
 
       newWork.push({
         type: workType,
@@ -2665,6 +2656,11 @@ async function tickInner() {
         }
       } else {
         dispatched.add(item.id);
+        // Sync PRD item status after successful spawn (#480)
+        if (item.meta?.item?.sourcePlan) {
+          try { syncPrdItemStatus(item.meta.item.id, WI_STATUS.DISPATCHED, item.meta.item.sourcePlan); }
+          catch (e) { log('warn', `prd sync after spawn: ${e.message}`); }
+        }
       }
     }
   }

--- a/engine/routing.js
+++ b/engine/routing.js
@@ -121,16 +121,26 @@ function resolveAgent(workType, config, authorAgent = null) {
     return true;
   };
 
-  // Check preferred and fallback first (routing table order)
-  if (preferred && isAvailable(preferred)) { _claimedAgents.add(preferred); return preferred; }
-  if (fallback && isAvailable(fallback)) { _claimedAgents.add(fallback); return fallback; }
+  // Helper: pick any idle agent sorted by error rate
+  const pickAnyIdle = (exclude = []) => {
+    const excludeSet = new Set(exclude.filter(Boolean));
+    const idle = Object.keys(agents)
+      .filter(id => !excludeSet.has(id) && isAvailable(id))
+      .sort((a, b) => getAgentErrorRate(a) - getAgentErrorRate(b));
+    if (idle[0]) { _claimedAgents.add(idle[0]); return idle[0]; }
+    return null;
+  };
+
+  // Resolve _any_ token — pick any available agent (#480)
+  if (preferred === '_any_') { const pick = pickAnyIdle(); if (pick) return pick; }
+  else if (preferred && isAvailable(preferred)) { _claimedAgents.add(preferred); return preferred; }
+
+  if (fallback === '_any_') { const pick = pickAnyIdle([preferred]); if (pick) return pick; }
+  else if (fallback && isAvailable(fallback)) { _claimedAgents.add(fallback); return fallback; }
 
   // Fall back to any idle agent, preferring lower error rates
-  const idle = Object.keys(agents)
-    .filter(id => id !== preferred && id !== fallback && isAvailable(id))
-    .sort((a, b) => getAgentErrorRate(a) - getAgentErrorRate(b));
-
-  if (idle[0]) { _claimedAgents.add(idle[0]); return idle[0]; }
+  const anyIdle = pickAnyIdle([preferred, fallback]);
+  if (anyIdle) return anyIdle;
 
   // No idle configured agent — try temp agent if enabled
   if (config.engine?.allowTempAgents) {

--- a/routing.md
+++ b/routing.md
@@ -10,7 +10,7 @@ How the engine decides who handles what. Parsed by engine.js — keep the table 
 | implement | dallas | ralph |
 | implement:large | rebecca | dallas |
 | review | ripley | lambert |
-| fix | _author_ | dallas |
+| fix | _author_ | _any_ |
 | plan | ripley | rebecca |
 | plan-to-prd | lambert | rebecca |
 | explore | ripley | rebecca |
@@ -22,6 +22,7 @@ How the engine decides who handles what. Parsed by engine.js — keep the table 
 
 Notes:
 - `_author_` means route to the PR author
+- `_any_` means route to any available idle agent (lowest error rate first)
 - `implement:large` is for items with `estimated_complexity: "large"`
 - Engine falls back to any idle agent if both preferred and fallback are busy
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2330,15 +2330,18 @@ async function testStateIntegrity() {
       'Pending discovery should clear in-memory cooldown for pending item key');
   });
 
-  await test('Central work items self-heal dispatched status when isAlreadyDispatched is true', () => {
+  await test('Central work items self-heal dispatched status only when in dispatch.active (#480)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
-    // discoverCentralWorkItems must self-heal items stuck at pending when already dispatched
+    // discoverCentralWorkItems must self-heal items stuck at pending when actively dispatched
     const centralFn = src.slice(src.indexOf('function discoverCentralWorkItems('));
     assert.ok(centralFn.includes('if (isAlreadyDispatched(key))'),
       'Central discovery must check isAlreadyDispatched separately for self-heal');
+    // Self-heal should only set DISPATCHED when item is in dispatch.active (not pending)
+    assert.ok(centralFn.includes('const existingActive = getDispatch().active?.find(d => d.meta?.dispatchKey === key)'),
+      'Central self-heal must check dispatch.active before setting dispatched status');
     assert.ok(centralFn.includes('m.status = WI_STATUS.DISPATCHED'),
-      'Central discovery must self-heal pending→dispatched via mutations map');
-    assert.ok(centralFn.includes('existing?.agent') && centralFn.includes('m.dispatched_to'),
+      'Central discovery must self-heal pending→dispatched via mutations map when in active');
+    assert.ok(centralFn.includes('existingActive.agent') && centralFn.includes('m.dispatched_to'),
       'Central discovery must populate dispatched_to from active dispatch entry');
     assert.ok(centralFn.includes('mutations.size > 0') && centralFn.includes('mutateJsonFileLocked(centralPath'),
       'Central discovery must persist changes via atomic mutateJsonFileLocked when mutations exist');
@@ -2370,15 +2373,29 @@ async function testStateIntegrity() {
       'pendingFix should be cleared after addToDispatch in discoverWork');
   });
 
-  await test('Work-item dispatched sync writes work items before PRD status sync', () => {
+  await test('Discovery does not prematurely mark items as dispatched (#480)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
-    const markIdx = src.indexOf("prdSyncQueue.push({ id: item.id, sourcePlan: item.sourcePlan });");
-    const writeIdx = src.indexOf('mutateWorkItems(projectWorkItemsPath(project), () => items)');
-    const syncIdx = src.indexOf("for (const s of prdSyncQueue) syncPrdItemStatus(s.id, 'dispatched', s.sourcePlan);");
-    assert.ok(markIdx > 0 && writeIdx > 0 && syncIdx > 0,
-      'discoverFromWorkItems should queue PRD sync, then write work items, then sync PRD');
-    assert.ok(writeIdx < syncIdx,
-      'work item write must happen before PRD dispatched sync to reduce divergence windows');
+    // Discovery should NOT eagerly stamp dispatched_at/dispatched_to on new items
+    assert.ok(!src.includes('item.dispatched_at = ts()'),
+      'discoverFromWorkItems must NOT prematurely set dispatched_at during discovery');
+    assert.ok(!src.includes('item.dispatched_to = agentId'),
+      'discoverFromWorkItems must NOT prematurely set dispatched_to during discovery');
+    // Self-heal in discoverFromWorkItems only sets DISPATCHED when item is in dispatch.active
+    assert.ok(src.includes('const existingActive = getDispatch().active?.find(d => d.meta?.dispatchKey === key)'),
+      'Self-heal must check dispatch.active before setting dispatched status');
+    // spawnAgent stamps dispatched_to/dispatched_at atomically
+    assert.ok(src.includes('wi.status !== WI_STATUS.DISPATCHED') && src.includes('wi.dispatched_to = wi.dispatched_to || agentId'),
+      'spawnAgent should atomically stamp dispatched status on work items');
+  });
+
+  await test('PRD dispatched sync deferred to dispatch loop after spawnAgent success (#480)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    // Discovery should NOT do PRD sync — it's deferred to after spawn
+    assert.ok(!src.includes("for (const s of prdSyncQueue) syncPrdItemStatus(s.id, 'dispatched', s.sourcePlan)"),
+      'discoverFromWorkItems should NOT sync PRD dispatched status (deferred to dispatch loop)');
+    // Dispatch loop should sync PRD after successful spawn
+    assert.ok(src.includes("syncPrdItemStatus(item.meta.item.id, WI_STATUS.DISPATCHED, item.meta.item.sourcePlan)"),
+      'dispatch loop should sync PRD dispatched status after successful spawnAgent');
   });
 
   await test('Auto-retry reads live work-item retry count before decision', () => {
@@ -3327,12 +3344,25 @@ async function testResolveAgent() {
 
   await test('resolveAgent checks preferred then fallback then idle', () => {
     // Verify the 3-tier resolution order
-    assert.ok(src.includes('if (preferred && isAvailable(preferred))'),
-      'Should check preferred first');
-    assert.ok(src.includes('if (fallback && isAvailable(fallback))'),
-      'Should check fallback second');
+    assert.ok(src.includes('else if (preferred && isAvailable(preferred))'),
+      'Should check preferred first (after _any_ check)');
+    assert.ok(src.includes('else if (fallback && isAvailable(fallback))'),
+      'Should check fallback second (after _any_ check)');
     assert.ok(src.includes('.sort((a, b) => getAgentErrorRate(a) - getAgentErrorRate(b))'),
       'Should sort remaining idle agents by error rate');
+  });
+
+  await test('resolveAgent supports _any_ token for routing to any idle agent (#480)', () => {
+    assert.ok(src.includes("preferred === '_any_'"),
+      'Should handle _any_ token for preferred agent');
+    assert.ok(src.includes("fallback === '_any_'"),
+      'Should handle _any_ token for fallback agent');
+    assert.ok(src.includes('pickAnyIdle'),
+      'Should use pickAnyIdle helper for _any_ resolution');
+    // Verify routing.md uses _any_ for fix fallback
+    const routing = fs.readFileSync(path.join(MINIONS_DIR, 'routing.md'), 'utf8');
+    assert.ok(routing.includes('| fix | _author_ | _any_ |'),
+      'routing.md should use _any_ as fallback for fix tasks');
   });
 
   await test('resolveAgent returns null when no agents available', () => {
@@ -3345,9 +3375,9 @@ async function testResolveAgent() {
       'Should track and check claimed agents per discovery pass');
   });
 
-  await test('resolveAgent excludes preferred and fallback from idle pool', () => {
-    assert.ok(src.includes('id !== preferred && id !== fallback'),
-      'Idle pool should exclude preferred/fallback to avoid rechecking');
+  await test('resolveAgent uses pickAnyIdle to fall back to any idle agent', () => {
+    assert.ok(src.includes('const anyIdle = pickAnyIdle([preferred, fallback])'),
+      'Final fallback should use pickAnyIdle excluding preferred and fallback');
   });
 }
 


### PR DESCRIPTION
## Summary
- **Bug 1**: Work items were marked `dispatched` during discovery before any agent spawned. If agents were busy, items showed `dispatched` in dashboard when no agent was running. Fixed by deferring status to `spawnAgent()` which atomically stamps `dispatched_to/dispatched_at/status`. PRD sync also moved to post-spawn in the dispatch loop.
- **Bug 2**: Fix routing fell through to `dallas` only when `_author_` was null. Added `_any_` token support to the routing resolver — picks any idle agent sorted by error rate. Updated `routing.md` to use `_any_` as fallback for fix tasks.
- Self-heal in discovery only sets `DISPATCHED` when item is in `dispatch.active` (actually spawned), not when in `dispatch.pending` (queued but not yet spawned).

## Files Changed
- `engine.js` — Removed premature DISPATCHED marking in `discoverFromWorkItems` and `discoverCentralWorkItems`. Added PRD sync after successful spawn in dispatch loop. Self-heal only promotes to DISPATCHED when in `dispatch.active`.
- `engine/routing.js` — Added `_any_` token + `pickAnyIdle()` helper for routing resolution.
- `routing.md` — Changed fix fallback from `dallas` to `_any_`, documented `_any_` token.
- `test/unit.test.js` — Updated/added tests for deferred dispatch status, `_any_` routing, and self-heal behavior.

## Test plan
- [x] All 877 unit tests pass (0 failures)
- [ ] Verify fix items route to any idle agent when dallas is busy
- [ ] Verify work items show `pending` in dashboard until agent actually spawns
- [ ] Verify PRD items sync to `dispatched` only after spawn succeeds

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)