### PR TITLE
fix: handle force-pushed dep branches on retry

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -493,8 +493,25 @@ async function spawnAgent(dispatchItem, config) {
                 await execAsync(`git merge "origin/${depBranch}" --no-edit`, { ..._gitOpts, cwd: worktreePath });
                 log('info', `Merged dependency branch ${depBranch} (${prId}) into worktree ${branchName}`);
               } catch (mergeErr) {
-                log('warn', `Failed to merge dependency ${depBranch} into ${branchName}: ${mergeErr.message}`);
-                depMergeFailed = true;
+                // Merge failed — possibly due to diverged history from a force-pushed (rebased) dep branch.
+                // Abort partial merge, reset worktree to clean main base, and re-merge all deps from scratch.
+                log('warn', `Merge of ${depBranch} into ${branchName} failed: ${mergeErr.message} — attempting reset and re-merge of all deps`);
+                try { await execAsync(`git merge --abort`, { ..._gitOpts, cwd: worktreePath }); } catch (_) { /* no merge in progress */ }
+                const mainRef = sanitizeBranch(shared.resolveMainBranch(rootDir, project.mainBranch));
+                try {
+                  await execAsync(`git reset --hard "origin/${mainRef}"`, { ..._gitOpts, cwd: worktreePath });
+                  log('info', `Reset worktree ${branchName} to origin/${mainRef} for clean dep re-merge`);
+                  // Re-merge ALL fetched dep branches from scratch on clean base
+                  for (const { branch: reBranch, prId: rePrId } of fetched) {
+                    await execAsync(`git merge "origin/${reBranch}" --no-edit`, { ..._gitOpts, cwd: worktreePath });
+                    log('info', `Re-merged dependency branch ${reBranch} (${rePrId}) into worktree ${branchName}`);
+                  }
+                  log('info', `Successfully re-merged all ${fetched.length} dep branches after reset for ${branchName}`);
+                } catch (resetErr) {
+                  log('warn', `Failed to reset and re-merge deps for ${branchName}: ${resetErr.message}`);
+                  try { await execAsync(`git merge --abort`, { ..._gitOpts, cwd: worktreePath }); } catch (_) { /* no merge in progress */ }
+                  depMergeFailed = true;
+                }
                 break;
               }
             }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6138,6 +6138,34 @@ async function testDispatchCycleIntegration() {
       'engine.js must resolve and merge dependency branches');
   });
 
+  await test('Dep merge handles force-pushed branches by resetting and re-merging', () => {
+    // When git merge fails (e.g. diverged history from force-push), the engine should:
+    // 1. Abort the partial merge
+    // 2. Reset worktree to origin/<mainBranch>
+    // 3. Re-merge all deps from scratch
+    assert.ok(engineSrc.includes('git merge --abort'),
+      'engine.js must abort partial merge on dep merge failure');
+    assert.ok(engineSrc.includes('git reset --hard') && engineSrc.includes('resolveMainBranch'),
+      'engine.js must reset worktree to main branch on dep merge failure');
+    assert.ok(engineSrc.includes('Re-merged dependency branch'),
+      'engine.js must re-merge all deps after reset');
+    assert.ok(engineSrc.includes('reset and re-merge of all deps'),
+      'engine.js must log the reset and re-merge attempt');
+  });
+
+  await test('Dep merge re-merge failure marks depMergeFailed', () => {
+    // If re-merge also fails (genuine conflict), depMergeFailed must be set
+    // so the dispatch is completed with ERROR and retried next tick
+    assert.ok(engineSrc.includes('Failed to reset and re-merge deps'),
+      'engine.js must log re-merge failure');
+    // After reset failure, must also abort any in-progress merge from the re-merge attempt
+    const resetCatchBlock = engineSrc.substring(
+      engineSrc.indexOf('Failed to reset and re-merge deps')
+    );
+    assert.ok(resetCatchBlock.includes('depMergeFailed = true'),
+      'engine.js must set depMergeFailed on re-merge failure');
+  });
+
   await test('Spawn renders playbook with system prompt', () => {
     assert.ok(engineSrc.includes('function renderPlaybook'),
       'engine.js must define renderPlaybook');


### PR DESCRIPTION
Closes yemi33/minions#738

## Summary

- When `git merge origin/<dep>` fails (e.g. diverged history from a force-pushed/rebased dep branch), the engine now:
  1. Aborts the partial merge (`git merge --abort`)
  2. Resets the worktree to `origin/<mainBranch>` (`git reset --hard`)
  3. Re-merges **all** fetched dep branches from scratch on the clean base
- If the re-merge also fails (genuine conflict), marks `depMergeFailed` and bails as before (retry next tick)
- Previously, the merge failure immediately set `depMergeFailed = true`, causing a permanent retry loop when a dep was force-pushed

## Test plan

- [x] 2 new source-pattern tests verify the reset-and-re-merge code paths exist
- [x] `npm test` passes (1297 pass, 12 pre-existing failures, 0 regressions)
- [ ] Manual: create work item A depending on B, dispatch A, force-push B, retry A — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)