### PR TITLE
fix(W-mnt7oquq9jr7): PRD item retry when work item missing

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1046,7 +1046,74 @@ const server = http.createServer(async (req, res) => {
           }
         }
       }
-      if (!wiPath) return jsonReply(res, 404, { error: 'work item not found in any source' });
+      // If no work item found, attempt to re-materialize from PRD item definition
+      if (!wiPath) {
+        const prdFile = body.prdFile;
+        if (!prdFile) return jsonReply(res, 404, { error: 'work item not found in any source' });
+
+        // Look up PRD item to create a new work item on-demand
+        const prdPath = path.join(PRD_DIR, prdFile);
+        const plan = shared.safeJson(prdPath);
+        if (!plan?.missing_features) return jsonReply(res, 404, { error: 'PRD file not found or invalid' });
+        const prdItem = plan.missing_features.find(f => f.id === id);
+        if (!prdItem) return jsonReply(res, 404, { error: 'PRD item not found in ' + prdFile });
+
+        // Determine target work-items file (project from PRD item or plan, fallback to central)
+        const projName = prdItem.project || plan.project || prdFile.replace(/-\d{4}-\d{2}-\d{2}\.json$/, '');
+        const proj = PROJECTS.find(p => p.name?.toLowerCase() === projName.toLowerCase());
+        const targetWiPath = proj ? shared.projectWorkItemsPath(proj) : path.join(MINIONS_DIR, 'work-items.json');
+
+        // Create new work item from PRD item definition (same logic as materializePlansAsWorkItems)
+        const complexity = prdItem.estimated_complexity || 'medium';
+        const criteria = (prdItem.acceptance_criteria || []).map(c => `- ${c}`).join('\n');
+        const newItem = {
+          id,
+          title: `Implement: ${prdItem.name}`,
+          type: complexity === 'large' ? 'implement:large' : 'implement',
+          priority: prdItem.priority || 'medium',
+          description: `${prdItem.description || ''}\n\n**Plan:** ${prdFile}\n**Plan Item:** ${prdItem.id}\n**Complexity:** ${complexity}${criteria ? '\n\n**Acceptance Criteria:**\n' + criteria : ''}`,
+          status: WI_STATUS.PENDING,
+          created: new Date().toISOString(),
+          createdBy: 'dashboard:prd-retry',
+          sourcePlan: prdFile,
+          depends_on: prdItem.depends_on || [],
+          branchStrategy: plan.branch_strategy || 'parallel',
+          featureBranch: plan.feature_branch || null,
+          project: prdItem.project || plan.project || null,
+          _source: proj?.name || 'central',
+          _retryCount: 0,
+        };
+        mutateWorkItems(targetWiPath, items => { items.push(newItem); });
+
+        // Reset PRD item status to pending
+        try {
+          const lifecycle = require('./engine/lifecycle');
+          lifecycle.syncPrdItemStatus(id, WI_STATUS.PENDING, prdFile);
+        } catch (e) { console.error('PRD status sync:', e.message); }
+
+        // Clear dispatch history and cooldowns for this item
+        const dispatchPath = path.join(MINIONS_DIR, 'engine', 'dispatch.json');
+        const sourcePrefix = proj ? `work-${proj.name}-` : 'central-work-';
+        const dispatchKey = sourcePrefix + id;
+        try {
+          mutateJsonFileLocked(dispatchPath, (dispatch) => {
+            dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
+            dispatch.completed = dispatch.completed.filter(d => d.meta?.dispatchKey !== dispatchKey);
+            dispatch.completed = dispatch.completed.filter(d => !d.meta?.parentKey || d.meta.parentKey !== dispatchKey);
+            return dispatch;
+          }, { defaultValue: { pending: [], active: [], completed: [] } });
+        } catch (e) { console.error('dispatch cleanup:', e.message); }
+        try {
+          const cooldownPath = path.join(MINIONS_DIR, 'engine', 'cooldowns.json');
+          const cooldowns = safeJsonObj(cooldownPath);
+          if (cooldowns[dispatchKey]) {
+            delete cooldowns[dispatchKey];
+            safeWrite(cooldownPath, cooldowns);
+          }
+        } catch (e) { console.error('cooldown cleanup:', e.message); }
+
+        return jsonReply(res, 200, { ok: true, id, rematerialized: true });
+      }
 
       let found = false;
       mutateJsonFileLocked(wiPath, (items) => {

--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -171,9 +171,10 @@ function renderPrdProgress(prog) {
     const agentLabel = wiAgent ? '<span style="font-size:9px;color:var(--muted)" title="' + escHtml(wiAgent.name || wi.dispatched_to) + '">' +
       (wiAgent.emoji || '') + ' ' + escHtml(wiAgent.name || wi.dispatched_to) + '</span>' : '';
 
-    // Requeue button for failed items
-    const canRequeue = wi && (wi.status === 'failed' || i.status === 'failed');
-    const requeueState = wi ? getPrdRequeueState(wi.id) : null;
+    // Requeue button for failed items or PRD items with no work item (orphaned/deleted)
+    const canRequeue = (wi && (wi.status === 'failed' || i.status === 'failed')) ||
+      (!wi && i.status && i.status !== 'missing' && i.status !== 'done' && i.status !== 'planned');
+    const requeueState = getPrdRequeueState(wi ? wi.id : i.id);
     let requeueBtn = '';
     if (requeueState && requeueState.status === 'pending') {
       requeueBtn = '<span style="color:var(--yellow);cursor:wait;font-size:9px;padding:1px 5px;background:rgba(210,153,34,0.1);border:1px solid rgba(210,153,34,0.35);border-radius:3px" title="Retry request in progress">requeuing…</span>';
@@ -182,7 +183,7 @@ function renderPrdProgress(prog) {
     } else if (requeueState && requeueState.status === 'error') {
       requeueBtn = '<span style="color:var(--red);cursor:default;font-size:9px;padding:1px 5px;background:rgba(248,81,73,0.1);border:1px solid rgba(248,81,73,0.35);border-radius:3px" title="' + escHtml(requeueState.message || 'Retry failed') + '">retry failed</span>';
     } else if (canRequeue) {
-      requeueBtn = '<span onclick="event.stopPropagation();prdItemRequeue(\'' + escHtml(wi.id) + '\',\'' + escHtml(wi._source || '') + '\')" style="color:var(--green);cursor:pointer;font-size:9px;padding:1px 5px;background:rgba(63,185,80,0.1);border:1px solid rgba(63,185,80,0.3);border-radius:3px" title="Requeue this work item">retry</span>';
+      requeueBtn = '<span onclick="event.stopPropagation();prdItemRequeue(\'' + escHtml(wi ? wi.id : i.id) + '\',\'' + escHtml(wi ? (wi._source || '') : '') + '\',\'' + escHtml(i.source || '') + '\')" style="color:var(--green);cursor:pointer;font-size:9px;padding:1px 5px;background:rgba(63,185,80,0.1);border:1px solid rgba(63,185,80,0.3);border-radius:3px" title="Requeue this work item">retry</span>';
     }
 
     return '<div class="prd-item-row st-' + (i.status || 'missing') + '" style="flex-wrap:wrap;cursor:pointer" onclick="prdItemEdit(\'' + src + '\',\'' + iid + '\')">' +
@@ -381,8 +382,8 @@ function renderPrdProgress(prog) {
             (agentDisplay ? '<span style="font-size:8px;color:var(--muted)">' + agentDisplay + '</span>' : '') +
             (function() {
               const w = wi[i.id];
-              if (!w) return '';
-              const rq = getPrdRequeueState(w.id);
+              const rqId = w ? w.id : i.id;
+              const rq = getPrdRequeueState(rqId);
               if (rq && rq.status === 'pending') {
                 return '<span style="font-size:8px;color:var(--yellow);cursor:wait;padding:1px 4px;background:rgba(210,153,34,0.1);border:1px solid rgba(210,153,34,0.35);border-radius:3px">requeuing…</span>';
               }
@@ -392,8 +393,11 @@ function renderPrdProgress(prog) {
               if (rq && rq.status === 'error') {
                 return '<span style="font-size:8px;color:var(--red);cursor:default;padding:1px 4px;background:rgba(248,81,73,0.1);border:1px solid rgba(248,81,73,0.35);border-radius:3px" title="' + escHtml(rq.message || 'Retry failed') + '">failed</span>';
               }
-              if (i.status !== 'failed') return '';
-              return '<span onclick="event.stopPropagation();prdItemRequeue(\'' + escHtml(w.id) + '\',\'' + escHtml(w._source || '') + '\')" style="font-size:8px;color:var(--green);cursor:pointer;padding:1px 4px;background:rgba(63,185,80,0.1);border:1px solid rgba(63,185,80,0.3);border-radius:3px">retry</span>';
+              // Show retry for failed items, or PRD items with no work item (orphaned/deleted)
+              const canRetry = (w && i.status === 'failed') ||
+                (!w && i.status && i.status !== 'missing' && i.status !== 'done' && i.status !== 'planned');
+              if (!canRetry) return '';
+              return '<span onclick="event.stopPropagation();prdItemRequeue(\'' + escHtml(rqId) + '\',\'' + escHtml(w ? (w._source || '') : '') + '\',\'' + escHtml(i.source || '') + '\')" style="font-size:8px;color:var(--green);cursor:pointer;padding:1px 4px;background:rgba(63,185,80,0.1);border:1px solid rgba(63,185,80,0.3);border-radius:3px">retry</span>';
             })() +
             (deps ? '<span style="font-size:8px;color:var(--muted)" title="Depends on: ' + escHtml(deps) + '">deps: ' + escHtml(deps) + '</span>' : '') +
           '</div>' +
@@ -713,13 +717,15 @@ async function prdItemRemove(source, itemId) {
   } catch (e) { alert('Error: ' + e.message); refresh(); }
 }
 
-async function prdItemRequeue(workItemId, source) {
+async function prdItemRequeue(workItemId, source, prdFile) {
   setPrdRequeueState(workItemId, { status: 'pending', message: '' });
   rerenderPrdFromCache();
   try {
+    const payload = { id: workItemId, source };
+    if (prdFile) payload.prdFile = prdFile;
     const res = await fetch('/api/work-items/retry', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: workItemId, source })
+      body: JSON.stringify(payload)
     });
     if (res.ok) {
       setPrdRequeueState(workItemId, { status: 'queued', until: Date.now() + 10000 });

--- a/engine.js
+++ b/engine.js
@@ -1185,6 +1185,10 @@ function autoCleanPrdWorkItems(prdFile, config) {
       }
       return dispatch;
     });
+    // Reset PRD item status to 'missing' so engine re-materializes on next tick
+    for (const id of deletedIds) {
+      try { syncPrdItemStatus(id, 'missing', prdFile); } catch (e) { log('warn', `PRD status reset for ${id}: ${e.message}`); }
+    }
     log('info', `Plan sync: cleared ${deletedIds.length} pending/failed work items for ${prdFile}`);
   }
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9966,11 +9966,55 @@ async function testAutoRecoveryAndAtomicity() {
       'Retry button should call prdItemRequeue');
   });
 
+  await test('PRD list view shows retry button when work item missing (orphaned PRD item)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    const renderItem = src.slice(src.indexOf('const renderItem'));
+    // canRequeue should handle !wi case for stuck PRD items
+    assert.ok(renderItem.includes("!wi && i.status") && renderItem.includes("!== 'missing'") && renderItem.includes("!== 'done'"),
+      'canRequeue should also trigger when no work item exists and PRD status is stuck');
+  });
+
   await test('PRD graph view also shows retry button for failed items', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
     const graphFn = src.slice(src.indexOf('const renderGraph'));
     assert.ok(graphFn.includes("'failed'") && graphFn.includes('prdItemRequeue'),
       'Graph view should check failed status and have prdItemRequeue click handler');
+  });
+
+  await test('PRD graph view shows retry for orphaned items (no work item)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    const graphFn = src.slice(src.indexOf('const renderGraph'));
+    assert.ok(graphFn.includes("!w && i.status") && graphFn.includes("!== 'missing'"),
+      'Graph view canRetry should handle missing work item case');
+  });
+
+  await test('prdItemRequeue sends prdFile parameter for re-materialization', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function prdItemRequeue'));
+    assert.ok(fn.includes('prdFile'),
+      'prdItemRequeue should accept and send prdFile parameter');
+    assert.ok(fn.includes('payload.prdFile'),
+      'prdItemRequeue should add prdFile to request payload');
+  });
+
+  await test('handleWorkItemsRetry re-materializes from PRD when work item missing', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const fn = src.slice(src.indexOf('async function handleWorkItemsRetry'));
+    assert.ok(fn.includes('body.prdFile'),
+      'Retry handler should check for prdFile in request body');
+    assert.ok(fn.includes("createdBy: 'dashboard:prd-retry'"),
+      'Re-materialized work items should be tagged as dashboard:prd-retry');
+    assert.ok(fn.includes('rematerialized: true'),
+      'Response should indicate work item was re-materialized');
+    assert.ok(fn.includes('syncPrdItemStatus'),
+      'Retry handler should sync PRD item status after re-materialization');
+  });
+
+  await test('autoCleanPrdWorkItems resets PRD status to missing after deleting work items', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function autoCleanPrdWorkItems'), src.indexOf('function autoCleanPrdWorkItems') + 2000);
+    assert.ok(fn.includes("syncPrdItemStatus(id, 'missing', prdFile)"),
+      'autoCleanPrdWorkItems must reset PRD item status to missing when deleting work items');
   });
 
   await test('PRD view toggle uses rerenderPrdFromCache (not refresh)', () => {


### PR DESCRIPTION
Closes yemi33/minions#781

## Summary

When a PRD item has no corresponding work item (deleted during cleanup or orphaned), there was no way to reset or retry it from the dashboard. This PR fixes all three root causes:

1. **Dashboard retry button** (`render-prd.js`): Now shows for PRD items where the work item was deleted — both list and graph views. Previously required `wi` to exist.

2. **Retry API** (`dashboard.js`): `/api/work-items/retry` now accepts a `prdFile` parameter. When no work item is found but `prdFile` is provided, it creates a new pending work item from the PRD item definition (same logic as `materializePlansAsWorkItems`), resets PRD status, and clears dispatch history/cooldowns.

3. **Auto-cleanup** (`engine.js`): `autoCleanPrdWorkItems` now calls `syncPrdItemStatus(id, 'missing', prdFile)` after deleting work items, so the engine re-materializes them on the next tick instead of leaving PRD items permanently stuck.

## Test plan

- [x] 5 new unit tests covering all three fixes (1300 passing, 12 pre-existing failures)
- [ ] Manual: delete a work item linked to a PRD item → verify retry button appears
- [ ] Manual: click retry on orphaned PRD item → verify work item is re-created
- [ ] Manual: trigger autoCleanPrdWorkItems → verify PRD status resets to 'missing'

🤖 Generated with [Claude Code](https://claude.com/claude-code)