### PR TITLE
fix: reset PRD status on work item deletion

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1147,6 +1147,14 @@ const server = http.createServer(async (req, res) => {
         if (cleaned) safeWrite(cooldownPath, cooldowns);
       } catch (e) { console.error('cooldown cleanup:', e.message); }
 
+      // Reset PRD item status so it doesn't stay 'dispatched' with no work item (#779)
+      if (item && item.sourcePlan) {
+        try {
+          const lifecycle = require('./engine/lifecycle');
+          lifecycle.syncPrdItemStatus(id, 'pending', item.sourcePlan);
+        } catch (e) { console.error('PRD status reset on delete:', e.message); }
+      }
+
       invalidateStatusCache();
       return jsonReply(res, 200, { ok: true, id, dispatchRemoved });
     } catch (e) { return jsonReply(res, 400, { error: e.message }); }

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -582,6 +582,42 @@ function runCleanup(config, verbose = false) {
     }
   } catch (e) { log('warn', 'migrate PRD legacy statuses: ' + e.message); }
 
+  // Reset orphaned PRD item statuses — dispatched/failed with no matching work item (#779)
+  try {
+    const config = queries.getConfig();
+    const allProjects = getProjects(config);
+    const wiIds = new Set();
+    for (const project of allProjects) {
+      const items = safeJson(projectWorkItemsPath(project)) || [];
+      for (const wi of items) { if (wi?.id) wiIds.add(wi.id); }
+    }
+    try {
+      const centralWi = safeJson(path.join(MINIONS_DIR, 'work-items.json')) || [];
+      for (const wi of centralWi) { if (wi?.id) wiIds.add(wi.id); }
+    } catch { /* optional */ }
+
+    let prdDirEntries;
+    try { prdDirEntries = fs.readdirSync(PRD_DIR).filter(f => f.endsWith('.json')); }
+    catch { prdDirEntries = []; }
+    for (const pf of prdDirEntries) {
+      const prdPath = path.join(PRD_DIR, pf);
+      const prd = safeJson(prdPath);
+      if (!prd?.missing_features) continue;
+      let reset = 0;
+      for (const feat of prd.missing_features) {
+        if ((feat.status === 'dispatched' || feat.status === 'failed') && !wiIds.has(feat.id)) {
+          feat.status = 'pending';
+          reset++;
+        }
+      }
+      if (reset > 0) {
+        safeWrite(prdPath, prd);
+        log('info', `Reset ${reset} orphaned PRD item status(es) → pending in ${pf}`);
+        cleaned++;
+      }
+    }
+  } catch (e) { log('warn', 'orphan PRD status reset: ' + e.message); }
+
   return cleaned;
 }
 

--- a/engine/queries.js
+++ b/engine/queries.js
@@ -953,7 +953,9 @@ function getPrdInfo(config) {
   for (const item of items) {
     const wi = wiById[item.id];
     // Work item status is source of truth when available (PRD JSON may lag behind)
-    const rawStatus = wi ? (wi.status || item.status) : item.status;
+    // If PRD says dispatched/failed but no work item exists, treat as pending (orphaned — #779)
+    const rawStatus = wi ? (wi.status || item.status)
+      : ((item.status === 'dispatched' || item.status === 'failed') ? 'pending' : item.status);
     item.status = statusDisplay[rawStatus] || rawStatus || 'missing';
     // Attach execution metadata for display (agent, PR link, fail reason)
     if (wi) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2678,6 +2678,16 @@ async function testLegacyStatusMigration() {
       'cleanup should log reconciliation of failed-with-PR items');
   });
 
+  await test('cleanup.js resets orphaned PRD item statuses (#779)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+    assert.ok(src.includes("feat.status === 'dispatched'") && src.includes("!wiIds.has(feat.id)"),
+      'cleanup must detect orphaned dispatched PRD items with no matching work item');
+    assert.ok(src.includes("feat.status === 'failed'") && src.includes("feat.status = 'pending'"),
+      'cleanup must reset orphaned dispatched/failed PRD items to pending');
+    assert.ok(src.includes('orphaned PRD item status'),
+      'cleanup must log orphaned PRD status resets');
+  });
+
   await test('syncPrdFromPrs filter includes failed items with _pr (#407)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
     const fnBody = src.slice(
@@ -8681,6 +8691,15 @@ async function testDashboardAuditMedium() {
       'delete must use mutateJsonFileLocked for atomic read-modify-write');
   });
 
+  await test('handleWorkItemsDelete resets PRD item status (#779)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const deleteFn = src.slice(src.indexOf('async function handleWorkItemsDelete'), src.indexOf('async function handleWorkItemsArchive'));
+    assert.ok(deleteFn.includes('syncPrdItemStatus'),
+      'work item delete must call syncPrdItemStatus to reset PRD item status');
+    assert.ok(deleteFn.includes('item.sourcePlan'),
+      'PRD reset must check item.sourcePlan before calling syncPrdItemStatus');
+  });
+
   await test('openEditScheduleModal calls _updateCronPreview', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-schedules.js'), 'utf8');
     const editFn = src.match(/function openEditScheduleModal[\s\S]*?^}/m);
@@ -9990,6 +10009,16 @@ async function testAutoRecoveryAndAtomicity() {
       'PRD progress items mapping must include agent field');
     assert.ok(prdFn.includes('failReason: i._failReason') || prdFn.includes("failReason: i._failReason || ''"),
       'PRD progress items mapping must include failReason field');
+  });
+
+  await test('getPrdInfo resets orphaned dispatched/failed PRD items when work item missing (#779)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
+    const prdFn = src.slice(src.indexOf('function getPrdInfo'));
+    // When no work item exists and PRD status is dispatched, rawStatus should become pending
+    assert.ok(prdFn.includes("item.status === 'dispatched'") && prdFn.includes("'pending'"),
+      'getPrdInfo must reset orphaned dispatched PRD items to pending when work item is missing');
+    assert.ok(prdFn.includes("item.status === 'failed'"),
+      'getPrdInfo must also reset orphaned failed PRD items when work item is missing');
   });
 
   await test('areDependenciesMet returns failed when dep item is failed', () => {


### PR DESCRIPTION
## Summary

Closes yemi33/minions#779

When a work item is deleted from `work-items.json`, the corresponding PRD item status was not reset — leaving it stuck as `dispatched` (wip) indefinitely with no agent, no dispatch, and no work item.

**Three-pronged fix:**

1. **`dashboard.js` handleWorkItemsDelete** — calls `syncPrdItemStatus` to reset PRD item to `pending` when work item is deleted
2. **`engine/queries.js` getPrdInfo** — defensive orphan detection: if PRD says dispatched/failed but no work item exists, treat as `pending`
3. **`engine/cleanup.js` runCleanup** — periodic scan resets orphaned PRD items (dispatched/failed with no matching work item) back to `pending`

## Test plan

- [x] 3 new unit tests covering all three fix points pass
- [x] `npm test` — all fix-related tests pass (12 pre-existing failures unrelated to this change)
- [x] Verified `getPrdInfo` orphan detection logic resets `dispatched` → `pending` when work item is missing
- [x] Verified `handleWorkItemsDelete` calls `syncPrdItemStatus` with correct args
- [x] Verified `runCleanup` scans all PRD files for orphaned statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)