### PR TITLE
fix: handle local-only dep branches in dep merge

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -471,22 +471,39 @@ async function spawnAgent(dispatchItem, config) {
           );
           const hasFetchFailures = fetchResults.some(r => r.status === 'rejected');
           const allPrsForFetch = hasFetchFailures ? shared.getProjects(config).reduce((acc, p) => acc.concat(safeJson(shared.projectPrPath(p)) || []), []) : [];
+          // Track branches recovered by local-only push so they can be merged
+          const recoveredBranches = new Set();
           for (let i = 0; i < fetchResults.length; i++) {
             if (fetchResults[i].status === 'rejected') {
               const failedBranch = fetchable[i].branch;
               const failedPrId = fetchable[i].prId;
+              const errMsg = fetchResults[i].reason?.message || '';
               const pr = allPrsForFetch.find(p => p.id === failedPrId);
               if (pr && (pr.status === 'merged' || pr.status === 'closed')) {
                 log('info', `Dependency ${failedBranch} (${failedPrId}) already merged — skipping, changes already in main`);
                 continue;
               }
+              // If remote ref missing, check if branch exists locally and push it (#782)
+              if (errMsg.includes('couldn\'t find remote ref') || errMsg.includes('not found in upstream')) {
+                try {
+                  await execAsync(`git rev-parse --verify "refs/heads/${failedBranch}"`, { ..._gitOpts, cwd: rootDir });
+                  // Branch exists locally — push it to origin
+                  log('info', `Dependency ${failedBranch} exists locally but not on remote — pushing to origin`);
+                  await execAsync(`git push origin "${failedBranch}"`, { ..._gitOpts, cwd: rootDir, timeout: 60000 });
+                  log('info', `Successfully pushed local-only dependency branch ${failedBranch} to origin`);
+                  recoveredBranches.add(failedBranch);
+                  continue;
+                } catch (localErr) {
+                  log('warn', `Dependency ${failedBranch} not found locally or push failed: ${localErr.message}`);
+                }
+              }
               _failedRefCache.add(failedBranch);
-              log('warn', `Failed to fetch dependency ${failedBranch}: ${fetchResults[i].reason?.message}`);
+              log('warn', `Failed to fetch dependency ${failedBranch}: ${errMsg}`);
               depMergeFailed = true;
             }
           }
-          // Merge successfully-fetched branches sequentially (merges modify the worktree)
-          const fetched = fetchable.filter((_, i) => fetchResults[i].status === 'fulfilled');
+          // Merge successfully-fetched + recovered (local-only pushed) branches sequentially
+          const fetched = fetchable.filter((_, i) => fetchResults[i].status === 'fulfilled' || recoveredBranches.has(fetchable[i].branch));
           if (!depMergeFailed) {
             for (const { branch: depBranch, prId } of fetched) {
               try {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6185,6 +6185,29 @@ async function testDispatchCycleIntegration() {
       'engine.js must set depMergeFailed on re-merge failure');
   });
 
+  await test('Dep merge handles local-only branches by pushing to origin (#782)', () => {
+    // When git fetch fails with "couldn't find remote ref", the engine should:
+    // 1. Check if branch exists locally via git rev-parse
+    // 2. Push it to origin if it exists
+    // 3. Include it in the fetched list for merging
+    assert.ok(engineSrc.includes('find remote ref'),
+      'engine.js must detect missing remote ref errors');
+    assert.ok(engineSrc.includes('git rev-parse --verify'),
+      'engine.js must check if branch exists locally when remote ref missing');
+    assert.ok(engineSrc.includes('exists locally but not on remote'),
+      'engine.js must log when pushing local-only dependency branch');
+    assert.ok(engineSrc.includes('git push origin'),
+      'engine.js must push local-only dependency branches to origin');
+    assert.ok(engineSrc.includes('recoveredBranches'),
+      'engine.js must track recovered (local-only pushed) branches');
+    // Recovered branches must be included in the fetched list for merging
+    assert.ok(engineSrc.includes('recoveredBranches.has('),
+      'engine.js must include recovered branches in the merge set');
+    // If local check or push fails, should still mark as failed (not loop forever)
+    assert.ok(engineSrc.includes('not found locally or push failed'),
+      'engine.js must handle push failure for local-only branches gracefully');
+  });
+
   await test('Spawn renders playbook with system prompt', () => {
     assert.ok(engineSrc.includes('function renderPlaybook'),
       'engine.js must define renderPlaybook');


### PR DESCRIPTION
## Summary

Closes yemi33/minions#782

- When `git fetch origin <branch>` fails with "couldn't find remote ref", check if the branch exists locally via `git rev-parse`
- If the branch exists locally, push it to origin automatically and include it in the merge set
- If the branch doesn't exist locally or push fails, fall through to normal failure handling (no infinite retry loop)

## Root Cause

`resolveDependencyBranches` resolves dep branches from `pull-requests.json`. The dep merge block then does `git fetch origin "<branch>"` — if the branch was never pushed (e.g. agent created branch but crashed before pushing), the fetch fails and the item is marked failed with "will retry next tick", repeating indefinitely with no recovery.

## Changes

- **engine.js**: Added local-only branch detection and auto-push recovery in the fetch failure handler. Tracks recovered branches in a `recoveredBranches` Set and includes them in the merge set alongside successfully-fetched branches.
- **test/unit.test.js**: Added source-pattern test verifying the local-only branch handling code paths exist.

## Test plan

- [x] `npm test` — 1296 passed, 12 failed (all pre-existing), 2 skipped
- [ ] Manual: Create a local-only dep branch, verify dependent item spawn pushes it and merges successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)