### PR TITLE
[E2E] Bidirectional Teams integration for Command Center

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -2095,6 +2095,9 @@ If nothing to do: { "duplicates": [], "reclassify": [], "remove": [] }`;
         }, { defaultValue: { pending: [], active: [], completed: [] } });
       }
 
+      // Teams notification for plan approval — non-blocking
+      try { teams.teamsNotifyPlanEvent({ name: plan.plan_summary || body.file, file: body.file }, 'plan-approved').catch(() => {}); } catch {}
+
       invalidateStatusCache();
       return jsonReply(res, 200, { ok: true, status: 'approved', resumedWorkItems: resumed });
     } catch (e) { return jsonReply(res, 400, { error: e.message }); }
@@ -2303,6 +2306,10 @@ If nothing to do: { "duplicates": [], "reclassify": [], "remove": [] }`;
       plan.rejectedBy = body.rejectedBy || os.userInfo().username;
       if (body.reason) plan.rejectionReason = body.reason;
       safeWrite(planPath, plan);
+
+      // Teams notification for plan rejection — non-blocking
+      try { teams.teamsNotifyPlanEvent({ name: plan.plan_summary || body.file, file: body.file }, 'plan-rejected').catch(() => {}); } catch {}
+
       return jsonReply(res, 200, { ok: true, status: 'rejected' });
     } catch (e) { return jsonReply(res, 400, { error: e.message }); }
   }

--- a/dashboard.js
+++ b/dashboard.js
@@ -3307,6 +3307,11 @@ What would you like to discuss or change? When you're happy, say "approve" and I
           });
         }
 
+        // Mirror CC response to Teams (non-blocking, skip Teams-originated)
+        if (!tabId.startsWith('teams-')) {
+          teams.teamsPostCCResponse(body.message, result.text).catch(() => {});
+        }
+
         return jsonReply(res, 200, { ...parseCCActions(result.text), sessionId: ccSession.sessionId, newSession: !wasResume });
       } finally {
         ccInFlightTabs.delete(tabId);
@@ -3413,6 +3418,13 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         // Send final result with actions
         const { text: displayText, actions } = parseCCActions(result.text);
         res.write('data: ' + JSON.stringify({ type: 'done', text: displayText, actions, sessionId: ccSession.sessionId, newSession: !wasResume }) + '\n\n');
+
+        // Mirror CC response to Teams (non-blocking, skip Teams-originated)
+        const _streamTabId = body.tabId || 'default';
+        if (!_streamTabId.startsWith('teams-')) {
+          teams.teamsPostCCResponse(body.message, result.text).catch(() => {});
+        }
+
         res.end();
       } finally {
         ccInFlightTabs.delete(tabId);

--- a/dashboard.js
+++ b/dashboard.js
@@ -20,6 +20,7 @@ const _dashboardVersion = {
 };
 const shared = require('./engine/shared');
 const queries = require('./engine/queries');
+const teams = require('./engine/teams');
 const os = require('os');
 
 const { safeRead, safeReadDir, safeWrite, safeJson, safeJsonObj, safeJsonArr, safeUnlink, mutateJsonFileLocked, mutateWorkItems, getProjects: _getProjects, DONE_STATUSES, WI_STATUS } = shared;
@@ -38,6 +39,7 @@ function reloadConfig() {
 }
 
 const PLANS_DIR = path.join(MINIONS_DIR, 'plans');
+const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json');
 
 // Resolve a plan/PRD file path: .json files live in prd/, .md files in plans/
 // Validates that the file stays within the expected directory to prevent path traversal.
@@ -3703,6 +3705,93 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     }
   }
 
+  // ── Teams Bot Handler ─────────────────────────────────────────────────────
+
+  async function handleTeamsBot(req, res) {
+    if (!teams.isTeamsEnabled()) {
+      return jsonReply(res, 503, { error: 'Teams integration disabled' }, req);
+    }
+    const adapter = teams.createAdapter();
+    if (!adapter) {
+      return jsonReply(res, 503, { error: 'Teams adapter unavailable' }, req);
+    }
+    try {
+      await adapter.process(req, res, async (context) => {
+        const activity = context.activity;
+        const cfg = teams.getTeamsConfig();
+
+        // Save conversation reference on install/member events
+        if (activity.type === 'conversationUpdate' && activity.membersAdded?.length) {
+          const ref = context.activity.conversation?.id;
+          if (ref) {
+            const convRef = {
+              activityId: activity.id,
+              user: activity.from,
+              bot: activity.recipient,
+              conversation: activity.conversation,
+              channelId: activity.channelId,
+              locale: activity.locale,
+              serviceUrl: activity.serviceUrl,
+            };
+            teams.saveConversationRef(activity.conversation.id, convRef);
+            shared.log('info', `Teams conversationUpdate: saved ref for ${activity.conversation.id}`);
+          }
+        }
+
+        if (activity.type === 'installationUpdate') {
+          const convRef = {
+            activityId: activity.id,
+            user: activity.from,
+            bot: activity.recipient,
+            conversation: activity.conversation,
+            channelId: activity.channelId,
+            locale: activity.locale,
+            serviceUrl: activity.serviceUrl,
+          };
+          if (activity.conversation?.id) {
+            teams.saveConversationRef(activity.conversation.id, convRef);
+            shared.log('info', `Teams installationUpdate: saved ref for ${activity.conversation.id}`);
+          }
+        }
+
+        // Handle incoming messages
+        if (activity.type === 'message' && activity.text) {
+          // Filter bot's own echo messages
+          if (activity.from?.id === cfg.appId) return;
+
+          const msgId = `teams-${Date.now()}-${shared.uid()}`;
+          const convRef = {
+            activityId: activity.id,
+            user: activity.from,
+            bot: activity.recipient,
+            conversation: activity.conversation,
+            channelId: activity.channelId,
+            locale: activity.locale,
+            serviceUrl: activity.serviceUrl,
+          };
+          mutateJsonFileLocked(TEAMS_INBOX_PATH, (inbox) => {
+            if (!Array.isArray(inbox)) inbox = [];
+            inbox.push({
+              id: msgId,
+              text: activity.text,
+              from: activity.from?.name || activity.from?.id || 'unknown',
+              conversationRef: convRef,
+              receivedAt: new Date().toISOString(),
+              _processedAt: null,
+            });
+            return inbox;
+          }, { defaultValue: [] });
+          shared.log('info', `Teams message received from ${activity.from?.name || 'unknown'}: ${activity.text.slice(0, 80)}`);
+        }
+      });
+    } catch (err) {
+      shared.log('warn', `Teams bot handler error: ${err.message}`);
+      if (!res.headersSent) {
+        return jsonReply(res, 500, { error: 'Bot processing failed' }, req);
+      }
+    }
+  }
+
   // ── Route Registry ──────────────────────────────────────────────────────────
   // Order matters: specific routes before general ones (e.g., /api/plans/approve before /api/plans/:file)
 
@@ -4305,6 +4394,9 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     { method: 'POST', path: '/api/settings', desc: 'Update engine + claude + agent config', params: 'engine?, claude?, agents?', handler: handleSettingsUpdate },
     { method: 'POST', path: '/api/settings/routing', desc: 'Update routing.md', params: 'content', handler: handleSettingsRouting },
     { method: 'POST', path: '/api/settings/reset', desc: 'Reset engine + claude + agent settings to defaults', handler: handleSettingsReset },
+
+    // Teams Bot Framework webhook
+    { method: 'POST', path: '/api/bot', desc: 'Bot Framework webhook for Teams integration', handler: handleTeamsBot },
   ];
 
   // ── Route Dispatcher ────────────────────────────────────────────────────────

--- a/docs/teams-production.md
+++ b/docs/teams-production.md
@@ -1,0 +1,368 @@
+# Teams Production Endpoint Migration
+
+Guide for migrating the Minions Teams bot from a Dev Tunnel to a stable public HTTPS endpoint for production use. Choose one of the three deployment options below based on your infrastructure.
+
+**Key fact:** The Azure Bot messaging endpoint URL can be changed at any time in the Azure Portal — it takes effect immediately. No bot reinstallation is needed in Teams. This means you can switch between Dev Tunnel and production endpoints freely.
+
+**Prerequisites:**
+
+- A working Teams integration via Dev Tunnel (see [docs/teams-setup.md](teams-setup.md))
+- Azure CLI installed (`az --version`) for Options 1 and 2
+- A public-facing server or VM for Option 3
+
+---
+
+## Option 1: Azure App Service
+
+Deploy the Minions dashboard as an Azure App Service with a stable FQDN.
+
+### Steps
+
+1. **Create an App Service Plan** (skip if you have one):
+
+   ```bash
+   az appservice plan create \
+     --name minions-plan \
+     --resource-group rg-minions \
+     --sku B1 \
+     --is-linux
+   ```
+
+2. **Create the Web App:**
+
+   ```bash
+   az webapp create \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --plan minions-plan \
+     --runtime "NODE:20-lts"
+   ```
+
+   This creates a publicly accessible URL: `https://minions-dashboard.azurewebsites.net`
+
+3. **Configure environment variables:**
+
+   ```bash
+   az webapp config appsettings set \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --settings \
+       PORT=8080 \
+       NODE_ENV=production
+   ```
+
+   > Azure App Service routes external port 443 (HTTPS) to your app's internal port (default 8080). Set `PORT=8080` so the dashboard listens on the expected port.
+
+4. **Deploy the code:**
+
+   ```bash
+   # From the minions repository root
+   az webapp deploy \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --src-path . \
+     --type zip
+   ```
+
+   Alternatively, configure continuous deployment from your Git repository:
+
+   ```bash
+   az webapp deployment source config \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --repo-url https://github.com/your-org/minions \
+     --branch master \
+     --manual-integration
+   ```
+
+5. **Copy `config.json` to the App Service.** The simplest approach is to use the Kudu console or App Service Editor to upload your `config.json` to the application root. Alternatively, mount an Azure File Share containing your config.
+
+6. **Update the Azure Bot messaging endpoint:**
+
+   - Open the [Azure Portal](https://portal.azure.com) > your Azure Bot resource > **Configuration**.
+   - Change the **Messaging endpoint** to:
+     ```
+     https://minions-dashboard.azurewebsites.net/api/bot
+     ```
+   - Click **Apply**. The change takes effect immediately.
+
+### Verify
+
+1. Open `https://minions-dashboard.azurewebsites.net/api/routes` in a browser — you should see the API route list.
+2. In the Azure Bot resource, click **Test in Web Chat** and send a message.
+3. Send a message in Teams to the bot — confirm it receives and responds.
+
+### Rollback
+
+To revert to Dev Tunnel:
+
+1. Start your local Dev Tunnel: `devtunnel host -p 7331 --allow-anonymous`
+2. Update the Azure Bot messaging endpoint back to your tunnel URL: `https://<tunnel>.devtunnels.ms/api/bot`
+3. Click **Apply**. Traffic returns to your local machine immediately.
+
+---
+
+## Option 2: Azure Container App
+
+Containerize the dashboard and deploy to Azure Container Apps with a stable FQDN.
+
+### Steps
+
+1. **Create a Dockerfile** in the repository root:
+
+   ```dockerfile
+   FROM node:20-slim
+   WORKDIR /app
+   COPY package*.json ./
+   RUN npm ci --omit=dev 2>/dev/null || true
+   COPY . .
+   EXPOSE 7331
+   CMD ["node", "dashboard.js"]
+   ```
+
+   > Minions has zero npm dependencies beyond Node.js built-ins, so `npm ci` may be a no-op. The botbuilder package (added by this feature branch) is the exception.
+
+2. **Build and push to Azure Container Registry:**
+
+   ```bash
+   # Create a container registry (skip if you have one)
+   az acr create \
+     --name minionsacr \
+     --resource-group rg-minions \
+     --sku Basic
+
+   # Build and push
+   az acr build \
+     --registry minionsacr \
+     --image minions-dashboard:latest .
+   ```
+
+3. **Create a Container Apps environment** (skip if you have one):
+
+   ```bash
+   az containerapp env create \
+     --name minions-env \
+     --resource-group rg-minions \
+     --location eastus
+   ```
+
+4. **Deploy the container:**
+
+   ```bash
+   az containerapp create \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --environment minions-env \
+     --image minionsacr.azurecr.io/minions-dashboard:latest \
+     --registry-server minionsacr.azurecr.io \
+     --target-port 7331 \
+     --ingress external \
+     --min-replicas 1 \
+     --max-replicas 1 \
+     --env-vars NODE_ENV=production
+   ```
+
+   > Use `--min-replicas 1 --max-replicas 1` because the Minions engine uses file-based state that doesn't support multiple replicas.
+
+5. **Get the FQDN:**
+
+   ```bash
+   az containerapp show \
+     --name minions-dashboard \
+     --resource-group rg-minions \
+     --query "properties.configuration.ingress.fqdn" \
+     --output tsv
+   ```
+
+   This returns something like: `minions-dashboard.happyfield-abc123.eastus.azurecontainerapps.io`
+
+6. **Update the Azure Bot messaging endpoint:**
+
+   - Open the [Azure Portal](https://portal.azure.com) > your Azure Bot resource > **Configuration**.
+   - Change the **Messaging endpoint** to:
+     ```
+     https://minions-dashboard.happyfield-abc123.eastus.azurecontainerapps.io/api/bot
+     ```
+   - Click **Apply**. The change takes effect immediately.
+
+### Verify
+
+1. Open `https://<your-fqdn>/api/routes` in a browser.
+2. Test via Azure Bot **Test in Web Chat**.
+3. Send a message in Teams — confirm end-to-end flow works.
+
+### Rollback
+
+To revert to Dev Tunnel:
+
+1. Start your local Dev Tunnel: `devtunnel host -p 7331 --allow-anonymous`
+2. Update the Azure Bot messaging endpoint back to your tunnel URL.
+3. Click **Apply**. Immediate switchover.
+
+Optionally stop the container to save costs:
+
+```bash
+az containerapp update \
+  --name minions-dashboard \
+  --resource-group rg-minions \
+  --min-replicas 0 --max-replicas 0
+```
+
+---
+
+## Option 3: Reverse Proxy (nginx / Caddy)
+
+For servers with a public IP address or an existing reverse proxy setup.
+
+### Steps (Caddy — recommended for simplicity)
+
+Caddy automatically provisions and renews TLS certificates via Let's Encrypt.
+
+1. **Install Caddy:**
+
+   ```bash
+   # Debian/Ubuntu
+   sudo apt install -y caddy
+
+   # macOS
+   brew install caddy
+   ```
+
+2. **Configure Caddy.** Create or edit `/etc/caddy/Caddyfile`:
+
+   ```
+   minions.yourdomain.com {
+     reverse_proxy localhost:7331
+   }
+   ```
+
+   > Replace `minions.yourdomain.com` with your actual domain. Ensure a DNS A record points this domain to your server's public IP.
+
+3. **Start Caddy:**
+
+   ```bash
+   sudo systemctl enable --now caddy
+   ```
+
+   Caddy automatically obtains a Let's Encrypt TLS certificate for your domain.
+
+4. **Start the Minions dashboard:**
+
+   ```bash
+   minions dash
+   ```
+
+   Or run it as a systemd service for persistence:
+
+   ```bash
+   # /etc/systemd/system/minions-dashboard.service
+   [Unit]
+   Description=Minions Dashboard
+   After=network.target
+
+   [Service]
+   Type=simple
+   User=your-user
+   WorkingDirectory=/path/to/minions
+   ExecStart=/usr/bin/node dashboard.js
+   Restart=on-failure
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+   ```bash
+   sudo systemctl enable --now minions-dashboard
+   ```
+
+5. **Update the Azure Bot messaging endpoint:**
+
+   - Open the Azure Portal > your Azure Bot resource > **Configuration**.
+   - Change the **Messaging endpoint** to:
+     ```
+     https://minions.yourdomain.com/api/bot
+     ```
+   - Click **Apply**. The change takes effect immediately.
+
+### Steps (nginx)
+
+1. **Install nginx and certbot:**
+
+   ```bash
+   sudo apt install -y nginx certbot python3-certbot-nginx
+   ```
+
+2. **Configure nginx.** Create `/etc/nginx/sites-available/minions`:
+
+   ```nginx
+   server {
+     listen 80;
+     server_name minions.yourdomain.com;
+
+     location / {
+       proxy_pass http://localhost:7331;
+       proxy_http_version 1.1;
+       proxy_set_header Upgrade $http_upgrade;
+       proxy_set_header Connection 'upgrade';
+       proxy_set_header Host $host;
+       proxy_set_header X-Real-IP $remote_addr;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+     }
+   }
+   ```
+
+   ```bash
+   sudo ln -s /etc/nginx/sites-available/minions /etc/nginx/sites-enabled/
+   sudo nginx -t && sudo systemctl reload nginx
+   ```
+
+3. **Obtain a TLS certificate:**
+
+   ```bash
+   sudo certbot --nginx -d minions.yourdomain.com
+   ```
+
+   Certbot modifies the nginx config to add TLS and sets up auto-renewal.
+
+4. **Start the Minions dashboard** (same as Caddy option above).
+
+5. **Update the Azure Bot messaging endpoint** (same as Caddy option above).
+
+### Verify
+
+1. Open `https://minions.yourdomain.com/api/routes` in a browser — confirm the route list loads over HTTPS.
+2. Check the TLS certificate: `curl -vI https://minions.yourdomain.com 2>&1 | grep "SSL certificate"`.
+3. Test via Azure Bot **Test in Web Chat**.
+4. Send a message in Teams — confirm the bot responds.
+
+### Rollback
+
+To revert to Dev Tunnel:
+
+1. Start your local Dev Tunnel: `devtunnel host -p 7331 --allow-anonymous`
+2. Update the Azure Bot messaging endpoint back to your tunnel URL.
+3. Click **Apply**. Immediate switchover.
+
+The reverse proxy can remain running — it just won't receive Bot Framework traffic until the endpoint is pointed back.
+
+---
+
+## Choosing an Option
+
+| Criteria | App Service | Container App | Reverse Proxy |
+|----------|-------------|---------------|---------------|
+| Setup complexity | Medium | Medium | Low (Caddy) / Medium (nginx) |
+| TLS management | Automatic | Automatic | Automatic (Caddy/certbot) |
+| Cost | ~$13/mo (B1) | Pay-per-use | Free (your server + Let's Encrypt) |
+| Custom domain | Supported | Supported | Required |
+| Scaling | Supported but not needed | Supported but not needed | Manual |
+| Best for | Azure-native teams | Container workflows | Existing servers |
+
+> **Note on replicas:** Minions uses file-based state (`engine/*.json`). Do not run multiple replicas — use exactly 1 instance. All three options above default to single-instance deployment.
+
+## Common Notes
+
+- **Endpoint changes are immediate.** When you update the messaging endpoint in the Azure Bot Configuration, it takes effect right away. No bot reinstallation, no downtime, no user-visible change in Teams.
+- **No deprecated webhooks.** This guide uses Azure Bot Framework exclusively. Do not use deprecated O365 Connector webhooks or Power Automate flows — they are being removed by Microsoft.
+- **Config portability.** The same `config.json` works across all environments. Just ensure the `teams.appId` and `teams.appPassword` are correct for the bot registration that points to your production URL.

--- a/docs/teams-setup.md
+++ b/docs/teams-setup.md
@@ -1,0 +1,300 @@
+# Teams Integration Setup
+
+End-to-end guide for connecting Minions to Microsoft Teams via Azure Bot Framework. After completing these steps, messages sent to a Teams channel will be routed to the Minions Command Center, and agent events (completions, PR merges, plan updates) will be posted back to Teams.
+
+**Prerequisites:**
+
+- An Azure subscription (free tier works)
+- Azure CLI installed (`az --version`) or access to the [Azure Portal](https://portal.azure.com)
+- Dev Tunnel CLI installed (`devtunnel --version`) — see [Step 5](#step-5-set-up-dev-tunnel) for installation
+- Minions dashboard running locally (`minions dash`)
+- Admin or owner permissions on the target Teams team (for side-loading)
+
+## Step 1: Create an Azure Bot Resource
+
+1. Open the [Azure Portal](https://portal.azure.com) and search for **Azure Bot** in the top search bar.
+2. Click **Create**.
+3. Fill in the basics:
+   - **Bot handle**: A unique name (e.g., `minions-bot`). This is the internal identifier — it doesn't appear in Teams.
+   - **Subscription**: Select your Azure subscription.
+   - **Resource group**: Create a new one (e.g., `rg-minions`) or use an existing one.
+   - **Data residency**: Choose **Global** unless you have regional compliance requirements.
+   - **Pricing tier**: Select **F0 (Free)** for development.
+4. Under **Microsoft App ID**, select **Single Tenant**.
+   - Choose **Create new Microsoft App ID**.
+   - This creates a new Entra ID (Azure AD) app registration for the bot.
+
+   > **Why Single Tenant?** Single-tenant bots only accept tokens from your Azure AD tenant, which is more secure for an internal tool like Minions. Multi-tenant is needed only if the bot must work across organizations.
+
+5. Click **Review + create**, then **Create**.
+6. Wait for deployment to complete (usually under 1 minute), then click **Go to resource**.
+
+## Step 2: Configure the Teams Channel
+
+1. In your Azure Bot resource, click **Channels** in the left sidebar.
+2. Click the **Microsoft Teams** icon in the available channels list.
+3. Accept the Terms of Service.
+4. Leave the channel settings at defaults:
+   - **Messaging** tab: Enabled (default).
+   - **Calling** and **Group Chat** tabs: Leave disabled unless needed.
+5. Click **Apply**.
+
+The Teams channel should now appear as **Running** in the channels list.
+
+## Step 3: Obtain App ID and App Password
+
+You need two credentials: the **App ID** (also called Microsoft App ID or Client ID) and the **App Password** (a client secret).
+
+### Get the App ID
+
+1. In your Azure Bot resource, click **Configuration** in the left sidebar.
+2. Copy the **Microsoft App ID** value. This is a GUID like `a1b2c3d4-e5f6-7890-abcd-ef1234567890`.
+3. Save it — you'll add it to your Minions config.
+
+### Create an App Password (Client Secret)
+
+1. On the same **Configuration** page, click **Manage Password** next to the Microsoft App ID. This opens the Entra ID app registration.
+2. In the app registration, click **Certificates & secrets** in the left sidebar.
+3. Click **New client secret**.
+4. Enter a description (e.g., `minions-bot-secret`) and choose an expiry (e.g., 24 months).
+5. Click **Add**.
+6. **Immediately copy the secret Value** (not the Secret ID). It is shown only once — if you navigate away, you cannot retrieve it again.
+
+### Add Credentials to Minions Config
+
+Add a `teams` section to your `config.json`:
+
+```json
+{
+  "projects": [ ... ],
+  "agents": { ... },
+  "engine": { ... },
+  "teams": {
+    "enabled": true,
+    "appId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "appPassword": "your-client-secret-value-here",
+    "notifyEvents": ["pr-merged", "agent-completed", "plan-completed", "agent-failed"],
+    "ccMirror": true,
+    "inboxPollInterval": 15000
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Master switch — `true` to activate Teams integration |
+| `appId` | Microsoft App ID from the Azure Bot Configuration page |
+| `appPassword` | Client secret value from Entra ID Certificates & secrets |
+| `notifyEvents` | Which events trigger Teams notifications (see below) |
+| `ccMirror` | Mirror CC dashboard responses to Teams (`true`/`false`) |
+| `inboxPollInterval` | How often to check for new Teams messages, in ms (default: 15000) |
+
+**Available notification events:** `pr-merged`, `agent-completed`, `plan-completed`, `agent-failed`, `pr-abandoned`, `pr-approved`, `pr-build-failed`, `plan-approved`, `plan-rejected`, `verify-created`
+
+> **Security note:** `config.json` is gitignored by default and should never be committed. For shared machines, consider setting the app password via an environment variable and reading it in your config setup.
+
+## Step 4: Set the Messaging Endpoint
+
+The messaging endpoint is the URL that Azure Bot Framework sends incoming messages to. It must point to your Minions dashboard's `/api/bot` route.
+
+1. In your Azure Bot resource, click **Configuration** in the left sidebar.
+2. Set the **Messaging endpoint** to:
+   ```
+   https://<your-tunnel-url>/api/bot
+   ```
+   For local development, this will be your Dev Tunnel URL (see [Step 5](#step-5-set-up-dev-tunnel)).
+
+   For example: `https://abc123.devtunnels.ms/api/bot`
+
+3. Click **Apply** to save.
+
+> The endpoint must be **HTTPS**. Bot Framework will not send messages to plain HTTP URLs. Dev Tunnels and production hosting (Azure App Service, etc.) both provide HTTPS by default.
+
+> Changes to the messaging endpoint take effect immediately — no need to reinstall the bot in Teams.
+
+## Step 5: Set Up Dev Tunnel
+
+[Dev Tunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/overview) create a public HTTPS URL that forwards traffic to your local machine. This lets Azure Bot Framework reach your locally running dashboard.
+
+### Install Dev Tunnel CLI
+
+If you don't have it installed:
+
+```bash
+# Windows (winget)
+winget install Microsoft.devtunnel
+
+# macOS (Homebrew)
+brew install --cask devtunnel
+
+# Linux (curl)
+curl -sL https://aka.ms/DevTunnelCliInstall | bash
+```
+
+### Authenticate
+
+```bash
+devtunnel user login
+```
+
+This opens a browser for Microsoft account authentication. Sign in with the same account that has access to your Azure subscription.
+
+### Start the Tunnel
+
+```bash
+devtunnel host -p 7331 --allow-anonymous
+```
+
+- `-p 7331` forwards to the Minions dashboard port.
+- `--allow-anonymous` allows Bot Framework to reach the endpoint without additional auth (the Bot Framework adapter handles its own authentication via the App ID and Password).
+
+You'll see output like:
+
+```
+Connect via browser: https://abc123.devtunnels.ms
+Inspect network activity: https://abc123-7331.devtunnels.ms
+
+Hosting port: 7331
+  Connect via browser: https://abc123-7331.devtunnels.ms
+```
+
+### Copy the Forwarding URL to Azure Bot
+
+1. Copy the **port-specific** tunnel URL from the output (e.g., `https://abc123-7331.devtunnels.ms`).
+2. Go back to your Azure Bot resource > **Configuration**.
+3. Set the **Messaging endpoint** to:
+   ```
+   https://abc123-7331.devtunnels.ms/api/bot
+   ```
+4. Click **Apply**.
+
+### Persistent Tunnel (Optional)
+
+By default, the tunnel URL changes each time you restart `devtunnel host`. To get a persistent URL:
+
+```bash
+# Create a named tunnel
+devtunnel create minions-tunnel
+
+# Add the port
+devtunnel port create minions-tunnel -p 7331
+
+# Host with anonymous access
+devtunnel host minions-tunnel --allow-anonymous
+```
+
+The named tunnel keeps the same URL across restarts — you won't need to update the Azure Bot messaging endpoint each time.
+
+### Verify Connectivity
+
+With the tunnel running and the dashboard started (`minions dash`), open the tunnel URL in a browser:
+
+```
+https://abc123-7331.devtunnels.ms/api/routes
+```
+
+You should see the Minions API route list as JSON. If you get a connection error, check that:
+- The dashboard is running (`minions dash`)
+- The tunnel is active (`devtunnel host` is still running)
+- The port number matches (7331)
+
+## Step 6: Install the Bot in Teams
+
+There are two ways to add the bot to a Teams channel: via App Studio / Teams Developer Portal (recommended for development) or via the Teams Admin Center (for org-wide deployment).
+
+### Option A: Teams Developer Portal (Recommended for Development)
+
+1. Open [Teams Developer Portal](https://dev.teams.microsoft.com/apps) in a browser.
+2. Click **New app**.
+3. Fill in the app details:
+   - **Name**: `Minions Bot` (or any display name)
+   - **Short description**: `Minions agent orchestration`
+   - **Developer name**: Your name or team name
+   - **Website**: `https://github.com/yemi33/minions` (or any URL)
+   - **Privacy policy** and **Terms of use**: Can be any URL for development
+4. Under **App features**, click **Bot**.
+5. Select **Enter a bot ID manually** and paste the **App ID** from [Step 3](#step-3-obtain-app-id-and-app-password).
+6. Check the scopes:
+   - **Team** — enables the bot in team channels
+   - **Group chat** — optional, enables the bot in group chats
+7. Click **Save**.
+8. Click **Publish** > **Publish to your org** (or **Download app package** to side-load manually).
+
+### Side-Load the App Package
+
+If your organization doesn't allow direct publishing:
+
+1. In the Developer Portal, click **Download app package** to get a `.zip` file.
+2. Open Microsoft Teams.
+3. Click **Apps** in the left sidebar.
+4. Click **Manage your apps** > **Upload an app**.
+5. Select **Upload a custom app** (or **Upload a custom app for [org name]** if you have admin rights).
+6. Choose the downloaded `.zip` file.
+7. In the app details dialog, click **Add to a team**.
+8. Select the team and channel where you want the bot.
+9. Click **Set up a bot**.
+
+### Option B: Teams Admin Center (Org-Wide Deployment)
+
+For deploying to all users or specific groups:
+
+1. Open [Teams Admin Center](https://admin.teams.microsoft.com/).
+2. Go to **Teams apps** > **Manage apps**.
+3. Click **Upload new app** and upload the app package `.zip`.
+4. Go to **Teams apps** > **Setup policies**.
+5. Edit the relevant policy and add the Minions Bot to the **Installed apps** list.
+
+### Verify the Bot Works
+
+1. Open the Teams channel where you installed the bot.
+2. Send a message that @mentions the bot:
+   ```
+   @Minions Bot hello
+   ```
+3. If everything is configured correctly, the message will:
+   - Reach your dashboard via the Dev Tunnel
+   - Be written to `engine/teams-inbox.json`
+   - Be processed by the CC on the next poll cycle
+   - The CC response will appear as a thread reply in Teams
+
+If you don't see a response, check:
+- **Dashboard logs**: Look for incoming `/api/bot` requests
+- **Dev Tunnel**: Ensure it's still running and the URL matches the Azure Bot messaging endpoint
+- **Azure Bot**: Test the bot connection in the Azure Portal via **Test in Web Chat** (Configuration page)
+- **Config**: Verify `config.json` has `teams.enabled: true` and correct `appId`/`appPassword`
+
+## Troubleshooting
+
+### "Unauthorized" or 401 Errors
+
+The App ID or App Password in `config.json` doesn't match what's registered in Azure. Double-check:
+- The App ID matches the Azure Bot's **Microsoft App ID** on the Configuration page.
+- The App Password is the client secret **Value** (not the Secret ID) from Entra ID.
+- The client secret hasn't expired.
+
+### "Endpoint not reachable" in Azure Bot Test
+
+- Verify the Dev Tunnel is running: `devtunnel host -p 7331 --allow-anonymous`
+- Verify the messaging endpoint URL ends with `/api/bot`
+- Verify the dashboard is running: `minions dash`
+- Try opening the tunnel URL in a browser to confirm it's accessible
+
+### Bot Doesn't Respond in Teams
+
+- Check `engine/teams-inbox.json` — if messages appear there, the webhook is working but the CC processing loop may not be running.
+- Check that the engine is running: `minions start`
+- Check the engine logs for Teams-related errors.
+- Ensure `config.teams.enabled` is `true`.
+
+### "App not found" When Side-Loading
+
+- Your Teams admin may have disabled custom app side-loading. Contact your Teams admin to enable **Upload custom apps** in the Teams Admin Center > Setup policies.
+- Alternatively, ask an admin to upload the app via the Admin Center (Option B above).
+
+## What's Next
+
+Once the bot is responding to messages in Teams:
+
+- **Agent notifications** will appear in the Teams channel when agents complete work, PRs are merged, or plans are finished.
+- **CC mirror** mode (enabled by default) posts Command Center responses from the dashboard to Teams so the whole team sees orchestration activity.
+- For production deployment (replacing Dev Tunnel with a stable public URL), see [docs/teams-production.md](teams-production.md).

--- a/engine/ado.js
+++ b/engine/ado.js
@@ -406,6 +406,13 @@ async function pollPrStatus(config) {
           pr.buildErrorLog = logParts.join('\n\n');
           log('info', `PR ${pr.id}: fetched error logs from ${logParts.length} failing pipeline(s)`);
         }
+
+        // Teams notification for build failure — non-blocking
+        try {
+          const teams = require('./teams');
+          const prFilePath = shared.projectPrPath(project);
+          teams.teamsNotifyPrEvent(pr, 'build-failed', project, prFilePath).catch(() => {});
+        } catch {}
       }
     }
 

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -372,6 +372,19 @@ const commands = {
       }
     }, 3000);
 
+    // Teams inbox poll timer — process incoming Teams messages through CC
+    const teams = require('./teams');
+    const teamsInboxInterval = config.teams?.inboxPollInterval ?? shared.ENGINE_DEFAULTS.teams.inboxPollInterval;
+    const teamsInboxTimer = teams.isTeamsEnabled() ? setInterval(() => {
+      try {
+        const ctrl = getControl();
+        if (ctrl.state !== 'running') return;
+        teams.processTeamsInbox().catch(err => {
+          shared.log('warn', `Teams inbox poll error: ${err.message}`);
+        });
+      } catch {}
+    }, teamsInboxInterval) : null;
+
     console.log(`Tick interval: ${interval / 1000}s | Max concurrent: ${config.engine?.maxConcurrent || 5}`);
     console.log('Press Ctrl+C to stop');
 
@@ -422,6 +435,7 @@ const commands = {
       console.log(`\n${signal} received — initiating graceful shutdown...`);
       clearInterval(tickTimer);
       clearInterval(fastPollTimer);
+      if (teamsInboxTimer) clearInterval(teamsInboxTimer);
       for (const f of _watchedFiles) { try { fs.unwatchFile(f); } catch { /* cleanup */ } }
       safeWrite(CONTROL_PATH, { state: 'stopping', pid: process.pid, stopping_at: e.ts() });
       e.log('info', `Graceful shutdown initiated (${signal})`);

--- a/engine/github.js
+++ b/engine/github.js
@@ -413,6 +413,13 @@ async function pollPrStatus(config) {
               pr.buildErrorLog = errorLog;
               log('info', `PR ${pr.id}: fetched ${errorLog.split('\n').length} lines of build error log`);
             }
+
+            // Teams notification for build failure — non-blocking
+            try {
+              const teams = require('./teams');
+              const prFilePath = shared.projectPrPath(project);
+              teams.teamsNotifyPrEvent(pr, 'build-failed', project, prFilePath).catch(() => {});
+            } catch {}
           }
         }
       }

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -276,9 +276,24 @@ function checkPlanCompletion(meta, config) {
       });
     });
     log('info', `Created verification work item ${verifyId} for plan ${planFile}`);
+
+    // Teams notification for verify creation — non-blocking
+    try {
+      const teams = require('./teams');
+      teams.teamsNotifyPlanEvent({ name: plan.plan_summary || planFile, file: planFile }, 'verify-created').catch(() => {});
+    } catch {}
   }
 
   // Archive deferred until verify completes
+
+  // Teams notification for plan completion — non-blocking
+  try {
+    const teams = require('./teams');
+    teams.teamsNotifyPlanEvent({
+      name: plan.plan_summary || planFile, file: planFile, project: plan.project,
+      doneCount: doneItems.length, totalCount: planFeatureIds.size,
+    }, 'plan-completed').catch(() => {});
+  } catch {}
 
   log('info', `PRD ${planFile} completed: ${doneItems.length} done, ${failedItems.length} failed, runtime ${runtimeMin}m`);
   return true;

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -883,6 +883,14 @@ async function handlePostMerge(pr, project, config, newStatus) {
     });
   }
 
+  // Teams PR lifecycle notification — non-blocking
+  try {
+    const teams = require('./teams');
+    const prEvent = newStatus === PR_STATUS.MERGED ? 'pr-merged' : 'pr-abandoned';
+    const prFilePath = project ? projectPrPath(project) : null;
+    teams.teamsNotifyPrEvent(pr, prEvent, project, prFilePath).catch(() => {});
+  } catch {}
+
   log('info', `Post-merge hooks completed for ${pr.id}`);
 }
 

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -883,17 +883,6 @@ async function handlePostMerge(pr, project, config, newStatus) {
     });
   }
 
-  const teamsUrl = process.env.TEAMS_PLAN_FLOW_URL;
-  if (teamsUrl) {
-    try {
-      await fetch(teamsUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: `PR ${pr.id} merged: ${pr.title} (${project.name}) by ${pr.agent || 'unknown'}` })
-      });
-    } catch (err) { log('warn', `Teams post-merge notify failed: ${err.message}`); }
-  }
-
   log('info', `Post-merge hooks completed for ${pr.id}`);
 }
 
@@ -1485,6 +1474,12 @@ async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, confi
   const isAutoRetry = !effectiveSuccess && meta?.item?.id && (meta.item._retryCount || 0) < ENGINE_DEFAULTS.maxRetries;
   const metricsResult = isAutoRetry ? 'retry' : finalResult;
   updateMetrics(agentId, dispatchItem, metricsResult, taskUsage, prsCreatedCount, model);
+
+  // Teams notification — non-blocking
+  try {
+    const teams = require('./teams');
+    teams.teamsNotifyCompletion(dispatchItem, finalResult, agentId).catch(() => {});
+  } catch {}
 
   return { resultSummary, taskUsage, autoRecovered, structuredCompletion };
 }

--- a/engine/preflight.js
+++ b/engine/preflight.js
@@ -192,6 +192,19 @@ function doctor(minionsHome) {
     } else {
       runtimeResults.push({ name: 'Agents configured', ok: false, message: 'no agents in config.json' });
     }
+
+    // Check Teams integration
+    const teams = config.teams;
+    if (teams && teams.enabled === true) {
+      if (!teams.appId || !teams.appPassword) {
+        const missing = [!teams.appId && 'appId', !teams.appPassword && 'appPassword'].filter(Boolean).join(', ');
+        runtimeResults.push({ name: 'Teams integration', ok: 'warn', message: `enabled but missing: ${missing}` });
+      } else {
+        runtimeResults.push({ name: 'Teams integration', ok: true, message: 'configured' });
+      }
+    } else {
+      runtimeResults.push({ name: 'Teams integration', ok: 'warn', message: 'disabled — see docs/teams-setup.md' });
+    }
   } catch {
     runtimeResults.push({ name: 'Config', ok: false, message: `missing or invalid — run: minions init` });
   }

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -550,6 +550,15 @@ const ENGINE_DEFAULTS = {
   ccModel: 'sonnet', // model for Command Center and doc-chat (sonnet, haiku, opus)
   ccEffort: null, // effort level for CC/doc-chat (null, 'low', 'medium', 'high')
   ccMaxTurns: 50, // max tool-use turns for CC/doc-chat before CLI stops
+  // Teams integration — config.teams shape: { enabled, appId, appPassword, notifyEvents, ccMirror, inboxPollInterval }
+  teams: {
+    enabled: false,
+    appId: '',
+    appPassword: '',
+    notifyEvents: ['pr-merged', 'agent-completed', 'plan-completed', 'agent-failed'],
+    ccMirror: true,
+    inboxPollInterval: 15000,
+  },
 };
 
 // ─── Status & Type Constants ─────────────────────────────────────────────────

--- a/engine/teams-cards.js
+++ b/engine/teams-cards.js
@@ -1,0 +1,137 @@
+/**
+ * engine/teams-cards.js — Adaptive Card templates for Teams notifications.
+ * All cards use schema version 1.4 and include fallback text.
+ */
+
+const SCHEMA = 'http://adaptivecards.io/schemas/adaptive-card.json';
+const VERSION = '1.4';
+const DASHBOARD_URL = 'http://localhost:7331';
+
+function wrapCard(body, actions, fallbackText) {
+  return {
+    type: 'AdaptiveCard',
+    $schema: SCHEMA,
+    version: VERSION,
+    fallbackText: fallbackText || 'Minions notification',
+    body,
+    actions: actions || [],
+  };
+}
+
+/**
+ * Agent completion card — shows agent name, task title, result, PR link.
+ * @param {string} agent — agent name/id
+ * @param {object} item — { title, id }
+ * @param {string} result — 'success' or 'error'
+ * @param {string} [prUrl] — PR URL if available
+ */
+function buildCompletionCard(agent, item, result, prUrl) {
+  const isSuccess = result === 'success';
+  const badge = isSuccess ? 'Done' : 'Failed';
+  const color = isSuccess ? 'good' : 'attention';
+  const title = item?.title || item?.id || 'Unknown task';
+
+  const body = [
+    { type: 'TextBlock', text: `${badge} — ${agent}`, weight: 'bolder', size: 'medium', color },
+    { type: 'TextBlock', text: title, wrap: true },
+  ];
+
+  const actions = [
+    { type: 'Action.OpenUrl', title: 'Open Dashboard', url: DASHBOARD_URL },
+  ];
+  if (prUrl) {
+    actions.unshift({ type: 'Action.OpenUrl', title: 'View PR', url: prUrl });
+  }
+
+  return wrapCard(body, actions, `${badge}: ${agent} — ${title}`);
+}
+
+/**
+ * PR lifecycle card — shows PR title, event, author, project.
+ * @param {object} pr — { id, title, url, agent }
+ * @param {string} event — 'pr-merged', 'pr-abandoned', 'build-failed', etc.
+ * @param {object} [project] — { name }
+ */
+function buildPrCard(pr, event, project) {
+  const title = pr?.title || pr?.id || 'Unknown PR';
+  const agent = pr?.agent || 'unknown';
+  const projectName = project?.name || '';
+
+  const body = [
+    { type: 'TextBlock', text: `${event}`, weight: 'bolder', size: 'medium' },
+    { type: 'ColumnSet', columns: [
+      { type: 'Column', width: 'stretch', items: [
+        { type: 'TextBlock', text: title, wrap: true, weight: 'bolder' },
+        { type: 'TextBlock', text: `${agent}${projectName ? ' | ' + projectName : ''}`, isSubtle: true, spacing: 'none' },
+      ]},
+    ]},
+  ];
+
+  const actions = [
+    { type: 'Action.OpenUrl', title: 'Open Dashboard', url: DASHBOARD_URL },
+  ];
+  if (pr?.url) {
+    actions.unshift({ type: 'Action.OpenUrl', title: 'View PR', url: pr.url });
+  }
+
+  return wrapCard(body, actions, `${event}: ${title} (${agent})`);
+}
+
+/**
+ * Plan lifecycle card — shows plan name, event, item counts.
+ * @param {object} plan — { name, file, doneCount, totalCount }
+ * @param {string} event — 'plan-completed', 'plan-approved', 'plan-rejected', 'verify-created'
+ */
+function buildPlanCard(plan, event) {
+  const name = plan?.name || plan?.file || 'Unknown plan';
+  const hasCounts = plan?.doneCount != null && plan?.totalCount != null;
+
+  const body = [
+    { type: 'TextBlock', text: `${event}`, weight: 'bolder', size: 'medium' },
+    { type: 'TextBlock', text: name, wrap: true },
+  ];
+
+  if (hasCounts) {
+    body.push({ type: 'TextBlock', text: `${plan.doneCount}/${plan.totalCount} items completed`, isSubtle: true });
+  }
+
+  const actions = [
+    { type: 'Action.OpenUrl', title: 'Open Dashboard', url: `${DASHBOARD_URL}/prd` },
+  ];
+
+  return wrapCard(body, actions, `${event}: ${name}${hasCounts ? ` (${plan.doneCount}/${plan.totalCount})` : ''}`);
+}
+
+/**
+ * CC response mirror card — shows user question and CC answer.
+ * @param {string} question — user's CC input
+ * @param {string} answer — CC response (truncated if needed)
+ */
+function buildCCResponseCard(question, answer) {
+  const maxLen = 3000;
+  const truncated = answer.length > maxLen
+    ? answer.slice(0, maxLen) + '...'
+    : answer;
+
+  const body = [
+    { type: 'TextBlock', text: 'Command Center', weight: 'bolder', size: 'medium' },
+    { type: 'TextBlock', text: `> ${question.slice(0, 200)}`, wrap: true, isSubtle: true },
+    { type: 'TextBlock', text: truncated, wrap: true },
+  ];
+
+  const actions = [
+    { type: 'Action.OpenUrl', title: 'Open Dashboard', url: DASHBOARD_URL },
+  ];
+
+  return wrapCard(body, actions, `CC: ${question.slice(0, 100)} — ${answer.slice(0, 200)}`);
+}
+
+module.exports = {
+  buildCompletionCard,
+  buildPrCard,
+  buildPlanCard,
+  buildCCResponseCard,
+  SCHEMA,
+  VERSION,
+  DASHBOARD_URL,
+};

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -291,6 +291,59 @@ async function teamsNotifyCompletion(dispatchItem, result, agentId) {
   }
 }
 
+// ── PR Lifecycle Notifications ─────────────────────────────────────────────
+
+/**
+ * Notify Teams about a PR lifecycle event (merge, abandon, build-failed, approved).
+ * Deduplicates via _teamsNotifiedEvents on PR object.
+ * @param {object} pr — the PR object from pull-requests.json
+ * @param {string} event — event type: 'pr-merged', 'pr-abandoned', 'build-failed', 'pr-approved'
+ * @param {object} project — the project config object
+ * @param {string} prFilePath — path to pull-requests.json for dedup write
+ */
+async function teamsNotifyPrEvent(pr, event, project, prFilePath) {
+  if (!isTeamsEnabled()) return;
+  const cfg = getTeamsConfig();
+  if (!cfg.notifyEvents || !cfg.notifyEvents.includes(event)) return;
+
+  // Dedup check — don't re-notify the same event
+  if (pr._teamsNotifiedEvents && pr._teamsNotifiedEvents.includes(event)) return;
+
+  const prLink = pr.url || '';
+  const linkText = prLink ? ` | [PR](${prLink})` : '';
+  const projectName = project?.name || 'unknown';
+  const agent = pr.agent || 'unknown';
+  const title = pr.title || pr.id || 'Untitled PR';
+
+  const text = `**${event}** — _${agent}_ | ${title} (${projectName})${linkText} | [dashboard](http://localhost:7331)`;
+
+  // Find first available conversation ref
+  const state = safeJson(TEAMS_STATE_PATH) || {};
+  const convKeys = Object.keys(state.conversations || {});
+  if (convKeys.length === 0) return;
+
+  try {
+    await teamsPost(convKeys[0], text);
+    log('info', `Teams PR notification sent: ${event} for ${pr.id}`);
+
+    // Record dedup — update _teamsNotifiedEvents on PR via lock
+    if (prFilePath) {
+      mutateJsonFileLocked(prFilePath, (prs) => {
+        if (!Array.isArray(prs)) return prs;
+        const target = prs.find(p => p.id === pr.id);
+        if (target) {
+          if (!target._teamsNotifiedEvents) target._teamsNotifiedEvents = [];
+          if (!target._teamsNotifiedEvents.includes(event)) {
+            target._teamsNotifiedEvents.push(event);
+          }
+        }
+      }, { defaultValue: [] });
+    }
+  } catch (err) {
+    log('warn', `Teams PR notification failed for ${pr.id}: ${err.message}`);
+  }
+}
+
 // Reset cached adapter (for testing)
 function _resetAdapter() { _adapter = null; _botbuilder = null; _lastCCMirrorPost = 0; }
 
@@ -305,6 +358,7 @@ module.exports = {
   processTeamsInbox,
   teamsPostCCResponse,
   teamsNotifyCompletion,
+  teamsNotifyPrEvent,
   CC_MIRROR_RATE_LIMIT_MS,
   TEAMS_STATE_PATH,
   TEAMS_INBOX_PATH,

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -12,6 +12,8 @@ const { log, safeJson, mutateJsonFileLocked, ENGINE_DEFAULTS } = shared;
 const { ENGINE_DIR, getConfig } = queries;
 
 const TEAMS_STATE_PATH = path.join(ENGINE_DIR, 'teams-state.json');
+const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json');
+const TEAMS_INBOX_CAP = 200;
 
 // Lazy-load botbuilder — may not be installed
 let _botbuilder = null;
@@ -149,6 +151,70 @@ async function teamsPost(key, text) {
   }
 }
 
+/**
+ * Process unread messages in the Teams inbox.
+ * Reads engine/teams-inbox.json, sends each unprocessed message through CC
+ * via the dashboard HTTP API, posts the CC response as a Teams reply,
+ * and marks the message as processed. Prunes oldest processed messages
+ * when inbox exceeds TEAMS_INBOX_CAP.
+ */
+async function processTeamsInbox() {
+  if (!isTeamsEnabled()) return;
+
+  // Read inbox — snapshot unprocessed messages, then release lock
+  const inbox = safeJson(TEAMS_INBOX_PATH);
+  if (!Array.isArray(inbox) || inbox.length === 0) return;
+
+  const unprocessed = inbox.filter(m => !m._processedAt);
+  if (unprocessed.length === 0) return;
+
+  log('info', `Teams inbox: ${unprocessed.length} unprocessed message(s)`);
+  const cfg = getTeamsConfig();
+  const port = process.env.PORT || 7331;
+
+  // Process sequentially to avoid CC session conflicts
+  for (const msg of unprocessed) {
+    try {
+      // Call CC via dashboard HTTP API
+      const ccRes = await fetch(`http://localhost:${port}/api/command-center`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: msg.text, tabId: `teams-${msg.id}` }),
+      });
+      const ccData = await ccRes.json().catch(() => ({}));
+      const responseText = ccData.text || ccData.error || 'No response from Command Center';
+
+      // Track usage under 'teams' category
+      const llm = require('./llm');
+      llm.trackEngineUsage('teams', ccData.usage || null);
+
+      // Post reply to Teams
+      if (msg.conversationRef?.conversation?.id) {
+        await teamsPost(msg.conversationRef.conversation.id, responseText);
+      }
+
+      // Mark as processed
+      mutateJsonFileLocked(TEAMS_INBOX_PATH, (data) => {
+        if (!Array.isArray(data)) return data;
+        const entry = data.find(m => m.id === msg.id);
+        if (entry) entry._processedAt = new Date().toISOString();
+
+        // Prune oldest processed messages when inbox exceeds cap
+        if (data.length > TEAMS_INBOX_CAP) {
+          const processed = data.filter(m => m._processedAt).sort((a, b) => (a.receivedAt || '').localeCompare(b.receivedAt || ''));
+          const toRemove = data.length - TEAMS_INBOX_CAP;
+          const removeIds = new Set(processed.slice(0, toRemove).map(m => m.id));
+          return data.filter(m => !removeIds.has(m.id));
+        }
+      }, { defaultValue: [] });
+
+      log('info', `Teams inbox: processed message ${msg.id} from ${msg.from}`);
+    } catch (err) {
+      log('warn', `Teams inbox: failed to process message ${msg.id}: ${err.message}`);
+    }
+  }
+}
+
 // Reset cached adapter (for testing)
 function _resetAdapter() { _adapter = null; _botbuilder = null; }
 
@@ -160,6 +226,9 @@ module.exports = {
   getConversationRef,
   teamsReply,
   teamsPost,
+  processTeamsInbox,
   TEAMS_STATE_PATH,
+  TEAMS_INBOX_PATH,
+  TEAMS_INBOX_CAP,
   _resetAdapter, // exported for testing
 };

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -16,6 +16,14 @@ const TEAMS_STATE_PATH = path.join(ENGINE_DIR, 'teams-state.json');
 const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json');
 const TEAMS_INBOX_CAP = 200;
 
+// ── Rate Limiting & Circuit Breaker Constants ─────────────────────────────
+const MAX_RETRIES_429 = 2;
+const MAX_RETRIES_5XX = 3;
+const CIRCUIT_FAILURE_THRESHOLD = 5;
+const CIRCUIT_RECOVERY_MS = 10 * 60 * 1000; // 10 minutes
+const OUTBOUND_QUEUE_MAX = 100;
+const OUTBOUND_DRAIN_INTERVAL_MS = 250; // 4 messages per second
+
 // Lazy-load botbuilder — may not be installed
 let _botbuilder = null;
 function getBotbuilder() {
@@ -109,6 +117,172 @@ function getConversationRef(key) {
   return state.conversations?.[key]?.ref || null;
 }
 
+// ── Circuit Breaker ───────────────────────────────────────────────────────
+
+const _circuit = {
+  state: 'closed', // 'closed' | 'open' | 'half-open'
+  failures: 0,
+  openedAt: 0,
+};
+
+function _isCircuitOpen() {
+  if (_circuit.state === 'closed') return false;
+  if (_circuit.state === 'open') {
+    if (Date.now() - _circuit.openedAt >= CIRCUIT_RECOVERY_MS) {
+      _circuit.state = 'half-open';
+      log('info', 'Teams circuit breaker: half-open — allowing probe request');
+      return false;
+    }
+    return true;
+  }
+  return false; // half-open allows one probe
+}
+
+function _onSendSuccess() {
+  if (_circuit.state !== 'closed') {
+    log('info', `Teams circuit breaker: closed (was ${_circuit.state})`);
+  }
+  _circuit.state = 'closed';
+  _circuit.failures = 0;
+}
+
+function _onSendFailure() {
+  _circuit.failures++;
+  if (_circuit.state === 'half-open') {
+    _circuit.state = 'open';
+    _circuit.openedAt = Date.now();
+    log('warn', 'Teams circuit breaker: probe failed — reopening for 10 minutes');
+  } else if (_circuit.failures >= CIRCUIT_FAILURE_THRESHOLD) {
+    _circuit.state = 'open';
+    _circuit.openedAt = Date.now();
+    log('warn', `Teams circuit breaker: OPEN after ${_circuit.failures} consecutive failures — disabling for 10 minutes`);
+  }
+}
+
+// ── Retry Logic ───────────────────────────────────────────────────────────
+
+function _sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Execute sendFn with retry on 429 (Retry-After) and 5xx (exponential backoff).
+ * @param {Function} sendFn — async function that performs the actual send
+ */
+async function _sendWithRetry(sendFn) {
+  let lastErr;
+  let retries429 = 0;
+  let retries5xx = 0;
+  const maxAttempts = 1 + MAX_RETRIES_429 + MAX_RETRIES_5XX;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await sendFn();
+      return;
+    } catch (err) {
+      lastErr = err;
+      const status = err.statusCode || err.status || 0;
+
+      if (status === 429 && retries429 < MAX_RETRIES_429) {
+        retries429++;
+        const retryAfterSec = parseInt(err.headers?.['retry-after'] || '1', 10);
+        const delayMs = Math.max(retryAfterSec, 1) * 1000;
+        log('info', `Teams 429 — retry ${retries429}/${MAX_RETRIES_429} after ${delayMs}ms`);
+        await _sleep(delayMs);
+        continue;
+      }
+
+      if (status >= 500 && status < 600 && retries5xx < MAX_RETRIES_5XX) {
+        retries5xx++;
+        const backoffMs = Math.pow(2, retries5xx - 1) * 1000; // 1s, 2s, 4s
+        log('info', `Teams ${status} — retry ${retries5xx}/${MAX_RETRIES_5XX} after ${backoffMs}ms`);
+        await _sleep(backoffMs);
+        continue;
+      }
+
+      throw err;
+    }
+  }
+  if (lastErr) throw lastErr;
+}
+
+// ── Outbound Queue ────────────────────────────────────────────────────────
+
+const _outboundQueue = [];
+let _drainTimer = null;
+
+function _enqueueMessage(key, content) {
+  if (_outboundQueue.length >= OUTBOUND_QUEUE_MAX) {
+    log('warn', `Teams outbound queue full (${OUTBOUND_QUEUE_MAX}) — dropping message for ${key}`);
+    return;
+  }
+  _outboundQueue.push({ key, content });
+  _startDrainTimer();
+}
+
+function _startDrainTimer() {
+  if (_drainTimer) return;
+  _drainTimer = setInterval(_drainQueue, OUTBOUND_DRAIN_INTERVAL_MS);
+}
+
+function _stopDrainTimer() {
+  if (_drainTimer) {
+    clearInterval(_drainTimer);
+    _drainTimer = null;
+  }
+}
+
+async function _drainQueue() {
+  if (_outboundQueue.length === 0) {
+    _stopDrainTimer();
+    return;
+  }
+
+  const item = _outboundQueue.shift();
+  if (!item) return;
+
+  try {
+    await _sendProactive(item.key, item.content);
+  } catch (err) {
+    log('warn', `Teams queued message failed for ${item.key}: ${err.message}`);
+  }
+}
+
+/**
+ * Send a proactive message with circuit breaker and retry.
+ * Called by the drain timer — not directly by callers.
+ */
+async function _sendProactive(key, content) {
+  if (_isCircuitOpen()) {
+    log('info', `Teams circuit open — skipping message to ${key}`);
+    return;
+  }
+
+  const adapter = createAdapter();
+  if (!adapter) return;
+
+  const ref = getConversationRef(key);
+  if (!ref) {
+    log('warn', `Teams post skipped — no conversation ref for key: ${key}`);
+    return;
+  }
+
+  try {
+    const activity = toActivity(content);
+    await _sendWithRetry(async () => {
+      await adapter.continueConversationAsync(getTeamsConfig().appId, ref, async (context) => {
+        await context.sendActivity(activity);
+      });
+    });
+    _onSendSuccess();
+    const len = typeof content === 'string' ? content.length : JSON.stringify(content).length;
+    log('info', `Teams proactive message sent to ${key} (${len} chars)`);
+  } catch (err) {
+    _onSendFailure();
+    log('warn', `Teams proactive post failed for ${key}: ${err.message}`);
+  }
+}
+
 /**
  * Build an activity object from text or Adaptive Card.
  * @param {string|object} content — plain text string or Adaptive Card object (with type: 'AdaptiveCard')
@@ -138,11 +312,19 @@ function toActivity(content) {
 async function teamsReply(context, content) {
   const adapter = createAdapter();
   if (!adapter || !context) return;
+  if (_isCircuitOpen()) {
+    log('info', 'Teams circuit open — skipping reply');
+    return;
+  }
   try {
-    await context.sendActivity(toActivity(content));
+    await _sendWithRetry(async () => {
+      await context.sendActivity(toActivity(content));
+    });
+    _onSendSuccess();
     const len = typeof content === 'string' ? content.length : JSON.stringify(content).length;
     log('info', `Teams reply sent (${len} chars)`);
   } catch (err) {
+    _onSendFailure();
     log('warn', `Teams reply failed: ${err.message}`);
   }
 }
@@ -154,25 +336,8 @@ async function teamsReply(context, content) {
  * @param {string|object} content — message text or Adaptive Card object
  */
 async function teamsPost(key, content) {
-  const adapter = createAdapter();
-  if (!adapter) return;
-
-  const ref = getConversationRef(key);
-  if (!ref) {
-    log('warn', `Teams post skipped — no conversation ref for key: ${key}`);
-    return;
-  }
-
-  try {
-    const activity = toActivity(content);
-    await adapter.continueConversationAsync(getTeamsConfig().appId, ref, async (context) => {
-      await context.sendActivity(activity);
-    });
-    const len = typeof content === 'string' ? content.length : JSON.stringify(content).length;
-    log('info', `Teams proactive message sent to ${key} (${len} chars)`);
-  } catch (err) {
-    log('warn', `Teams proactive post failed for ${key}: ${err.message}`);
-  }
+  if (!createAdapter()) return;
+  _enqueueMessage(key, content);
 }
 
 /**
@@ -382,8 +547,17 @@ async function teamsNotifyPlanEvent(planInfo, event) {
   }
 }
 
-// Reset cached adapter (for testing)
-function _resetAdapter() { _adapter = null; _botbuilder = null; _lastCCMirrorPost = 0; }
+// Reset cached adapter and internal state (for testing)
+function _resetAdapter() {
+  _adapter = null;
+  _botbuilder = null;
+  _lastCCMirrorPost = 0;
+  _circuit.state = 'closed';
+  _circuit.failures = 0;
+  _circuit.openedAt = 0;
+  _outboundQueue.length = 0;
+  _stopDrainTimer();
+}
 
 module.exports = {
   getTeamsConfig,
@@ -402,5 +576,14 @@ module.exports = {
   TEAMS_STATE_PATH,
   TEAMS_INBOX_PATH,
   TEAMS_INBOX_CAP,
+  MAX_RETRIES_429,
+  MAX_RETRIES_5XX,
+  CIRCUIT_FAILURE_THRESHOLD,
+  CIRCUIT_RECOVERY_MS,
+  OUTBOUND_QUEUE_MAX,
+  OUTBOUND_DRAIN_INTERVAL_MS,
+  _circuit, // exported for testing
+  _outboundQueue, // exported for testing
   _resetAdapter, // exported for testing
+  _stopDrainTimer, // exported for testing
 };

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -256,6 +256,41 @@ async function teamsPostCCResponse(userMessage, ccResponse) {
   log('info', `Teams CC mirror sent (${formatted.length} chars)`);
 }
 
+// ── Post-Completion Notifications ──────────────────────────────────────────
+
+/**
+ * Notify Teams when an agent completes or fails a task.
+ * Only posts if the event type is in config.teams.notifyEvents.
+ * @param {object} dispatchItem — the dispatch entry (id, type, task, meta)
+ * @param {string} result — 'success', 'error', or 'timeout'
+ * @param {string} agentId — the agent that ran the task
+ */
+async function teamsNotifyCompletion(dispatchItem, result, agentId) {
+  if (!isTeamsEnabled()) return;
+  const cfg = getTeamsConfig();
+  const eventType = result === 'success' ? 'agent-completed' : 'agent-failed';
+  if (!cfg.notifyEvents || !cfg.notifyEvents.includes(eventType)) return;
+
+  const emoji = result === 'success' ? 'Done' : 'Failed';
+  const title = dispatchItem.task || dispatchItem.meta?.item?.title || dispatchItem.id;
+  const prLink = dispatchItem.meta?.pr?.url || dispatchItem.pr || '';
+  const prText = prLink ? ` | [PR](${prLink})` : '';
+
+  const text = `**${emoji}** — _${agentId}_ ${result}: ${title}${prText} | [dashboard](http://localhost:7331)`;
+
+  // Find first available conversation ref
+  const state = safeJson(TEAMS_STATE_PATH) || {};
+  const convKeys = Object.keys(state.conversations || {});
+  if (convKeys.length === 0) return;
+
+  try {
+    await teamsPost(convKeys[0], text);
+    log('info', `Teams completion notification sent for ${dispatchItem.id} (${result})`);
+  } catch (err) {
+    log('warn', `Teams completion notification failed: ${err.message}`);
+  }
+}
+
 // Reset cached adapter (for testing)
 function _resetAdapter() { _adapter = null; _botbuilder = null; _lastCCMirrorPost = 0; }
 
@@ -269,6 +304,7 @@ module.exports = {
   teamsPost,
   processTeamsInbox,
   teamsPostCCResponse,
+  teamsNotifyCompletion,
   CC_MIRROR_RATE_LIMIT_MS,
   TEAMS_STATE_PATH,
   TEAMS_INBOX_PATH,

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -1,0 +1,165 @@
+/**
+ * engine/teams.js — Microsoft Teams integration via Azure Bot Framework.
+ * Provides adapter creation, message posting, and conversation reference persistence.
+ * All functions are no-ops when Teams is disabled or botbuilder is not installed.
+ */
+
+const path = require('path');
+const shared = require('./shared');
+const queries = require('./queries');
+
+const { log, safeJson, mutateJsonFileLocked, ENGINE_DEFAULTS } = shared;
+const { ENGINE_DIR, getConfig } = queries;
+
+const TEAMS_STATE_PATH = path.join(ENGINE_DIR, 'teams-state.json');
+
+// Lazy-load botbuilder — may not be installed
+let _botbuilder = null;
+function getBotbuilder() {
+  if (_botbuilder) return _botbuilder;
+  try {
+    _botbuilder = require('botbuilder');
+  } catch {
+    log('warn', 'botbuilder package not installed — Teams integration unavailable');
+    _botbuilder = null;
+  }
+  return _botbuilder;
+}
+
+/**
+ * Merge user config.teams with ENGINE_DEFAULTS.teams.
+ * Returns the merged teams config object.
+ */
+function getTeamsConfig() {
+  const config = getConfig();
+  const defaults = ENGINE_DEFAULTS.teams;
+  const user = config.teams || {};
+  return { ...defaults, ...user };
+}
+
+/**
+ * Returns true if Teams integration is enabled and has required credentials.
+ */
+function isTeamsEnabled() {
+  const cfg = getTeamsConfig();
+  return cfg.enabled === true && !!cfg.appId && !!cfg.appPassword;
+}
+
+// Cached adapter instance — created once per process
+let _adapter = null;
+
+/**
+ * Create and return a BotFrameworkAdapter instance.
+ * Returns null when Teams is disabled or botbuilder is not installed.
+ */
+function createAdapter() {
+  if (_adapter) return _adapter;
+
+  if (!isTeamsEnabled()) {
+    log('info', 'Teams adapter not created — integration disabled or missing credentials');
+    return null;
+  }
+
+  const botbuilder = getBotbuilder();
+  if (!botbuilder) return null;
+
+  const cfg = getTeamsConfig();
+  try {
+    _adapter = new botbuilder.CloudAdapter(
+      new botbuilder.ConfigurationBotFrameworkAuthentication({
+        MicrosoftAppId: cfg.appId,
+        MicrosoftAppPassword: cfg.appPassword,
+        MicrosoftAppType: 'SingleTenant',
+      })
+    );
+    log('info', 'Teams adapter created successfully');
+    return _adapter;
+  } catch (err) {
+    log('warn', `Teams adapter creation failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Save a conversation reference for later proactive messaging.
+ * Uses mutateJsonFileLocked for concurrency safety.
+ * @param {string} key — identifier for this conversation (e.g. channel ID or user ID)
+ * @param {object} ref — conversation reference from TurnContext.getConversationReference()
+ */
+function saveConversationRef(key, ref) {
+  if (!key || !ref) return;
+  mutateJsonFileLocked(TEAMS_STATE_PATH, (state) => {
+    if (!state.conversations) state.conversations = {};
+    state.conversations[key] = { ref, savedAt: shared.ts() };
+  });
+  log('info', `Teams conversation ref saved: ${key}`);
+}
+
+/**
+ * Retrieve a saved conversation reference.
+ * @param {string} key — identifier used in saveConversationRef
+ * @returns {object|null} — the conversation reference, or null if not found
+ */
+function getConversationRef(key) {
+  if (!key) return null;
+  const state = safeJson(TEAMS_STATE_PATH) || {};
+  return state.conversations?.[key]?.ref || null;
+}
+
+/**
+ * Reply to an existing Teams conversation turn.
+ * No-op when adapter is null (Teams disabled or botbuilder missing).
+ * @param {object} context — TurnContext from bot handler
+ * @param {string} text — message text to send
+ */
+async function teamsReply(context, text) {
+  const adapter = createAdapter();
+  if (!adapter || !context) return;
+  try {
+    await context.sendActivity(text);
+    log('info', `Teams reply sent (${text.length} chars)`);
+  } catch (err) {
+    log('warn', `Teams reply failed: ${err.message}`);
+  }
+}
+
+/**
+ * Proactively post a message to a saved Teams conversation.
+ * No-op when adapter is null or conversation ref is not found.
+ * @param {string} key — conversation key used in saveConversationRef
+ * @param {string} text — message text to send
+ */
+async function teamsPost(key, text) {
+  const adapter = createAdapter();
+  if (!adapter) return;
+
+  const ref = getConversationRef(key);
+  if (!ref) {
+    log('warn', `Teams post skipped — no conversation ref for key: ${key}`);
+    return;
+  }
+
+  try {
+    await adapter.continueConversationAsync(getTeamsConfig().appId, ref, async (context) => {
+      await context.sendActivity(text);
+    });
+    log('info', `Teams proactive message sent to ${key} (${text.length} chars)`);
+  } catch (err) {
+    log('warn', `Teams proactive post failed for ${key}: ${err.message}`);
+  }
+}
+
+// Reset cached adapter (for testing)
+function _resetAdapter() { _adapter = null; _botbuilder = null; }
+
+module.exports = {
+  getTeamsConfig,
+  isTeamsEnabled,
+  createAdapter,
+  saveConversationRef,
+  getConversationRef,
+  teamsReply,
+  teamsPost,
+  TEAMS_STATE_PATH,
+  _resetAdapter, // exported for testing
+};

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -344,6 +344,34 @@ async function teamsNotifyPrEvent(pr, event, project, prFilePath) {
   }
 }
 
+// ── Plan Lifecycle Notifications ───────────────────────────────────────────
+
+/**
+ * Notify Teams about a plan lifecycle event (completed, approved, rejected, verify-created).
+ * @param {object} planInfo — { name, file, project, doneCount, totalCount } or similar
+ * @param {string} event — 'plan-completed', 'plan-approved', 'plan-rejected', 'verify-created'
+ */
+async function teamsNotifyPlanEvent(planInfo, event) {
+  if (!isTeamsEnabled()) return;
+  const cfg = getTeamsConfig();
+  if (!cfg.notifyEvents || !cfg.notifyEvents.includes(event)) return;
+
+  const planName = planInfo.name || planInfo.file || 'Unknown plan';
+  const counts = planInfo.doneCount != null ? ` (${planInfo.doneCount}/${planInfo.totalCount} items)` : '';
+  const text = `**${event}** — ${planName}${counts} | [dashboard](http://localhost:7331)`;
+
+  const state = safeJson(TEAMS_STATE_PATH) || {};
+  const convKeys = Object.keys(state.conversations || {});
+  if (convKeys.length === 0) return;
+
+  try {
+    await teamsPost(convKeys[0], text);
+    log('info', `Teams plan notification sent: ${event} for ${planName}`);
+  } catch (err) {
+    log('warn', `Teams plan notification failed: ${err.message}`);
+  }
+}
+
 // Reset cached adapter (for testing)
 function _resetAdapter() { _adapter = null; _botbuilder = null; _lastCCMirrorPost = 0; }
 
@@ -359,6 +387,7 @@ module.exports = {
   teamsPostCCResponse,
   teamsNotifyCompletion,
   teamsNotifyPrEvent,
+  teamsNotifyPlanEvent,
   CC_MIRROR_RATE_LIMIT_MS,
   TEAMS_STATE_PATH,
   TEAMS_INBOX_PATH,

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -215,8 +215,49 @@ async function processTeamsInbox() {
   }
 }
 
+// ── CC Mirror to Teams ─────────────────────────────────────────────────────
+
+const CC_MIRROR_RATE_LIMIT_MS = 5000;
+let _lastCCMirrorPost = 0;
+
+/**
+ * Mirror a CC response to Teams so the team sees orchestration activity.
+ * Truncates response at 4000 chars with a dashboard link suffix.
+ * Rate-limited to 1 post per 5 seconds — excess posts silently skipped.
+ * @param {string} userMessage — the user's CC input
+ * @param {string} ccResponse — the CC response text
+ */
+async function teamsPostCCResponse(userMessage, ccResponse) {
+  if (!isTeamsEnabled()) return;
+  const cfg = getTeamsConfig();
+  if (!cfg.ccMirror) return;
+
+  // Rate limit
+  const now = Date.now();
+  if (now - _lastCCMirrorPost < CC_MIRROR_RATE_LIMIT_MS) return;
+  _lastCCMirrorPost = now;
+
+  const maxLen = 4000;
+  const truncatedResponse = ccResponse.length > maxLen
+    ? ccResponse.slice(0, maxLen) + '... [see dashboard](http://localhost:7331)'
+    : ccResponse;
+
+  const formatted = `**CC** — _${userMessage.slice(0, 200)}_\n\n${truncatedResponse}`;
+
+  // Find first available conversation ref
+  const state = safeJson(TEAMS_STATE_PATH) || {};
+  const convKeys = Object.keys(state.conversations || {});
+  if (convKeys.length === 0) {
+    log('info', 'Teams CC mirror skipped — no conversation refs stored');
+    return;
+  }
+
+  await teamsPost(convKeys[0], formatted);
+  log('info', `Teams CC mirror sent (${formatted.length} chars)`);
+}
+
 // Reset cached adapter (for testing)
-function _resetAdapter() { _adapter = null; _botbuilder = null; }
+function _resetAdapter() { _adapter = null; _botbuilder = null; _lastCCMirrorPost = 0; }
 
 module.exports = {
   getTeamsConfig,
@@ -227,6 +268,8 @@ module.exports = {
   teamsReply,
   teamsPost,
   processTeamsInbox,
+  teamsPostCCResponse,
+  CC_MIRROR_RATE_LIMIT_MS,
   TEAMS_STATE_PATH,
   TEAMS_INBOX_PATH,
   TEAMS_INBOX_CAP,

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -10,6 +10,7 @@ const queries = require('./queries');
 
 const { log, safeJson, mutateJsonFileLocked, ENGINE_DEFAULTS } = shared;
 const { ENGINE_DIR, getConfig } = queries;
+const cards = require('./teams-cards');
 
 const TEAMS_STATE_PATH = path.join(ENGINE_DIR, 'teams-state.json');
 const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json');
@@ -109,17 +110,38 @@ function getConversationRef(key) {
 }
 
 /**
+ * Build an activity object from text or Adaptive Card.
+ * @param {string|object} content — plain text string or Adaptive Card object (with type: 'AdaptiveCard')
+ * @returns {string|object} — activity-compatible value for sendActivity
+ */
+function toActivity(content) {
+  if (typeof content === 'string') return content;
+  if (content && content.type === 'AdaptiveCard') {
+    return {
+      type: 'message',
+      text: content.fallbackText || '',
+      attachments: [{
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content,
+      }],
+    };
+  }
+  return String(content);
+}
+
+/**
  * Reply to an existing Teams conversation turn.
  * No-op when adapter is null (Teams disabled or botbuilder missing).
  * @param {object} context — TurnContext from bot handler
- * @param {string} text — message text to send
+ * @param {string|object} content — message text or Adaptive Card object
  */
-async function teamsReply(context, text) {
+async function teamsReply(context, content) {
   const adapter = createAdapter();
   if (!adapter || !context) return;
   try {
-    await context.sendActivity(text);
-    log('info', `Teams reply sent (${text.length} chars)`);
+    await context.sendActivity(toActivity(content));
+    const len = typeof content === 'string' ? content.length : JSON.stringify(content).length;
+    log('info', `Teams reply sent (${len} chars)`);
   } catch (err) {
     log('warn', `Teams reply failed: ${err.message}`);
   }
@@ -129,9 +151,9 @@ async function teamsReply(context, text) {
  * Proactively post a message to a saved Teams conversation.
  * No-op when adapter is null or conversation ref is not found.
  * @param {string} key — conversation key used in saveConversationRef
- * @param {string} text — message text to send
+ * @param {string|object} content — message text or Adaptive Card object
  */
-async function teamsPost(key, text) {
+async function teamsPost(key, content) {
   const adapter = createAdapter();
   if (!adapter) return;
 
@@ -142,10 +164,12 @@ async function teamsPost(key, text) {
   }
 
   try {
+    const activity = toActivity(content);
     await adapter.continueConversationAsync(getTeamsConfig().appId, ref, async (context) => {
-      await context.sendActivity(text);
+      await context.sendActivity(activity);
     });
-    log('info', `Teams proactive message sent to ${key} (${text.length} chars)`);
+    const len = typeof content === 'string' ? content.length : JSON.stringify(content).length;
+    log('info', `Teams proactive message sent to ${key} (${len} chars)`);
   } catch (err) {
     log('warn', `Teams proactive post failed for ${key}: ${err.message}`);
   }
@@ -237,12 +261,7 @@ async function teamsPostCCResponse(userMessage, ccResponse) {
   if (now - _lastCCMirrorPost < CC_MIRROR_RATE_LIMIT_MS) return;
   _lastCCMirrorPost = now;
 
-  const maxLen = 4000;
-  const truncatedResponse = ccResponse.length > maxLen
-    ? ccResponse.slice(0, maxLen) + '... [see dashboard](http://localhost:7331)'
-    : ccResponse;
-
-  const formatted = `**CC** — _${userMessage.slice(0, 200)}_\n\n${truncatedResponse}`;
+  const card = cards.buildCCResponseCard(userMessage, ccResponse);
 
   // Find first available conversation ref
   const state = safeJson(TEAMS_STATE_PATH) || {};
@@ -252,8 +271,8 @@ async function teamsPostCCResponse(userMessage, ccResponse) {
     return;
   }
 
-  await teamsPost(convKeys[0], formatted);
-  log('info', `Teams CC mirror sent (${formatted.length} chars)`);
+  await teamsPost(convKeys[0], card);
+  log('info', `Teams CC mirror sent`);
 }
 
 // ── Post-Completion Notifications ──────────────────────────────────────────
@@ -271,12 +290,10 @@ async function teamsNotifyCompletion(dispatchItem, result, agentId) {
   const eventType = result === 'success' ? 'agent-completed' : 'agent-failed';
   if (!cfg.notifyEvents || !cfg.notifyEvents.includes(eventType)) return;
 
-  const emoji = result === 'success' ? 'Done' : 'Failed';
   const title = dispatchItem.task || dispatchItem.meta?.item?.title || dispatchItem.id;
-  const prLink = dispatchItem.meta?.pr?.url || dispatchItem.pr || '';
-  const prText = prLink ? ` | [PR](${prLink})` : '';
-
-  const text = `**${emoji}** — _${agentId}_ ${result}: ${title}${prText} | [dashboard](http://localhost:7331)`;
+  const prUrl = dispatchItem.meta?.pr?.url || dispatchItem.pr || '';
+  const item = { title, id: dispatchItem.meta?.item?.id || dispatchItem.id };
+  const card = cards.buildCompletionCard(agentId, item, result, prUrl || undefined);
 
   // Find first available conversation ref
   const state = safeJson(TEAMS_STATE_PATH) || {};
@@ -284,7 +301,7 @@ async function teamsNotifyCompletion(dispatchItem, result, agentId) {
   if (convKeys.length === 0) return;
 
   try {
-    await teamsPost(convKeys[0], text);
+    await teamsPost(convKeys[0], card);
     log('info', `Teams completion notification sent for ${dispatchItem.id} (${result})`);
   } catch (err) {
     log('warn', `Teams completion notification failed: ${err.message}`);
@@ -309,13 +326,7 @@ async function teamsNotifyPrEvent(pr, event, project, prFilePath) {
   // Dedup check — don't re-notify the same event
   if (pr._teamsNotifiedEvents && pr._teamsNotifiedEvents.includes(event)) return;
 
-  const prLink = pr.url || '';
-  const linkText = prLink ? ` | [PR](${prLink})` : '';
-  const projectName = project?.name || 'unknown';
-  const agent = pr.agent || 'unknown';
-  const title = pr.title || pr.id || 'Untitled PR';
-
-  const text = `**${event}** — _${agent}_ | ${title} (${projectName})${linkText} | [dashboard](http://localhost:7331)`;
+  const card = cards.buildPrCard(pr, event, project);
 
   // Find first available conversation ref
   const state = safeJson(TEAMS_STATE_PATH) || {};
@@ -323,7 +334,7 @@ async function teamsNotifyPrEvent(pr, event, project, prFilePath) {
   if (convKeys.length === 0) return;
 
   try {
-    await teamsPost(convKeys[0], text);
+    await teamsPost(convKeys[0], card);
     log('info', `Teams PR notification sent: ${event} for ${pr.id}`);
 
     // Record dedup — update _teamsNotifiedEvents on PR via lock
@@ -357,15 +368,14 @@ async function teamsNotifyPlanEvent(planInfo, event) {
   if (!cfg.notifyEvents || !cfg.notifyEvents.includes(event)) return;
 
   const planName = planInfo.name || planInfo.file || 'Unknown plan';
-  const counts = planInfo.doneCount != null ? ` (${planInfo.doneCount}/${planInfo.totalCount} items)` : '';
-  const text = `**${event}** — ${planName}${counts} | [dashboard](http://localhost:7331)`;
+  const card = cards.buildPlanCard(planInfo, event);
 
   const state = safeJson(TEAMS_STATE_PATH) || {};
   const convKeys = Object.keys(state.conversations || {});
   if (convKeys.length === 0) return;
 
   try {
-    await teamsPost(convKeys[0], text);
+    await teamsPost(convKeys[0], card);
     log('info', `Teams plan notification sent: ${event} for ${planName}`);
   } catch (err) {
     log('warn', `Teams plan notification failed: ${err.message}`);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2"
   },
-  "dependencies": {},
+  "dependencies": {
+    "botbuilder": "4.23.3"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9750,6 +9750,29 @@ async function testAutoRecoveryAndAtomicity() {
     assert.strictEqual(shared.ENGINE_DEFAULTS.ccMaxTurns, 50, 'ccMaxTurns default should be 50');
   });
 
+  await test('ENGINE_DEFAULTS.teams has all required fields', () => {
+    const teams = shared.ENGINE_DEFAULTS.teams;
+    assert.ok(teams, 'ENGINE_DEFAULTS should have a teams section');
+    assert.strictEqual(teams.enabled, false, 'teams.enabled default should be false');
+    assert.strictEqual(teams.appId, '', 'teams.appId default should be empty string');
+    assert.strictEqual(teams.appPassword, '', 'teams.appPassword default should be empty string');
+    assert.ok(Array.isArray(teams.notifyEvents), 'teams.notifyEvents should be an array');
+    assert.ok(teams.notifyEvents.includes('pr-merged'), 'notifyEvents should include pr-merged');
+    assert.ok(teams.notifyEvents.includes('agent-completed'), 'notifyEvents should include agent-completed');
+    assert.ok(teams.notifyEvents.includes('plan-completed'), 'notifyEvents should include plan-completed');
+    assert.ok(teams.notifyEvents.includes('agent-failed'), 'notifyEvents should include agent-failed');
+    assert.strictEqual(teams.ccMirror, true, 'teams.ccMirror default should be true');
+    assert.strictEqual(teams.inboxPollInterval, 15000, 'teams.inboxPollInterval default should be 15000');
+  });
+
+  await test('doctor Teams check: warns when enabled but missing credentials', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'preflight.js'), 'utf8');
+    assert.ok(src.includes('Teams integration'), 'doctor should check Teams integration');
+    assert.ok(src.includes('teams.appId'), 'doctor should validate appId');
+    assert.ok(src.includes('teams.appPassword'), 'doctor should validate appPassword');
+    assert.ok(src.includes('docs/teams-setup.md'), 'doctor should reference setup guide when disabled');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9773,6 +9773,67 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(src.includes('docs/teams-setup.md'), 'doctor should reference setup guide when disabled');
   });
 
+  await test('engine/teams.js exports required functions', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.createAdapter, 'function', 'createAdapter should be a function');
+    assert.strictEqual(typeof teams.teamsReply, 'function', 'teamsReply should be a function');
+    assert.strictEqual(typeof teams.saveConversationRef, 'function', 'saveConversationRef should be a function');
+    assert.strictEqual(typeof teams.getConversationRef, 'function', 'getConversationRef should be a function');
+    assert.strictEqual(typeof teams.teamsPost, 'function', 'teamsPost should be a function');
+    assert.strictEqual(typeof teams.getTeamsConfig, 'function', 'getTeamsConfig should be a function');
+    assert.strictEqual(typeof teams.isTeamsEnabled, 'function', 'isTeamsEnabled should be a function');
+  });
+
+  await test('getTeamsConfig merges defaults with user config', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    const cfg = teams.getTeamsConfig();
+    // Should have all default fields even with no user config
+    assert.strictEqual(cfg.enabled, false, 'default enabled should be false');
+    assert.ok(Array.isArray(cfg.notifyEvents), 'notifyEvents should be an array');
+    assert.strictEqual(cfg.ccMirror, true, 'default ccMirror should be true');
+    assert.strictEqual(cfg.inboxPollInterval, 15000, 'default inboxPollInterval should be 15000');
+  });
+
+  await test('isTeamsEnabled returns false when disabled', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    // Default config has enabled: false
+    assert.strictEqual(teams.isTeamsEnabled(), false, 'should be false with default config');
+  });
+
+  await test('createAdapter returns null when Teams is disabled', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    const adapter = teams.createAdapter();
+    assert.strictEqual(adapter, null, 'adapter should be null when disabled');
+  });
+
+  await test('saveConversationRef uses mutateJsonFileLocked', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes('mutateJsonFileLocked(TEAMS_STATE_PATH'), 'saveConversationRef should use mutateJsonFileLocked');
+  });
+
+  await test('teamsReply and teamsPost are safe no-ops when adapter is null', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    // Should not throw
+    await teams.teamsReply(null, 'test');
+    await teams.teamsPost('key', 'test');
+  });
+
+  await test('getConversationRef returns null for unknown key', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(teams.getConversationRef('nonexistent'), null);
+  });
+
+  await test('teams.js uses shared.log for all logging', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes("const { log,"), 'should destructure log from shared');
+    // Should not use console.log directly
+    const lines = src.split('\n');
+    const consoleLogLines = lines.filter(l => l.includes('console.log') && !l.trimStart().startsWith('//'));
+    assert.strictEqual(consoleLogLines.length, 0, 'should not use console.log directly');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9987,6 +9987,47 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(fn.includes('cfg.ccMirror'), 'should check ccMirror config');
   });
 
+  await test('teamsNotifyCompletion is exported from engine/teams.js', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.teamsNotifyCompletion, 'function', 'teamsNotifyCompletion should be a function');
+  });
+
+  await test('teamsNotifyCompletion returns early when Teams disabled', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    await teams.teamsNotifyCompletion({ id: 'test', task: 'test' }, 'success', 'dallas');
+  });
+
+  await test('teamsNotifyCompletion filters by notifyEvents config', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsNotifyCompletion'));
+    assert.ok(fn.includes('cfg.notifyEvents'), 'should check notifyEvents config');
+    assert.ok(fn.includes("'agent-completed'"), 'should map success to agent-completed');
+    assert.ok(fn.includes("'agent-failed'"), 'should map failure to agent-failed');
+  });
+
+  await test('teamsNotifyCompletion formats message with agent, title, result, and PR link', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsNotifyCompletion'));
+    assert.ok(fn.includes('agentId'), 'should include agent ID');
+    assert.ok(fn.includes('title'), 'should include task title');
+    assert.ok(fn.includes('result'), 'should include result status');
+    assert.ok(fn.includes('prLink') || fn.includes('pr'), 'should handle PR link');
+    assert.ok(fn.includes('dashboard'), 'should include dashboard link');
+  });
+
+  await test('Dead TEAMS_PLAN_FLOW_URL block is removed from lifecycle.js', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    assert.ok(!src.includes('TEAMS_PLAN_FLOW_URL'), 'TEAMS_PLAN_FLOW_URL should be removed');
+  });
+
+  await test('runPostCompletionHooks calls teamsNotifyCompletion', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function runPostCompletionHooks'));
+    assert.ok(fn.includes('teamsNotifyCompletion'), 'should call teamsNotifyCompletion');
+    assert.ok(fn.includes('.catch(() => {})'), 'should be non-blocking with .catch');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10078,6 +10078,48 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(src.includes("'build-failed'"), 'github.js should notify on build-failed');
   });
 
+  await test('teamsNotifyPlanEvent is exported from engine/teams.js', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.teamsNotifyPlanEvent, 'function', 'teamsNotifyPlanEvent should be a function');
+  });
+
+  await test('teamsNotifyPlanEvent returns early when Teams disabled', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    await teams.teamsNotifyPlanEvent({ name: 'test plan' }, 'plan-completed');
+  });
+
+  await test('teamsNotifyPlanEvent filters by notifyEvents and formats message', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsNotifyPlanEvent'));
+    assert.ok(fn.includes('cfg.notifyEvents'), 'should check notifyEvents config');
+    assert.ok(fn.includes('planInfo.name'), 'should use plan name');
+    assert.ok(fn.includes('doneCount'), 'should include item counts');
+    assert.ok(fn.includes('dashboard'), 'should include dashboard link');
+  });
+
+  await test('checkPlanCompletion hooks Teams for plan-completed and verify-created', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function checkPlanCompletion'));
+    assert.ok(fn.includes('teamsNotifyPlanEvent'), 'should call teamsNotifyPlanEvent');
+    assert.ok(fn.includes("'plan-completed'"), 'should notify plan-completed');
+    assert.ok(fn.includes("'verify-created'"), 'should notify verify-created');
+  });
+
+  await test('handlePlansApprove hooks Teams for plan-approved', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function handlePlansApprove'));
+    assert.ok(fn.includes('teamsNotifyPlanEvent'), 'should call teamsNotifyPlanEvent');
+    assert.ok(fn.includes("'plan-approved'"), 'should notify plan-approved');
+  });
+
+  await test('handlePlansReject hooks Teams for plan-rejected', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function handlePlansReject'));
+    assert.ok(fn.includes('teamsNotifyPlanEvent'), 'should call teamsNotifyPlanEvent');
+    assert.ok(fn.includes("'plan-rejected'"), 'should notify plan-rejected');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10181,6 +10181,158 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(src.includes('cards.buildCCResponseCard'), 'teamsPostCCResponse should use buildCCResponseCard');
   });
 
+  // ── Teams Rate Limiting & Error Handling ──────────────────────────────────
+
+  await test('teams.js exports rate limiting constants', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(teams.MAX_RETRIES_429, 2, 'MAX_RETRIES_429 should be 2');
+    assert.strictEqual(teams.MAX_RETRIES_5XX, 3, 'MAX_RETRIES_5XX should be 3');
+    assert.strictEqual(teams.CIRCUIT_FAILURE_THRESHOLD, 5, 'CIRCUIT_FAILURE_THRESHOLD should be 5');
+    assert.strictEqual(teams.CIRCUIT_RECOVERY_MS, 10 * 60 * 1000, 'CIRCUIT_RECOVERY_MS should be 10 minutes');
+    assert.strictEqual(teams.OUTBOUND_QUEUE_MAX, 100, 'OUTBOUND_QUEUE_MAX should be 100');
+    assert.strictEqual(teams.OUTBOUND_DRAIN_INTERVAL_MS, 250, 'OUTBOUND_DRAIN_INTERVAL_MS should be 250ms (4/sec)');
+  });
+
+  await test('circuit breaker starts in closed state', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    assert.strictEqual(teams._circuit.state, 'closed', 'initial state should be closed');
+    assert.strictEqual(teams._circuit.failures, 0, 'initial failures should be 0');
+  });
+
+  await test('circuit breaker state is reset by _resetAdapter', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._circuit.state = 'open';
+    teams._circuit.failures = 10;
+    teams._circuit.openedAt = Date.now();
+    teams._resetAdapter();
+    assert.strictEqual(teams._circuit.state, 'closed', 'should reset to closed');
+    assert.strictEqual(teams._circuit.failures, 0, 'should reset failures to 0');
+    assert.strictEqual(teams._circuit.openedAt, 0, 'should reset openedAt to 0');
+  });
+
+  await test('circuit breaker source: opens after CIRCUIT_FAILURE_THRESHOLD failures', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes('_circuit.failures >= CIRCUIT_FAILURE_THRESHOLD'), 'should check failure threshold');
+    assert.ok(src.includes("_circuit.state = 'open'"), 'should set state to open');
+    assert.ok(src.includes('CIRCUIT_RECOVERY_MS'), 'should reference recovery time');
+  });
+
+  await test('circuit breaker source: half-open probe after recovery period', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function _isCircuitOpen'));
+    assert.ok(fn.includes("'half-open'"), 'should transition to half-open');
+    assert.ok(fn.includes('CIRCUIT_RECOVERY_MS'), 'should check recovery period');
+  });
+
+  await test('circuit breaker source: probe failure reopens circuit', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function _onSendFailure'));
+    assert.ok(fn.includes("_circuit.state === 'half-open'"), 'should check for half-open state');
+    assert.ok(fn.includes("_circuit.state = 'open'"), 'should reopen on probe failure');
+  });
+
+  await test('circuit breaker source: success resets to closed', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function _onSendSuccess'));
+    assert.ok(fn.includes("_circuit.state = 'closed'"), 'should reset to closed on success');
+    assert.ok(fn.includes('_circuit.failures = 0'), 'should reset failure count');
+  });
+
+  await test('_sendWithRetry handles 429 with Retry-After', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function _sendWithRetry'));
+    assert.ok(fn.includes('status === 429'), 'should detect 429 status');
+    assert.ok(fn.includes('retry-after'), 'should read Retry-After header');
+    assert.ok(fn.includes('MAX_RETRIES_429'), 'should use MAX_RETRIES_429 limit');
+    assert.ok(fn.includes('_sleep(delayMs)'), 'should delay before retry');
+  });
+
+  await test('_sendWithRetry handles 5xx with exponential backoff', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function _sendWithRetry'));
+    assert.ok(fn.includes('status >= 500'), 'should detect 5xx status');
+    assert.ok(fn.includes('Math.pow(2, retries5xx - 1) * 1000'), 'should use exponential backoff (1s, 2s, 4s)');
+    assert.ok(fn.includes('MAX_RETRIES_5XX'), 'should use MAX_RETRIES_5XX limit');
+  });
+
+  await test('outbound queue is exported and starts empty', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    assert.ok(Array.isArray(teams._outboundQueue), '_outboundQueue should be an array');
+    assert.strictEqual(teams._outboundQueue.length, 0, 'should start empty');
+  });
+
+  await test('outbound queue source: drops messages at OUTBOUND_QUEUE_MAX', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function _enqueueMessage'));
+    assert.ok(fn.includes('_outboundQueue.length >= OUTBOUND_QUEUE_MAX'), 'should check queue length against max');
+    assert.ok(fn.includes('dropping message'), 'should log when dropping');
+  });
+
+  await test('outbound queue source: drains at OUTBOUND_DRAIN_INTERVAL_MS', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes('setInterval(_drainQueue, OUTBOUND_DRAIN_INTERVAL_MS)'), 'should drain at configured interval');
+  });
+
+  await test('outbound queue source: auto-stops drain timer when empty', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function _drainQueue'));
+    assert.ok(fn.includes('_outboundQueue.length === 0'), 'should check if queue is empty');
+    assert.ok(fn.includes('_stopDrainTimer()'), 'should stop timer when empty');
+  });
+
+  await test('teamsPost uses outbound queue instead of direct send', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsPost('));
+    assert.ok(fn.includes('_enqueueMessage'), 'teamsPost should enqueue instead of sending directly');
+    assert.ok(!fn.includes('continueConversationAsync'), 'teamsPost should not call adapter directly');
+  });
+
+  await test('teamsReply uses circuit breaker and retry', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsReply('));
+    assert.ok(fn.includes('_isCircuitOpen()'), 'teamsReply should check circuit breaker');
+    assert.ok(fn.includes('_sendWithRetry'), 'teamsReply should use _sendWithRetry');
+    assert.ok(fn.includes('_onSendSuccess()'), 'teamsReply should call _onSendSuccess');
+    assert.ok(fn.includes('_onSendFailure()'), 'teamsReply should call _onSendFailure');
+  });
+
+  await test('_sendProactive uses circuit breaker and retry', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function _sendProactive('));
+    assert.ok(fn.includes('_isCircuitOpen()'), '_sendProactive should check circuit breaker');
+    assert.ok(fn.includes('_sendWithRetry'), '_sendProactive should use _sendWithRetry');
+    assert.ok(fn.includes('_onSendSuccess()'), '_sendProactive should call _onSendSuccess');
+    assert.ok(fn.includes('_onSendFailure()'), '_sendProactive should call _onSendFailure');
+  });
+
+  await test('no unhandled rejections in Teams code — all async paths have catch', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    // Every async function that calls sendActivity or continueConversationAsync
+    // should be wrapped in try-catch
+    const asyncFns = src.match(/async function \w+/g) || [];
+    for (const fn of asyncFns) {
+      const fnName = fn.replace('async function ', '');
+      const fnBody = src.slice(src.indexOf(fn));
+      const nextFn = fnBody.indexOf('\nasync function ', 1);
+      const body = nextFn > 0 ? fnBody.slice(0, nextFn) : fnBody;
+      if (body.includes('await') && !body.includes('try')) {
+        // processTeamsInbox has try-catch inside the for loop
+        if (fnName !== '_sleep') {
+          assert.fail(`${fnName} has await but no try-catch — potential unhandled rejection`);
+        }
+      }
+    }
+  });
+
+  await test('_resetAdapter clears outbound queue and drain timer', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._outboundQueue.push({ key: 'test', content: 'msg' });
+    teams._resetAdapter();
+    assert.strictEqual(teams._outboundQueue.length, 0, 'queue should be cleared');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9880,6 +9880,62 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(src.includes("const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json')"), 'TEAMS_INBOX_PATH should be defined');
   });
 
+  await test('processTeamsInbox is exported from engine/teams.js', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.processTeamsInbox, 'function', 'processTeamsInbox should be a function');
+  });
+
+  await test('processTeamsInbox returns early when Teams disabled', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    // Default config has enabled: false — should return immediately without errors
+    await teams.processTeamsInbox();
+  });
+
+  await test('processTeamsInbox reads inbox and filters unprocessed', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function processTeamsInbox'));
+    assert.ok(fn.includes('safeJson(TEAMS_INBOX_PATH)'), 'should read from TEAMS_INBOX_PATH');
+    assert.ok(fn.includes('!m._processedAt'), 'should filter for unprocessed messages');
+    assert.ok(fn.includes('_processedAt'), 'should mark messages as processed');
+  });
+
+  await test('processTeamsInbox calls CC via HTTP API', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function processTeamsInbox'));
+    assert.ok(fn.includes('/api/command-center'), 'should call CC via dashboard HTTP API');
+    assert.ok(fn.includes('fetch('), 'should use fetch for HTTP call');
+  });
+
+  await test('processTeamsInbox tracks usage under teams category', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function processTeamsInbox'));
+    assert.ok(fn.includes("trackEngineUsage('teams'"), 'should track usage under teams category');
+  });
+
+  await test('processTeamsInbox prunes inbox when exceeding cap', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function processTeamsInbox'));
+    assert.ok(fn.includes('TEAMS_INBOX_CAP'), 'should reference TEAMS_INBOX_CAP');
+    assert.ok(fn.includes('data.length > TEAMS_INBOX_CAP'), 'should check if inbox exceeds cap');
+  });
+
+  await test('TEAMS_INBOX_CAP is 200', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(teams.TEAMS_INBOX_CAP, 200, 'TEAMS_INBOX_CAP should be 200');
+  });
+
+  await test('Teams inbox timer in cli.js fires only when engine is running', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(src.includes('teamsInboxTimer'), 'should define teamsInboxTimer');
+    assert.ok(src.includes("ctrl.state !== 'running'"), 'should check engine state before processing');
+    assert.ok(src.includes('processTeamsInbox'), 'should call processTeamsInbox');
+  });
+
+  await test('Teams inbox timer is cleared on shutdown', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(src.includes('clearInterval(teamsInboxTimer)'), 'should clear teamsInboxTimer on shutdown');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9948,11 +9948,10 @@ async function testAutoRecoveryAndAtomicity() {
     await teams.teamsPostCCResponse('test', 'response');
   });
 
-  await test('teamsPostCCResponse truncates at 4000 chars', () => {
+  await test('teamsPostCCResponse uses buildCCResponseCard', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
     const fn = src.slice(src.indexOf('async function teamsPostCCResponse'));
-    assert.ok(fn.includes('maxLen = 4000'), 'should truncate at 4000 chars');
-    assert.ok(fn.includes('[see dashboard]'), 'should add dashboard link suffix');
+    assert.ok(fn.includes('cards.buildCCResponseCard'), 'should use card builder');
   });
 
   await test('teamsPostCCResponse has 5s rate limit', () => {
@@ -10006,14 +10005,13 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(fn.includes("'agent-failed'"), 'should map failure to agent-failed');
   });
 
-  await test('teamsNotifyCompletion formats message with agent, title, result, and PR link', () => {
+  await test('teamsNotifyCompletion uses buildCompletionCard with agent, title, result', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
     const fn = src.slice(src.indexOf('async function teamsNotifyCompletion'));
     assert.ok(fn.includes('agentId'), 'should include agent ID');
     assert.ok(fn.includes('title'), 'should include task title');
     assert.ok(fn.includes('result'), 'should include result status');
-    assert.ok(fn.includes('prLink') || fn.includes('pr'), 'should handle PR link');
-    assert.ok(fn.includes('dashboard'), 'should include dashboard link');
+    assert.ok(fn.includes('cards.buildCompletionCard'), 'should use card builder');
   });
 
   await test('Dead TEAMS_PLAN_FLOW_URL block is removed from lifecycle.js', () => {
@@ -10047,14 +10045,12 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(fn.includes('mutateJsonFileLocked'), 'should use mutateJsonFileLocked for dedup write');
   });
 
-  await test('teamsNotifyPrEvent formats message with PR title, link, event, project, agent', () => {
+  await test('teamsNotifyPrEvent uses buildPrCard with pr, event, project', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
     const fn = src.slice(src.indexOf('async function teamsNotifyPrEvent'));
-    assert.ok(fn.includes('pr.title'), 'should include PR title');
-    assert.ok(fn.includes('pr.url'), 'should include PR link');
-    assert.ok(fn.includes('event'), 'should include event type');
-    assert.ok(fn.includes('project'), 'should include project');
-    assert.ok(fn.includes('pr.agent'), 'should include agent');
+    assert.ok(fn.includes('cards.buildPrCard'), 'should use card builder');
+    assert.ok(fn.includes('event'), 'should pass event');
+    assert.ok(fn.includes('project'), 'should pass project');
   });
 
   await test('handlePostMerge calls teamsNotifyPrEvent for merge and abandon', () => {
@@ -10089,13 +10085,12 @@ async function testAutoRecoveryAndAtomicity() {
     await teams.teamsNotifyPlanEvent({ name: 'test plan' }, 'plan-completed');
   });
 
-  await test('teamsNotifyPlanEvent filters by notifyEvents and formats message', () => {
+  await test('teamsNotifyPlanEvent filters by notifyEvents and uses buildPlanCard', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
     const fn = src.slice(src.indexOf('async function teamsNotifyPlanEvent'));
     assert.ok(fn.includes('cfg.notifyEvents'), 'should check notifyEvents config');
     assert.ok(fn.includes('planInfo.name'), 'should use plan name');
-    assert.ok(fn.includes('doneCount'), 'should include item counts');
-    assert.ok(fn.includes('dashboard'), 'should include dashboard link');
+    assert.ok(fn.includes('cards.buildPlanCard'), 'should use card builder for plan notifications');
   });
 
   await test('checkPlanCompletion hooks Teams for plan-completed and verify-created', () => {
@@ -10118,6 +10113,72 @@ async function testAutoRecoveryAndAtomicity() {
     const fn = src.slice(src.indexOf('async function handlePlansReject'));
     assert.ok(fn.includes('teamsNotifyPlanEvent'), 'should call teamsNotifyPlanEvent');
     assert.ok(fn.includes("'plan-rejected'"), 'should notify plan-rejected');
+  });
+
+  await test('engine/teams-cards.js exports all 4 card builders', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    assert.strictEqual(typeof cards.buildCompletionCard, 'function');
+    assert.strictEqual(typeof cards.buildPrCard, 'function');
+    assert.strictEqual(typeof cards.buildPlanCard, 'function');
+    assert.strictEqual(typeof cards.buildCCResponseCard, 'function');
+  });
+
+  await test('Adaptive Cards use schema v1.4 and have fallback text', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    const card = cards.buildCompletionCard('dallas', { title: 'test' }, 'success');
+    assert.strictEqual(card.version, '1.4', 'should use schema v1.4');
+    assert.strictEqual(card.type, 'AdaptiveCard', 'should be AdaptiveCard type');
+    assert.ok(card.fallbackText, 'should have fallback text');
+    assert.ok(card.actions.some(a => a.type === 'Action.OpenUrl'), 'should have OpenUrl actions');
+  });
+
+  await test('buildCompletionCard includes agent, title, result badge, PR link', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    const card = cards.buildCompletionCard('dallas', { title: 'Fix bug' }, 'success', 'https://pr');
+    assert.ok(card.fallbackText.includes('dallas'), 'fallback should include agent');
+    assert.ok(card.fallbackText.includes('Fix bug'), 'fallback should include title');
+    assert.ok(card.actions.some(a => a.url === 'https://pr'), 'should have PR link action');
+    assert.ok(card.actions.some(a => a.title === 'Open Dashboard'), 'should have dashboard link');
+  });
+
+  await test('buildPrCard includes PR title, event, author', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    const card = cards.buildPrCard({ id: 'PR-1', title: 'My PR', agent: 'dallas', url: 'https://pr' }, 'pr-merged', { name: 'test' });
+    assert.ok(card.fallbackText.includes('pr-merged'), 'fallback should include event');
+    assert.ok(card.fallbackText.includes('My PR'), 'fallback should include title');
+    assert.ok(card.actions.some(a => a.url === 'https://pr'), 'should have PR link');
+  });
+
+  await test('buildPlanCard includes plan name, event, item counts', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    const card = cards.buildPlanCard({ name: 'My Plan', doneCount: 3, totalCount: 5 }, 'plan-completed');
+    assert.ok(card.fallbackText.includes('plan-completed'), 'fallback should include event');
+    assert.ok(card.fallbackText.includes('3/5'), 'fallback should include counts');
+    assert.ok(card.actions.some(a => a.url.includes('/prd')), 'should link to PRD page');
+  });
+
+  await test('buildCCResponseCard truncates long answers', () => {
+    const cards = require(path.join(MINIONS_DIR, 'engine', 'teams-cards'));
+    const longAnswer = 'x'.repeat(4000);
+    const card = cards.buildCCResponseCard('question', longAnswer);
+    const bodyText = card.body.find(b => b.text && b.text.includes('x'));
+    assert.ok(bodyText.text.length < 4000, 'should truncate long answers');
+    assert.ok(bodyText.text.endsWith('...'), 'should end with ellipsis');
+  });
+
+  await test('teamsPost/teamsReply accept Adaptive Card objects', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes('function toActivity(content)'), 'should have toActivity helper');
+    assert.ok(src.includes('AdaptiveCard'), 'toActivity should handle AdaptiveCard type');
+    assert.ok(src.includes('application/vnd.microsoft.card.adaptive'), 'should use adaptive card content type');
+  });
+
+  await test('Notification functions use card builders', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    assert.ok(src.includes('cards.buildCompletionCard'), 'teamsNotifyCompletion should use buildCompletionCard');
+    assert.ok(src.includes('cards.buildPrCard'), 'teamsNotifyPrEvent should use buildPrCard');
+    assert.ok(src.includes('cards.buildPlanCard'), 'teamsNotifyPlanEvent should use buildPlanCard');
+    assert.ok(src.includes('cards.buildCCResponseCard'), 'teamsPostCCResponse should use buildCCResponseCard');
   });
 
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10028,6 +10028,56 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(fn.includes('.catch(() => {})'), 'should be non-blocking with .catch');
   });
 
+  await test('teamsNotifyPrEvent is exported from engine/teams.js', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.teamsNotifyPrEvent, 'function', 'teamsNotifyPrEvent should be a function');
+  });
+
+  await test('teamsNotifyPrEvent returns early when Teams disabled', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    await teams.teamsNotifyPrEvent({ id: 'PR-1', title: 'test' }, 'pr-merged', { name: 'test' }, null);
+  });
+
+  await test('teamsNotifyPrEvent filters by notifyEvents and deduplicates', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsNotifyPrEvent'));
+    assert.ok(fn.includes('cfg.notifyEvents'), 'should check notifyEvents config');
+    assert.ok(fn.includes('_teamsNotifiedEvents'), 'should check dedup array');
+    assert.ok(fn.includes('mutateJsonFileLocked'), 'should use mutateJsonFileLocked for dedup write');
+  });
+
+  await test('teamsNotifyPrEvent formats message with PR title, link, event, project, agent', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsNotifyPrEvent'));
+    assert.ok(fn.includes('pr.title'), 'should include PR title');
+    assert.ok(fn.includes('pr.url'), 'should include PR link');
+    assert.ok(fn.includes('event'), 'should include event type');
+    assert.ok(fn.includes('project'), 'should include project');
+    assert.ok(fn.includes('pr.agent'), 'should include agent');
+  });
+
+  await test('handlePostMerge calls teamsNotifyPrEvent for merge and abandon', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function handlePostMerge'));
+    assert.ok(fn.includes('teamsNotifyPrEvent'), 'should call teamsNotifyPrEvent');
+    assert.ok(fn.includes("'pr-merged'"), 'should handle pr-merged event');
+    assert.ok(fn.includes("'pr-abandoned'"), 'should handle pr-abandoned event');
+    assert.ok(fn.includes('.catch(() => {})'), 'should be non-blocking');
+  });
+
+  await test('ado.js pollPrStatus notifies Teams on build failure', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    assert.ok(src.includes('teamsNotifyPrEvent'), 'ado.js should call teamsNotifyPrEvent');
+    assert.ok(src.includes("'build-failed'"), 'ado.js should notify on build-failed');
+  });
+
+  await test('github.js pollPrStatus notifies Teams on build failure', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'github.js'), 'utf8');
+    assert.ok(src.includes('teamsNotifyPrEvent'), 'github.js should call teamsNotifyPrEvent');
+    assert.ok(src.includes("'build-failed'"), 'github.js should notify on build-failed');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9834,6 +9834,52 @@ async function testAutoRecoveryAndAtomicity() {
     assert.strictEqual(consoleLogLines.length, 0, 'should not use console.log directly');
   });
 
+  await test('POST /api/bot route is registered in dashboard.js', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(src.includes("path: '/api/bot'"), '/api/bot route should be registered');
+    assert.ok(src.includes("method: 'POST'") && src.includes('/api/bot'), 'should be a POST route');
+    assert.ok(src.includes('handleTeamsBot'), 'should reference handleTeamsBot handler');
+  });
+
+  await test('/api/bot returns 503 when Teams disabled', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const handler = src.slice(src.indexOf('async function handleTeamsBot'));
+    assert.ok(handler.includes('503'), 'should return 503 when disabled');
+    assert.ok(handler.includes('Teams integration disabled'), 'should include disabled message');
+  });
+
+  await test('/api/bot filters bot own messages by appId', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const handler = src.slice(src.indexOf('async function handleTeamsBot'));
+    assert.ok(handler.includes('cfg.appId'), 'should compare from.id to appId');
+    assert.ok(handler.includes('activity.from?.id === cfg.appId'), 'should filter bot own messages');
+  });
+
+  await test('/api/bot writes to teams-inbox.json with required fields', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const handler = src.slice(src.indexOf('async function handleTeamsBot'));
+    assert.ok(handler.includes('mutateJsonFileLocked(TEAMS_INBOX_PATH'), 'should use mutateJsonFileLocked for teams-inbox.json');
+    assert.ok(handler.includes('id: msgId'), 'message should have id field');
+    assert.ok(handler.includes('text: activity.text'), 'message should have text field');
+    assert.ok(handler.includes("from: activity.from?.name"), 'message should have from field');
+    assert.ok(handler.includes('conversationRef:'), 'message should have conversationRef field');
+    assert.ok(handler.includes('receivedAt:'), 'message should have receivedAt field');
+    assert.ok(handler.includes('_processedAt: null'), 'message should have _processedAt field');
+  });
+
+  await test('/api/bot saves conversationRef on conversationUpdate and installationUpdate', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const handler = src.slice(src.indexOf('async function handleTeamsBot'));
+    assert.ok(handler.includes("activity.type === 'conversationUpdate'"), 'should handle conversationUpdate');
+    assert.ok(handler.includes("activity.type === 'installationUpdate'"), 'should handle installationUpdate');
+    assert.ok(handler.includes('teams.saveConversationRef'), 'should call saveConversationRef');
+  });
+
+  await test('TEAMS_INBOX_PATH is defined in dashboard.js', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(src.includes("const TEAMS_INBOX_PATH = path.join(ENGINE_DIR, 'teams-inbox.json')"), 'TEAMS_INBOX_PATH should be defined');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9936,6 +9936,57 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(src.includes('clearInterval(teamsInboxTimer)'), 'should clear teamsInboxTimer on shutdown');
   });
 
+  await test('teamsPostCCResponse is exported from engine/teams.js', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(typeof teams.teamsPostCCResponse, 'function', 'teamsPostCCResponse should be a function');
+  });
+
+  await test('teamsPostCCResponse returns early when Teams disabled', async () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    teams._resetAdapter();
+    // Default config has enabled: false — should return immediately
+    await teams.teamsPostCCResponse('test', 'response');
+  });
+
+  await test('teamsPostCCResponse truncates at 4000 chars', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsPostCCResponse'));
+    assert.ok(fn.includes('maxLen = 4000'), 'should truncate at 4000 chars');
+    assert.ok(fn.includes('[see dashboard]'), 'should add dashboard link suffix');
+  });
+
+  await test('teamsPostCCResponse has 5s rate limit', () => {
+    const teams = require(path.join(MINIONS_DIR, 'engine', 'teams'));
+    assert.strictEqual(teams.CC_MIRROR_RATE_LIMIT_MS, 5000, 'rate limit should be 5000ms');
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsPostCCResponse'));
+    assert.ok(fn.includes('_lastCCMirrorPost'), 'should track last mirror post timestamp');
+    assert.ok(fn.includes('CC_MIRROR_RATE_LIMIT_MS'), 'should reference rate limit constant');
+  });
+
+  await test('CC mirror hooks in dashboard.js skip Teams-originated messages', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // Non-streaming handler
+    const ccHandler = src.slice(src.indexOf('async function handleCommandCenter('));
+    assert.ok(ccHandler.includes("tabId.startsWith('teams-')"), 'non-streaming should check tabId for teams origin');
+    assert.ok(ccHandler.includes('teamsPostCCResponse'), 'non-streaming should call teamsPostCCResponse');
+    assert.ok(ccHandler.includes('.catch(() => {})'), 'non-streaming mirror should be non-blocking');
+  });
+
+  await test('CC streaming mirror hooks skip Teams-originated messages', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const streamHandler = src.slice(src.indexOf('async function handleCommandCenterStream('));
+    assert.ok(streamHandler.includes("_streamTabId.startsWith('teams-')"), 'streaming should check tabId for teams origin');
+    assert.ok(streamHandler.includes('teamsPostCCResponse'), 'streaming should call teamsPostCCResponse');
+    assert.ok(streamHandler.includes('.catch(() => {})'), 'streaming mirror should be non-blocking');
+  });
+
+  await test('CC mirror checks ccMirror config before posting', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function teamsPostCCResponse'));
+    assert.ok(fn.includes('cfg.ccMirror'), 'should check ccMirror config');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));


### PR DESCRIPTION
## Summary

End-to-end aggregate PR for the **Bidirectional Teams integration for Command Center** plan (`minions-2026-04-09-2.json`).

Adds full Microsoft Teams ↔ Command Center bidirectional messaging via Azure Bot Framework:
- Receive messages from Teams, route them through CC, reply in-thread
- Mirror CC dashboard responses to a Teams channel
- Push agent completion, PR lifecycle, and plan lifecycle notifications as Adaptive Cards
- Production-grade rate limiting with circuit breaker, 429/5xx retries, and outbound queue

### Individual PRs merged into this branch

All 12 plan items were implemented on the shared `feat/cc-teams-integration` branch:

| Commit | Plan Item | Description |
|--------|-----------|-------------|
| `8ba71c8` | P-t4k8m2v1 | Azure Bot setup guide |
| `249cd47` | P-c6w1j8f4 | Teams config section and preflight validation |
| `7f0c8bc` | P-b7n3r5x9 | Install botbuilder and create engine/teams.js |
| `c16cecc` | P-d9p5h2a7 | Add /api/bot endpoint and wire Teams inbox |
| `f0aae49` | P-e3q7s1g6 | Process Teams inbox and reply via CC |
| `d360921` | P-f8v2k5n3 | Mirror CC responses to Teams |
| `c89d807` | P-g1m6t9w4 | Post-completion Teams notifications |
| `bb13caa` | P-h5r3j7c2 | PR lifecycle Teams notifications |
| `e7bac9d` | P-i2x8p4d6 | Plan lifecycle Teams notifications |
| `c77ddac` | P-j6n1f9b5 | Adaptive Card templates for Teams messages |
| `2bc7f73` | P-k4w7a3e8 | Rate limiting and error handling for Teams |
| `c7becba` | P-l9d5m2h1 | Production endpoint migration guide |

### Build / Test Status

- **Build:** ✅ PASS — `npm install` succeeded (botbuilder 4.23.3 + 113 transitive deps)
- **Tests:** ✅ PASS — 1144 tests passed, 0 failed (includes 39 new Teams-specific tests)
- **TEAMS_PLAN_FLOW_URL removal:** ✅ Verified — no references remain in lifecycle.js, dashboard.js, or shared.js

### Files Changed (13 files, +2169 lines)

- `engine/teams.js` — Core Teams module (589 lines)
- `engine/teams-cards.js` — Adaptive Card builders (137 lines)
- `engine/shared.js` — ENGINE_DEFAULTS.teams section
- `engine/preflight.js` — Teams doctor checks
- `engine/lifecycle.js` — Completion and plan notifications
- `engine/cli.js` — Teams inbox poll timer
- `engine/ado.js` — PR build failure Teams notification
- `engine/github.js` — PR build failure Teams notification
- `dashboard.js` — /api/bot endpoint, CC mirror hooks
- `test/unit.test.js` — 39 new Teams tests (583 lines)
- `docs/teams-setup.md` — Azure Bot setup guide
- `docs/teams-production.md` — Production endpoint migration guide
- `package.json` — botbuilder dependency

### Testing Guide

See `prd/guides/verify-minions-2026-04-09-2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)