### PR TITLE
fix(kill): reset central work-items.json on agent kill (closes #890)

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1622,7 +1622,7 @@ const server = http.createServer(async (req, res) => {
       }, { defaultValue: { pending: [], active: [], completed: [] } });
 
       // 4. Reset work items from dispatched → pending so they can be retried
-      const allWiPaths = [];
+      const allWiPaths = [path.join(MINIONS_DIR, 'work-items.json')];
       for (const proj of PROJECTS) allWiPaths.push(shared.projectWorkItemsPath(proj));
       let resetCount = 0;
       for (const wiPath of allWiPaths) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8773,6 +8773,25 @@ async function testStatusMutationGuards() {
       'Kill-agent work item reset must check completedAt before resetting items');
   });
 
+  // ─── Fix: handleAgentKill includes central work-items.json ──────────────
+
+  await test('handleAgentKill resets central work-items.json (not just project-scoped)', () => {
+    // Find the handleAgentKill function
+    const fnStart = dashboardSrc.indexOf('async function handleAgentKill');
+    assert.ok(fnStart >= 0, 'handleAgentKill function must exist');
+    const fnBody = dashboardSrc.substring(fnStart, fnStart + 2000);
+    // The allWiPaths array must include the central work-items.json path
+    assert.ok(
+      fnBody.includes("path.join(MINIONS_DIR, 'work-items.json')"),
+      'handleAgentKill must include central work-items.json in allWiPaths for plan-to-prd and other central tasks'
+    );
+    // Verify it's initialized WITH the central path, not just project paths
+    const wiPathsLine = fnBody.match(/const allWiPaths\s*=\s*\[([^\]]*)\]/);
+    assert.ok(wiPathsLine, 'allWiPaths must be initialized as an array');
+    assert.ok(wiPathsLine[1].includes('work-items.json'),
+      'allWiPaths must be initialized with central work-items.json before the project loop');
+  });
+
   // ─── Behavioral tests: simulate guard logic ─────────────────────────────
 
   await test('BEHAVIORAL: done item survives retry attempt', () => {


### PR DESCRIPTION
## Summary
- **Bug:** `POST /api/agent/:id/kill` only reset project-scoped work items (`dispatched → pending`), silently skipping the central `work-items.json`. This left plan-to-prd, ask, and other engine-internal tasks stuck as `dispatched` forever after a kill.
- **Fix:** Added `path.join(MINIONS_DIR, 'work-items.json')` to the `allWiPaths` array initialization in `handleAgentKill`, before the project loop.
- **Test:** Added source-pattern test verifying `handleAgentKill` includes central work-items.json in allWiPaths.

Closes #890

## Test plan
- [x] Unit tests pass (1463 passed, 0 failed)
- [ ] Kill an agent running a plan-to-prd task → verify `workItemsReset` count includes the central work item
- [ ] Confirm the central work item is reset to `pending` and auto-redispatched on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)