### PR TITLE
fix(W-mntkzthce4r2): PID file leak in indirect spawn + kb-sweep race condition

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1876,6 +1876,9 @@ const server = http.createServer(async (req, res) => {
       global._kbSweepInFlight = false;
     }
     if (global._kbSweepInFlight) return jsonReply(res, 409, { error: 'sweep already in progress' });
+    // Generation token prevents stale finally blocks from clearing the flag for a new sweep
+    const sweepToken = Date.now() + Math.random();
+    global._kbSweepToken = sweepToken;
     global._kbSweepInFlight = true;
     global._kbSweepStartedAt = Date.now();
     try {
@@ -2017,7 +2020,7 @@ If nothing to do: { "duplicates": [], "reclassify": [], "remove": [] }`;
       const summary = `${merged} duplicates merged, ${removed} stale removed, ${reclassified} reclassified${pruned ? ', ' + pruned + ' old swept files pruned' : ''}`;
       safeWrite(path.join(ENGINE_DIR, 'kb-swept.json'), JSON.stringify({ timestamp: new Date().toISOString(), summary }));
       return jsonReply(res, 200, { ok: true, summary, plan });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); } finally { global._kbSweepInFlight = false; }
+    } catch (e) { return jsonReply(res, 500, { error: e.message }); } finally { if (global._kbSweepToken === sweepToken) global._kbSweepInFlight = false; }
   }
 
   async function handlePlansList(req, res) {

--- a/engine/llm.js
+++ b/engine/llm.js
@@ -108,7 +108,9 @@ function _spawnProcess(promptText, sysPromptText, { direct, label, model, maxTur
   const sysPath = path.join(tmpDir, `${label}-sys-${id}.md`);
   safeWrite(promptPath, promptText);
   safeWrite(sysPath, sysPromptText || '');
-  cleanupFiles.push(promptPath, sysPath);
+  // spawn-agent.js derives a PID file from prompt path — include it in cleanup to prevent leaks
+  const pidPath = promptPath.replace(/prompt-/, 'pid-').replace(/\.md$/, '.pid');
+  cleanupFiles.push(promptPath, sysPath, pidPath);
 
   const spawnScript = path.join(ENGINE_DIR, 'spawn-agent.js');
   const args = [

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10281,6 +10281,22 @@ async function testAutoRecoveryAndAtomicity() {
     assert.ok(ccCallFn.includes('direct: true'), 'ccCall should pass direct: true to callLLM');
   });
 
+  await test('_spawnProcess indirect path includes PID file in cleanupFiles', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'llm.js'), 'utf8');
+    const indirectBlock = src.slice(src.indexOf('// Indirect: use spawn-agent.js'));
+    assert.ok(indirectBlock.includes('pidPath'), 'Should derive pidPath from promptPath');
+    assert.ok(indirectBlock.includes("replace(/prompt-/, 'pid-')"), 'Should use same PID derivation as spawn-agent.js');
+    assert.ok(indirectBlock.includes('cleanupFiles.push(promptPath, sysPath, pidPath)'), 'Should include pidPath in cleanupFiles');
+  });
+
+  await test('handleKnowledgeSweep uses generation token for race-safe finally', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const sweepFn = src.slice(src.indexOf('async function handleKnowledgeSweep'));
+    assert.ok(sweepFn.includes('sweepToken'), 'Should use a generation token');
+    assert.ok(sweepFn.includes('global._kbSweepToken = sweepToken'), 'Should store token globally');
+    assert.ok(sweepFn.includes('global._kbSweepToken === sweepToken'), 'finally should only clear flag if token matches');
+  });
+
   await test('dependency fetches run in parallel with Promise.allSettled', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
     assert.ok(src.includes('Promise.allSettled'), 'Should use Promise.allSettled for parallel dep fetches');


### PR DESCRIPTION
## Summary

- **PID file leak fix (engine/llm.js)**: The indirect spawn path creates prompt/sys temp files but `spawn-agent.js` also derives a PID file from the prompt path. This PID file was never added to `cleanupFiles`, causing hundreds of leaked `*-pid-*.pid` files in `engine/tmp/`. Fixed by deriving the same PID path and including it in cleanup.
- **kb-sweep race condition fix (dashboard.js)**: `handleKnowledgeSweep` auto-releases `_kbSweepInFlight` after 5 minutes, but the original sweep's `finally` block still fires later and clears the flag for any newly-started sweep, allowing unbounded concurrent sweeps. Fixed with a generation token (`sweepToken`) so `finally` only clears the flag if this sweep is still the current owner.
- **Cleanup**: Removed 484 leaked PID files from `engine/tmp/`
- **Tests**: Added 2 source-pattern tests verifying both fixes

## Test plan
- [x] `npm test` — 1329 passed, 0 failed, 2 skipped
- [ ] Verify no new PID file leaks after running kb-sweep or command-center calls
- [ ] Verify concurrent kb-sweep requests are properly guarded (second request gets 409)

🤖 Generated with [Claude Code](https://claude.com/claude-code)