### PR TITLE
fix(timeout): short-circuit restart grace period for verifiably-dead agents (closes #869)

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -146,6 +146,7 @@ const activeProcesses = new Map(); // dispatchId → { proc, agentId, startedAt 
 const realActivityMap = new Map(); // dispatchId → timestamp of last REAL agent output (not engine heartbeat)
 // tempAgents imported from engine/routing.js
 let engineRestartGraceUntil = 0; // timestamp — suppress orphan detection until this time
+const engineRestartGraceExempt = new Set(); // dispatch IDs with confirmed-dead PIDs at restart — bypass grace period
 
 // Per-tick cache of refs that failed to fetch — avoids repeating 30s ETIMEDOUT for same missing ref
 // Cleared at the start of each tick cycle (see tickInner)
@@ -3155,7 +3156,8 @@ module.exports = {
 
   // Dispatch management (re-exported from engine/dispatch.js)
   mutateDispatch, addToDispatch, isRetryableFailureReason, completeDispatch, writeInboxAlert, updateAgentStatus,
-  activeProcesses, realActivityMap, get engineRestartGraceUntil() { return engineRestartGraceUntil; },
+  activeProcesses, realActivityMap, engineRestartGraceExempt,
+  get engineRestartGraceUntil() { return engineRestartGraceUntil; },
   set engineRestartGraceUntil(v) { engineRestartGraceUntil = v; },
 
   // Agent lifecycle

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -161,6 +161,7 @@ const commands = {
           }
         }
 
+        const hadPid = agentPid && agentPid > 0; // track before liveness check
         if (agentPid && agentPid > 0) {
           try {
             if (process.platform === 'win32') {
@@ -170,6 +171,11 @@ const commands = {
               process.kill(agentPid, 0);
             }
           } catch { agentPid = null; }
+        }
+
+        // PID was found but confirmed dead — exempt from restart grace period (#869)
+        if (hadPid && !agentPid) {
+          e.engineRestartGraceExempt.add(item.id);
         }
 
         if (agentPid) {

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -127,6 +127,7 @@ function checkSteering(config) {
 function checkTimeouts(config) {
   const activeProcesses = engine().activeProcesses;
   const engineRestartGraceUntil = engine().engineRestartGraceUntil;
+  const engineRestartGraceExempt = engine().engineRestartGraceExempt;
   const { completeDispatch } = dispatch();
   const { runPostCompletionHooks } = require('./lifecycle');
 
@@ -307,8 +308,8 @@ function checkTimeouts(config) {
     const procInfo = activeProcesses.get(item.id);
     if (procInfo?._steeringAt && Date.now() - procInfo._steeringAt < 60000) continue;
 
-    if (!hasProcess && silentMs > effectiveTimeout && Date.now() > engineRestartGraceUntil) {
-      // No tracked process AND no recent output past effective timeout AND grace period expired → orphaned
+    if (!hasProcess && silentMs > effectiveTimeout && (Date.now() > engineRestartGraceUntil || engineRestartGraceExempt?.has(item.id))) {
+      // No tracked process AND no recent output past effective timeout AND (grace period expired OR confirmed-dead at restart) → orphaned
       log('warn', `Orphan detected: ${item.agent} (${item.id}) — no process tracked, silent for ${silentSec}s${isBlocking ? ' (blocking timeout exceeded)' : ''}`);
       dispatch().updateAgentStatus(item.id, AGENT_STATUS.TIMED_OUT, `Orphaned — no process, silent for ${silentSec}s`);
       // Clear session so retry starts fresh

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4185,6 +4185,32 @@ async function testCheckTimeouts() {
     assert.strictEqual(perTypeTimeouts.review, 600000, 'config overrides should merge correctly');
   });
 
+  await test('checkTimeouts reads engineRestartGraceExempt from engine (#869)', () => {
+    assert.ok(src.includes('engineRestartGraceExempt'),
+      'Should read engineRestartGraceExempt set to bypass grace period for confirmed-dead agents');
+  });
+
+  await test('checkTimeouts bypasses grace period for exempt dispatch IDs (#869)', () => {
+    // The orphan detection condition must check engineRestartGraceExempt to short-circuit
+    // the grace period for agents with confirmed-dead PIDs at restart time
+    assert.ok(src.includes('engineRestartGraceExempt?.has(item.id)') || src.includes('engineRestartGraceExempt.has(item.id)'),
+      'Orphan detection should check engineRestartGraceExempt to bypass grace period');
+  });
+
+  await test('engine.js exports engineRestartGraceExempt Set (#869)', () => {
+    const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    assert.ok(engineSrc.includes('engineRestartGraceExempt = new Set()'),
+      'engine.js should declare engineRestartGraceExempt as a Set');
+    assert.ok(engineSrc.includes('engineRestartGraceExempt,') || engineSrc.includes('engineRestartGraceExempt }'),
+      'engine.js should export engineRestartGraceExempt');
+  });
+
+  await test('cli.js records confirmed-dead PIDs in engineRestartGraceExempt (#869)', () => {
+    const cliSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(cliSrc.includes('engineRestartGraceExempt.add(item.id)'),
+      'cli.js re-attach loop should add confirmed-dead dispatch IDs to engineRestartGraceExempt');
+  });
+
   // Smoke test: actually call checkTimeouts({}) to catch ReferenceErrors at runtime (#775)
   // Previous tests only checked source strings — this exercises the real function.
   await test('checkTimeouts({}) does not throw ReferenceError (#775 smoke test)', () => {


### PR DESCRIPTION
## Summary
- When the engine restarts and finds an active dispatch with a PID confirmed dead (via `tasklist` on Windows / `process.kill(pid, 0)` on Unix), those dispatch IDs are now recorded in `engineRestartGraceExempt` Set
- `checkTimeouts` in `timeout.js` checks this exempt set and bypasses the 20-minute restart grace period for confirmed-dead agents, allowing orphan handling to fire immediately
- Previously, dead agents would show as "working" in the dashboard for up to 20 minutes post-restart

## Changes
- **engine.js**: Added `engineRestartGraceExempt` Set and exported it
- **engine/cli.js**: In the restart re-attach loop, when a PID is found but confirmed dead via liveness check, the dispatch ID is added to `engineRestartGraceExempt`
- **engine/timeout.js**: Orphan detection condition now checks `engineRestartGraceExempt.has(item.id)` as an alternative to the global grace period expiry
- **test/unit.test.js**: 4 new source-pattern tests verifying the exempt set exists, is exported, is populated, and is checked

## Test plan
- [x] `npm test` — 1460 passed, 0 failed, 2 skipped
- [ ] Manual: kill an agent process, restart engine, verify dead agent is detected on first tick (not after 20 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)