### PR TITLE
fix: project-scoped skill path format

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1081,7 +1081,7 @@ function extractSkillsFromOutput(output, agentId, dispatchItem, config) {
     let enrichedBlock = block;
     if (!m('author')) enrichedBlock = enrichedBlock.replace('---\n', `---\nauthor: ${agentName}\n`);
     if (!m('created')) enrichedBlock = enrichedBlock.replace('---\n', `---\ncreated: ${dateStamp()}\n`);
-    const filename = name.replace(/[^a-z0-9-]/g, '-') + '.md';
+    const skillDirName = name.replace(/[^a-z0-9-]/g, '-');
     if (scope === 'project' && project) {
       const proj = shared.getProjects(config).find(p => p.name === project);
       if (proj) {
@@ -1092,7 +1092,7 @@ function extractSkillsFromOutput(output, agentId, dispatchItem, config) {
           if (data.some(i => i.title === `Add skill: ${name}` && i.status !== WI_STATUS.FAILED)) return data;
           skillId = `SK${String(data.filter(i => i.id?.startsWith('SK')).length + 1).padStart(3, '0')}`;
           data.push({ id: skillId, type: 'implement', title: `Add skill: ${name}`,
-            description: `Create project-level skill \`${filename}\` in ${project}.\n\nWrite this file to \`${proj.localPath}/.claude/skills/${filename}\` via a PR.\n\n## Skill Content\n\n\`\`\`\n${enrichedBlock}\n\`\`\``,
+            description: `Create project-level skill \`${skillDirName}/SKILL.md\` in ${project}.\n\nWrite this file to \`${proj.localPath}/.claude/skills/${skillDirName}/SKILL.md\` via a PR.\n\n## Skill Content\n\n\`\`\`\n${enrichedBlock}\n\`\`\``,
             priority: 'low', status: WI_STATUS.QUEUED, created: ts(), createdBy: `engine:skill-extraction:${agentName}` });
           return data;
         });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4207,6 +4207,8 @@ async function testExtractSkills() {
     const skillWi = wi.find(w => w.title && w.title.includes('Add skill: app-deploy'));
     assert.ok(skillWi, 'Should queue a work item to PR the project-scoped skill');
     assert.ok(skillWi.description.includes('app-deploy'), 'Work item should reference skill name');
+    assert.ok(skillWi.description.includes('app-deploy/SKILL.md'), 'Work item path should use directory/SKILL.md format, not flat .md');
+    assert.ok(!skillWi.description.includes('app-deploy.md'), 'Work item path should NOT use flat .md format');
   });
 
   restore();


### PR DESCRIPTION
Closes yemi33/minions#790

## Summary
- Fix skill extraction in `engine/lifecycle.js` to use `<name>/SKILL.md` directory format instead of flat `<name>.md` for project-scoped skill work items
- Matches the Claude Code native skill format already used by the global (minions-scoped) branch
- Added test assertions verifying the correct path format in work item descriptions

## What changed
- `engine/lifecycle.js:1084`: Renamed `filename` to `skillDirName`, removed `.md` suffix
- `engine/lifecycle.js:1095`: Updated work item description to use `${skillDirName}/SKILL.md` path
- `test/unit.test.js:4209-4210`: Added assertions confirming directory format and rejecting flat format