### PR TITLE
fix: CC queue drain uses combined flush, not one-at-a-time while loop

### DIFF
--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -378,14 +378,11 @@ async function ccSend() {
   }
   var wasAborted = await _ccDoSend(message);
 
-  // Drain queued messages one at a time with abort delay
-  while (tab._queue && tab._queue.length > 0) {
-    if (wasAborted) {
-      await new Promise(function(r) { setTimeout(r, 600); });
-    }
-    var next = tab._queue.shift();
+  // Flush queued messages — combine into single request
+  if (tab._queue && tab._queue.length > 0) {
+    var combined = tab._queue.splice(0).join('\n\n');
     _renderQueueIndicator();
-    wasAborted = await _ccDoSend(next);
+    await _ccDoSend(combined);
   }
 }
 


### PR DESCRIPTION
## Summary

- PR-762 merged the while loop drain approach (one message at a time, 600ms abort delay) via a conflict resolution, overwriting master's combined flush
- This restores the combined flush: all queued messages are joined with `\n\n` and sent as a single request

## What changed

**Before (from PR-762 merge):**
```js
while (tab._queue && tab._queue.length > 0) {
  if (wasAborted) await new Promise(r => setTimeout(r, 600));
  var next = tab._queue.shift();
  _renderQueueIndicator();
  wasAborted = await _ccDoSend(next);
}
```

**After:**
```js
if (tab._queue && tab._queue.length > 0) {
  var combined = tab._queue.splice(0).join('\n\n');
  _renderQueueIndicator();
  await _ccDoSend(combined);
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)