### PR TITLE
fix(W-mnp7e5xpelmy): stale build status on ADO auth failure + retry

### DIFF
--- a/dashboard/js/render-prs.js
+++ b/dashboard/js/render-prs.js
@@ -12,8 +12,8 @@ function prRow(pr) {
   const reviewSource = sq.status || effectiveReviewStatus || 'pending';
   const reviewClass = reviewSource === 'approved' ? 'approved' : (reviewSource === 'changes-requested' || reviewSource === 'rejected') ? 'rejected' : reviewSource === 'waiting' ? 'building' : 'draft';
   const reviewLabel = sq.status === 'waiting' ? 'reviewing (minions)' : sq.status ? sq.status + ' (minions)' : (effectiveReviewStatus || 'pending');
-  const buildClass = pr.buildStatus === 'passing' ? 'build-pass' : pr.buildStatus === 'failing' ? 'build-fail' : pr.buildStatus === 'running' ? 'building' : 'no-build';
-  const buildLabel = pr.buildStatus || 'none';
+  const buildClass = pr._buildStatusStale ? 'build-stale' : pr.buildStatus === 'passing' ? 'build-pass' : pr.buildStatus === 'failing' ? 'build-fail' : pr.buildStatus === 'running' ? 'building' : 'no-build';
+  const buildLabel = (pr.buildStatus || 'none') + (pr._buildStatusStale ? ' (stale)' : '');
   const statusClass = pr.status === 'merged' ? 'merged' : pr.status === 'abandoned' ? 'rejected' : pr.status === 'active' ? 'active' : 'draft';
   const statusLabel = pr.status || 'active';
   const url = pr.url || '#';

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -251,6 +251,7 @@
   .pr-badge.build-pass { background: rgba(63,185,80,0.15); color: var(--green); border: 1px solid var(--green); }
   .pr-badge.build-fail { background: rgba(248,81,73,0.15); color: var(--red); border: 1px solid var(--red); }
   .pr-badge.no-build { background: var(--surface); color: var(--muted); border: 1px solid var(--border); }
+  .pr-badge.build-stale { background: rgba(210,153,34,0.15); color: var(--orange); border: 1px dashed var(--orange); }
   .error-details-btn { font-size: var(--text-xs); padding: var(--space-1) var(--space-3); margin-left: var(--space-2); background: rgba(248,81,73,0.15); color: var(--red); border: 1px solid var(--red); border-radius: var(--radius-lg); cursor: pointer; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; }
   .error-details-btn:hover { background: rgba(248,81,73,0.3); }
   .pr-empty { color: var(--muted); font-style: italic; font-size: var(--text-md); padding: var(--space-6) 0; }

--- a/engine.js
+++ b/engine.js
@@ -937,7 +937,7 @@ function reconcileItemsWithPrs(items, allPrs, { onlyIds } = {}) {
 // ─── Inbox Consolidation (extracted to engine/consolidation.js) ──────────────
 
 const { consolidateInbox } = require('./engine/consolidation');
-const { pollPrStatus, pollPrHumanComments, reconcilePrs, checkLiveReviewStatus: adoCheckLiveReview } = require('./engine/ado');
+const { pollPrStatus, pollPrHumanComments, reconcilePrs, checkLiveReviewStatus: adoCheckLiveReview, needsAdoPollRetry } = require('./engine/ado');
 const { pollPrStatus: ghPollPrStatus, pollPrHumanComments: ghPollPrHumanComments, reconcilePrs: ghReconcilePrs, checkLiveReviewStatus: ghCheckLiveReview } = require('./engine/github');
 
 // ─── State Snapshot ─────────────────────────────────────────────────────────
@@ -2447,7 +2447,8 @@ async function tickInner() {
 
   // 2.6. Poll PR status: build, review, merge (every 6 ticks = ~3 minutes)
   // Awaited so PR state is consistent before discoverWork reads it
-  if (tickCount % 6 === 0) {
+  // Also re-polls early if previous tick had ADO auth failures (stale build status recovery)
+  if (tickCount % 6 === 0 || needsAdoPollRetry()) {
     try { await pollPrStatus(config); } catch (err) { log('warn', `ADO PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
     try { await ghPollPrStatus(config); } catch (err) { log('warn', `GitHub PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
     // Sync PR status back to PRD items (missing → done when active PR exists)

--- a/engine/ado.js
+++ b/engine/ado.js
@@ -21,6 +21,20 @@ function engine() {
 let _adoTokenCache = { token: null, expiresAt: 0 };
 let _adoTokenFailedUntil = 0; // backoff: skip azureauth calls until this timestamp
 
+// ─── Auth Failure Tracking ──────────────────────────────────────────────────
+// Set when pollPrStatus encounters auth errors mid-loop. The engine checks this
+// to bypass the normal 6-tick cadence and re-poll on the next tick.
+let _adoPollHadAuthFailure = false;
+
+/** Check if auth failure during PR poll means an early re-poll is needed. */
+function needsAdoPollRetry() { return _adoPollHadAuthFailure; }
+
+/** Detect auth-related errors from adoFetch (HTML redirect, 401, 403). */
+function isAdoAuthError(err) {
+  const msg = err?.message || '';
+  return msg.includes('auth redirect') || msg.includes('HTML instead of JSON') || /ADO API (401|403)/.test(msg);
+}
+
 async function getAdoToken() {
   if (_adoTokenCache.token && Date.now() < _adoTokenCache.expiresAt) {
     return _adoTokenCache.token;
@@ -133,15 +147,22 @@ async function forEachActivePr(config, token, callback) {
 // ─── PR Status Polling ───────────────────────────────────────────────────────
 
 async function pollPrStatus(config) {
+  _adoPollHadAuthFailure = false; // reset before polling — set again if errors recur
+
   const token = await getAdoToken();
   if (!token) {
     log('warn', 'Skipping PR status poll — no ADO token available');
+    _adoPollHadAuthFailure = true; // trigger retry on next tick
     return;
   }
 
   const totalUpdated = await forEachActivePr(config, token, async (project, pr, prNum, orgBase) => {
+    try {
     const repoBase = `${orgBase}/${project.adoProject}/_apis/git/repositories/${project.repositoryId}/pullrequests/${prNum}`;
     let updated = false;
+
+    // Clear stale flag — we're attempting a fresh poll
+    if (pr._buildStatusStale) { delete pr._buildStatusStale; updated = true; }
 
     const prData = await adoFetch(`${repoBase}?api-version=7.1`, token);
 
@@ -278,6 +299,17 @@ async function pollPrStatus(config) {
     }
 
     return updated;
+    } catch (err) {
+      // Auth errors → mark build status stale so dashboard shows uncertainty
+      // and engine re-polls on next tick instead of waiting 6 ticks
+      if (isAdoAuthError(err)) {
+        pr._buildStatusStale = true;
+        _adoPollHadAuthFailure = true;
+        log('warn', `PR ${pr.id}: build status marked stale (auth error: ${err.message})`);
+        return true; // count as updated to persist the stale flag
+      }
+      throw err; // re-throw non-auth errors for forEachActivePr to handle
+    }
   });
 
   if (totalUpdated > 0) {
@@ -520,5 +552,7 @@ module.exports = {
   pollPrHumanComments,
   reconcilePrs,
   checkLiveReviewStatus,
+  needsAdoPollRetry,
+  isAdoAuthError, // exported for testing
 };
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8259,6 +8259,65 @@ async function testPrDuplicateRaceFix() {
     assert.ok(reconcileFn[0].includes('P-[a-z0-9]'), 'must match P- IDs');
   });
 
+  // ── ADO Auth Failure → Stale Build Status ──
+
+  await test('ado.js exports needsAdoPollRetry and isAdoAuthError helpers', () => {
+    const ado = require(path.join(MINIONS_DIR, 'engine', 'ado'));
+    assert.ok(typeof ado.needsAdoPollRetry === 'function', 'needsAdoPollRetry must be exported');
+    assert.ok(typeof ado.isAdoAuthError === 'function', 'isAdoAuthError must be exported');
+  });
+
+  await test('ado.js isAdoAuthError detects auth-related errors', () => {
+    const ado = require(path.join(MINIONS_DIR, 'engine', 'ado'));
+    assert.ok(ado.isAdoAuthError(new Error('ADO returned HTML instead of JSON (likely auth redirect) for https://dev.azure.com/...')),
+      'should detect HTML/auth redirect errors');
+    assert.ok(ado.isAdoAuthError(new Error('ADO API 401: Unauthorized')),
+      'should detect 401 errors');
+    assert.ok(ado.isAdoAuthError(new Error('ADO API 403: Forbidden')),
+      'should detect 403 errors');
+    assert.ok(!ado.isAdoAuthError(new Error('ADO API 500: Internal Server Error')),
+      'should NOT flag 500 errors as auth');
+    assert.ok(!ado.isAdoAuthError(new Error('Network timeout')),
+      'should NOT flag timeout errors as auth');
+  });
+
+  await test('ado.js pollPrStatus sets _buildStatusStale on auth error', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    const pollFn = src.match(/async function pollPrStatus[\s\S]*?^}/m);
+    assert.ok(pollFn, 'pollPrStatus must exist');
+    assert.ok(pollFn[0].includes('_buildStatusStale'), 'pollPrStatus must set _buildStatusStale flag on auth error');
+    assert.ok(pollFn[0].includes('isAdoAuthError'), 'pollPrStatus must use isAdoAuthError to detect auth errors');
+    assert.ok(pollFn[0].includes('_adoPollHadAuthFailure = true'), 'pollPrStatus must set _adoPollHadAuthFailure on auth error');
+    assert.ok(pollFn[0].includes('delete pr._buildStatusStale'), 'pollPrStatus must clear _buildStatusStale on successful poll');
+  });
+
+  await test('ado.js pollPrStatus resets _adoPollHadAuthFailure at start', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    const pollFn = src.match(/async function pollPrStatus[\s\S]*?^}/m);
+    assert.ok(pollFn, 'pollPrStatus must exist');
+    // The flag should be reset at the top of pollPrStatus, before any polling
+    const resetIdx = pollFn[0].indexOf('_adoPollHadAuthFailure = false');
+    assert.ok(resetIdx >= 0, 'pollPrStatus must reset _adoPollHadAuthFailure to false at start');
+    const fetchIdx = pollFn[0].indexOf('adoFetch');
+    assert.ok(resetIdx < fetchIdx, 'reset must happen before any adoFetch calls');
+  });
+
+  await test('engine.js imports needsAdoPollRetry and uses it in tick cadence', () => {
+    const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    assert.ok(engineSrc.includes('needsAdoPollRetry'), 'engine.js must import needsAdoPollRetry');
+    assert.ok(engineSrc.includes('needsAdoPollRetry()'), 'engine.js must call needsAdoPollRetry() in tick loop');
+    // Should be used alongside the 6-tick cadence check
+    assert.ok(engineSrc.includes('tickCount % 6 === 0 || needsAdoPollRetry()'),
+      'engine.js must bypass 6-tick cadence when needsAdoPollRetry() is true');
+  });
+
+  await test('dashboard render-prs.js shows stale build status indicator', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prs.js'), 'utf8');
+    assert.ok(src.includes('_buildStatusStale'), 'render-prs.js must check _buildStatusStale');
+    assert.ok(src.includes('build-stale'), 'render-prs.js must use build-stale CSS class');
+    assert.ok(src.includes('(stale)'), 'render-prs.js must show (stale) label');
+  });
+
   await test('lifecycle.js handlePostMerge branch regex matches all work item ID prefixes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
     const fn = src.match(/async function handlePostMerge[\s\S]*?^}/m);


### PR DESCRIPTION
## Summary

- When ADO token expires mid-tick during `pollPrStatus`, auth errors are caught per-PR and `_buildStatusStale: true` is set on affected PRs so the dashboard shows uncertainty (orange dashed "stale" badge)
- Added `needsAdoPollRetry()` export that the engine checks to bypass the normal 6-tick cadence and re-poll on the very next tick after auth failures
- On successful re-poll, the stale flag is cleared and fresh build status is restored

## Changes

| File | What |
|------|------|
| `engine/ado.js` | Auth failure tracking (`_adoPollHadAuthFailure` flag), `isAdoAuthError()` detector, try-catch in `pollPrStatus` callback to mark stale PRs, `needsAdoPollRetry()` export |
| `engine.js` | Import `needsAdoPollRetry`, bypass 6-tick cadence with `tickCount % 6 === 0 \|\| needsAdoPollRetry()` |
| `dashboard/js/render-prs.js` | Show `(stale)` label and `build-stale` CSS class when `_buildStatusStale` is set |
| `dashboard/styles.css` | Orange dashed border style for `.pr-badge.build-stale` |
| `test/unit.test.js` | 7 new tests covering: exports, auth error detection, stale flag logic, engine cadence bypass, dashboard indicator |

## Test plan

- [x] `npm test` — 881 passed, 0 failed, 2 skipped
- [ ] Verify `_buildStatusStale` flag appears on PRs when ADO token is invalid
- [ ] Verify stale flag is cleared after successful re-poll on next tick
- [ ] Verify dashboard shows orange "(stale)" badge for stale PRs
- [ ] Verify auto-fix agents are dispatched once build failure is detected after recovery

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)