### PR TITLE
fix: add checkTimeouts ReferenceError smoke test (closes #775)

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4059,6 +4059,22 @@ async function testCheckTimeouts() {
     assert.ok(perTypeTimeouts !== null, 'perTypeTimeouts should be constructable without ReferenceError');
     assert.strictEqual(perTypeTimeouts.review, 600000, 'config overrides should merge correctly');
   });
+
+  // Smoke test: actually call checkTimeouts({}) to catch ReferenceErrors at runtime (#775)
+  // Previous tests only checked source strings — this exercises the real function.
+  await test('checkTimeouts({}) does not throw ReferenceError (#775 smoke test)', () => {
+    const timeout = require('../engine/timeout');
+    try {
+      timeout.checkTimeouts({});
+    } catch (e) {
+      // TypeError, missing engine context, etc. are expected in a test harness.
+      // ReferenceError means a stale/undefined constant reference — that's the bug.
+      if (e instanceof ReferenceError) {
+        throw new Error(`checkTimeouts threw ReferenceError (stale constant?): ${e.message}`);
+      }
+      // Any other error is fine — the function needs a full engine context to run end-to-end.
+    }
+  });
 }
 
 // ─── engine.js — addToDispatch Tests ────────────────────────────────────────


### PR DESCRIPTION
Closes yemi33/minions#775

## Summary
- The code fix for `DEFAULT_HEARTBEAT_TIMEOUTS` was already applied in 9bbabd6, but existing regression tests only did source-string matching (`src.includes(...)`)
- Adds a **behavioral smoke test** that actually calls `checkTimeouts({})` and asserts no `ReferenceError` is thrown — this catches stale/undefined constant references at runtime, not just in source text
- The test allows `TypeError` and other expected errors from missing engine context, but specifically fails on `ReferenceError` (the class of bug from #775)

## Test plan
- [x] New smoke test passes: `checkTimeouts({}) does not throw ReferenceError (#775 smoke test)`
- [x] Full test suite: 1296 passed, 12 failed (all pre-existing), 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)