### PR TITLE
feat(P-w9d6j2h8): per-type heartbeat timeouts for read-heavy work types

### DIFF
--- a/engine/shared.js
+++ b/engine/shared.js
@@ -546,6 +546,7 @@ const ENGINE_DEFAULTS = {
   maxBuildFixAttempts: 3, // max consecutive auto-fix dispatch cycles per PR before escalation to human
   ccModel: 'sonnet', // model for Command Center and doc-chat (sonnet, haiku, opus)
   ccEffort: null, // effort level for CC/doc-chat (null, 'low', 'medium', 'high')
+  heartbeatTimeouts: {}, // populated after WORK_TYPE is defined (below)
 };
 
 // ─── Status & Type Constants ─────────────────────────────────────────────────
@@ -563,6 +564,15 @@ const WORK_TYPE = {
   VERIFY: 'verify', PLAN: 'plan', PLAN_TO_PRD: 'plan-to-prd', DECOMPOSE: 'decompose',
   MEETING: 'meeting', EXPLORE: 'explore', ASK: 'ask', TEST: 'test', DOCS: 'docs',
 };
+
+// Per-work-type heartbeat timeouts (ms) — read-heavy tasks need longer silence windows.
+// Keyed by WORK_TYPE constants; types not listed fall back to ENGINE_DEFAULTS.heartbeatTimeout.
+Object.assign(ENGINE_DEFAULTS.heartbeatTimeouts, {
+  [WORK_TYPE.EXPLORE]: 600000,   // 10 min — spends most time reading/analyzing, minimal stdout
+  [WORK_TYPE.ASK]:     600000,   // 10 min — research-heavy, long silent analysis periods
+  [WORK_TYPE.REVIEW]:  480000,   // 8 min — code review reads extensively before producing output
+});
+
 const PLAN_STATUS = {
   ACTIVE: 'active', AWAITING_APPROVAL: 'awaiting-approval', APPROVED: 'approved',
   PAUSED: 'paused', REJECTED: 'rejected', COMPLETED: 'completed',

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -9,7 +9,7 @@ const shared = require('./shared');
 const queries = require('./queries');
 
 const { safeRead, safeWrite, safeJson, mutateJsonFileLocked, getProjects, projectWorkItemsPath, log, ts,
-  ENGINE_DEFAULTS: DEFAULTS, WI_STATUS, DISPATCH_RESULT } = shared;
+  ENGINE_DEFAULTS: DEFAULTS, WI_STATUS, WORK_TYPE, DISPATCH_RESULT } = shared;
 const { getDispatch, getAgentStatus } = queries;
 const AGENTS_DIR = queries.AGENTS_DIR;
 const MINIONS_DIR = shared.MINIONS_DIR;
@@ -130,7 +130,10 @@ function checkTimeouts(config) {
   const { runPostCompletionHooks } = require('./lifecycle');
 
   const timeout = config.engine?.agentTimeout || DEFAULTS.agentTimeout;
-  const heartbeatTimeout = config.engine?.heartbeatTimeout || DEFAULTS.heartbeatTimeout;
+  const defaultHeartbeatTimeout = config.engine?.heartbeatTimeout || DEFAULTS.heartbeatTimeout;
+
+  // Per-work-type heartbeat timeouts: merge defaults with config overrides
+  const perTypeTimeouts = { ...DEFAULTS.heartbeatTimeouts, ...(config.engine?.heartbeatTimeouts || {}) };
 
   // 1. Check tracked processes for hard timeout (supports per-item deadline from fan-out)
   for (const [id, info] of activeProcesses.entries()) {
@@ -150,6 +153,10 @@ function checkTimeouts(config) {
 
   for (const item of (dispatchData.active || [])) {
     if (!item.agent) continue;
+
+    // Per-type heartbeat: look up work type from dispatch item, fall back to default
+    const workType = item.workType || item.meta?.item?.type;
+    const heartbeatTimeout = (workType && perTypeTimeouts[workType]) || defaultHeartbeatTimeout;
 
     const hasProcess = activeProcesses.has(item.id);
     const liveLogPath = path.join(AGENTS_DIR, item.agent, 'live-output.log');

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -523,7 +523,8 @@ async function testEngineDefaults() {
   await test('ENGINE_DEFAULTS has all required keys', () => {
     const required = ['tickInterval', 'maxConcurrent', 'inboxConsolidateThreshold',
       'agentTimeout', 'heartbeatTimeout', 'maxTurns', 'worktreeRoot',
-      'idleAlertMinutes', 'restartGracePeriod', 'worktreeCreateTimeout', 'worktreeCreateRetries'];
+      'idleAlertMinutes', 'restartGracePeriod', 'worktreeCreateTimeout', 'worktreeCreateRetries',
+      'heartbeatTimeouts'];
     for (const key of required) {
       assert.ok(shared.ENGINE_DEFAULTS[key] !== undefined, `Missing default: ${key}`);
     }
@@ -3879,6 +3880,56 @@ async function testCheckTimeouts() {
     const bashBlock = src.slice(src.indexOf("if (name === 'Bash')"), src.indexOf("if (name === 'Bash')") + 300);
     assert.ok(bashBlock.includes('120000') && !bashBlock.includes('600000'),
       'Bash blocking block should use 120000ms, not 600000ms');
+  });
+
+  // ── Per-type heartbeat timeout tests ──
+
+  await test('ENGINE_DEFAULTS.heartbeatTimeouts has explore, ask, review entries', () => {
+    const hbt = shared.ENGINE_DEFAULTS.heartbeatTimeouts;
+    assert.ok(hbt, 'heartbeatTimeouts map should exist');
+    assert.strictEqual(hbt[shared.WORK_TYPE.EXPLORE], 600000, 'EXPLORE should be 600000ms (10min)');
+    assert.strictEqual(hbt[shared.WORK_TYPE.ASK], 600000, 'ASK should be 600000ms (10min)');
+    assert.strictEqual(hbt[shared.WORK_TYPE.REVIEW], 480000, 'REVIEW should be 480000ms (8min)');
+  });
+
+  await test('heartbeatTimeouts keys use WORK_TYPE constants, not raw strings', () => {
+    const hbt = shared.ENGINE_DEFAULTS.heartbeatTimeouts;
+    // Verify the keys are the actual WORK_TYPE values (not something else)
+    assert.ok(Object.keys(hbt).includes(shared.WORK_TYPE.EXPLORE), 'Should use WORK_TYPE.EXPLORE as key');
+    assert.ok(Object.keys(hbt).includes(shared.WORK_TYPE.ASK), 'Should use WORK_TYPE.ASK as key');
+    assert.ok(Object.keys(hbt).includes(shared.WORK_TYPE.REVIEW), 'Should use WORK_TYPE.REVIEW as key');
+  });
+
+  await test('checkTimeouts resolves per-type heartbeat from dispatch item workType', () => {
+    assert.ok(src.includes('item.workType') || src.includes('item.meta?.item?.type'),
+      'Should read work type from dispatch item');
+    assert.ok(src.includes('perTypeTimeouts'),
+      'Should look up per-type timeout from merged map');
+    assert.ok(src.includes('defaultHeartbeatTimeout'),
+      'Should fall back to default heartbeat timeout when work type has no override');
+  });
+
+  await test('checkTimeouts merges config.engine.heartbeatTimeouts with defaults', () => {
+    assert.ok(src.includes('config.engine?.heartbeatTimeouts'),
+      'Should read heartbeatTimeouts from config for user overrides');
+    assert.ok(src.includes('...DEFAULTS.heartbeatTimeouts'),
+      'Should spread default heartbeatTimeouts as base');
+  });
+
+  await test('per-type heartbeat is base for blocking tool extension', () => {
+    // The per-type heartbeatTimeout is declared inside the per-item loop,
+    // so blocking tool detection (which uses heartbeatTimeout) naturally uses the per-type value.
+    // Verify heartbeatTimeout is scoped inside the item loop, not outside it.
+    const loopStart = src.indexOf('for (const item of (dispatchData.active');
+    const perTypeDecl = src.indexOf('const heartbeatTimeout = (workType && perTypeTimeouts');
+    assert.ok(loopStart > 0 && perTypeDecl > loopStart,
+      'heartbeatTimeout should be declared inside the per-item loop (per-type scoping)');
+  });
+
+  await test('implement/fix types fall back to default heartbeatTimeout (no override)', () => {
+    const hbt = shared.ENGINE_DEFAULTS.heartbeatTimeouts;
+    assert.strictEqual(hbt[shared.WORK_TYPE.IMPLEMENT], undefined, 'IMPLEMENT should not have per-type override');
+    assert.strictEqual(hbt[shared.WORK_TYPE.FIX], undefined, 'FIX should not have per-type override');
   });
 }
 


### PR DESCRIPTION
## Summary

- **Adds per-work-type heartbeat timeouts** to `ENGINE_DEFAULTS.heartbeatTimeouts` in `engine/shared.js` — explore/ask get 10min, review gets 8min, all others fall back to the existing 5min default
- **Updates `checkTimeouts()` in `engine/timeout.js`** to resolve per-type timeout from dispatch item `workType` or `meta.item.type` before falling back to default; blocking-tool heuristic extension still works on top of the per-type base
- **Config override** supported via `config.engine.heartbeatTimeouts` (merged with defaults)
- **7 new unit tests** covering per-type lookup, WORK_TYPE constant keys, config merge, blocking extension scoping, and fallback behavior

## Why

The uniform 300s (5min) heartbeat timeout causes false-positive agent kills on long-running read-only tasks. Explore, ask, and review work types legitimately produce no stdout for longer periods because they spend more time reading and analyzing.

## Files Changed

| File | Change |
|------|--------|
| `engine/shared.js` | `heartbeatTimeouts` map added to `ENGINE_DEFAULTS`, populated via `Object.assign` after `WORK_TYPE` is defined |
| `engine/timeout.js` | Per-item `heartbeatTimeout` resolved from `perTypeTimeouts` map inside the heartbeat loop |
| `test/unit.test.js` | 7 new tests in `testCheckTimeouts` and `testEngineDefaults` |

## Test plan

- [x] `npm test` — all 971 tests pass, 0 failures
- [ ] Verify explore/ask agents are not killed prematurely during long silent reads
- [ ] Verify implement/fix agents still use 5min default timeout
- [ ] Verify `config.engine.heartbeatTimeouts` override works at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)