### PR TITLE
feat(P-k7x2m9q4): fix dispatch.json race condition in CLI kill-all

### DIFF
--- a/engine/cli.js
+++ b/engine/cli.js
@@ -18,6 +18,9 @@ function engine() {
   return _engine;
 }
 
+let _dispatchModule = null;
+function dispatchModule() { if (!_dispatchModule) _dispatchModule = require('./dispatch'); return _dispatchModule; }
+
 function handleCommand(cmd, args) {
   if (!cmd) {
     commands.start();
@@ -932,8 +935,9 @@ const commands = {
 
       console.log(`Killed dispatch: ${item.id} (${item.agent}) — work item reset to pending`);
     }
-    dispatch.active = [];
-    safeWrite(DISPATCH_PATH, dispatch);
+    // Clear active dispatches atomically under file lock (avoids race with engine tick writes)
+    const { mutateDispatch } = dispatchModule();
+    mutateDispatch(d => { d.active = []; return d; });
 
     // Agent status derived from dispatch.json — clearing dispatch.active is sufficient.
     console.log('All agents reset to idle (dispatch cleared)');

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2267,9 +2267,10 @@ async function testStateIntegrity() {
     const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
     const dispatchSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');
     const cleanupSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+    const cliSrcDisp = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
 
     // Extract all mutateDispatch callback bodies from each file
-    for (const [name, src] of [['engine.js', engineSrc], ['dispatch.js', dispatchSrc], ['cleanup.js', cleanupSrc]]) {
+    for (const [name, src] of [['engine.js', engineSrc], ['dispatch.js', dispatchSrc], ['cleanup.js', cleanupSrc], ['cli.js', cliSrcDisp]]) {
       // Find all mutateDispatch( occurrences (skip the definition itself)
       const pattern = /mutateDispatch\(\((\w+)\)\s*=>\s*\{/g;
       let match;
@@ -2296,6 +2297,22 @@ async function testStateIntegrity() {
         }
       }
     }
+  });
+
+  await test('cli.js kill handler clears dispatch.active via mutateDispatch, not safeWrite', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    // Find the kill() handler body
+    const killIdx = src.indexOf('kill()');
+    assert.ok(killIdx > 0, 'cli.js must have a kill() handler');
+    const killSection = src.substring(killIdx, killIdx + 2000);
+    // Must NOT use safeWrite for dispatch.json
+    assert.ok(!killSection.includes('safeWrite(DISPATCH_PATH'),
+      'kill handler must not use safeWrite(DISPATCH_PATH) — use mutateDispatch for concurrency safety');
+    // Must use mutateDispatch to clear active
+    assert.ok(killSection.includes('mutateDispatch'),
+      'kill handler must use mutateDispatch to clear active dispatches under file lock');
+    assert.ok(killSection.includes('d.active = []') || killSection.includes('.active = []'),
+      'kill handler must clear active array inside mutateDispatch callback');
   });
 
   await test('spawnAgent null return is handled in dispatch loop', () => {


### PR DESCRIPTION
## Summary
- Replace `safeWrite(DISPATCH_PATH, dispatch)` with `mutateDispatch(d => { d.active = []; return d; })` in the CLI kill-all handler (`engine/cli.js`)
- This acquires a file lock before clearing active dispatches, preventing data loss when kill-all overlaps with an engine tick write
- Added lazy `dispatchModule()` require for `engine/dispatch.js` following the existing pattern used in `cleanup.js` and `timeout.js`

## Test plan
- [x] Added source-pattern test verifying kill handler uses `mutateDispatch`, not `safeWrite(DISPATCH_PATH)`
- [x] Extended existing `mutateDispatch` callback return-value test to also scan `cli.js`
- [x] All 966 unit tests pass with 0 regressions

**Plan:** minions-2026-04-09-2.json | **Item:** P-k7x2m9q4

🤖 Generated with [Claude Code](https://claude.com/claude-code)