### PR TITLE
fix(lifecycle): verify PRD file exists before marking plan-to-prd work item as done (closes #893)

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1494,6 +1494,50 @@ async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, confi
     // If decomposition produced nothing, fall through to mark parent as done
   }
 
+  // Verify plan-to-prd tasks actually created their PRD file before marking done (#893)
+  if (type === WORK_TYPE.PLAN_TO_PRD && effectiveSuccess && meta?.item?.id) {
+    let prdFound = false;
+    const expectedFile = meta.item._prdFilename;
+    if (expectedFile) {
+      prdFound = fs.existsSync(path.join(PRD_DIR, expectedFile));
+    }
+    if (!prdFound && meta?.item?.planFile) {
+      // Fall back to scanning PRD_DIR for matching source_plan
+      try {
+        for (const f of fs.readdirSync(PRD_DIR)) {
+          if (!f.endsWith('.json')) continue;
+          try {
+            const prd = safeJson(path.join(PRD_DIR, f));
+            if (prd && prd.source_plan === meta.item.planFile) { prdFound = true; break; }
+          } catch {}
+        }
+      } catch {}
+    }
+    if (!prdFound) {
+      skipDoneStatus = true;
+      const wiPath = resolveWorkItemPath(meta);
+      if (wiPath) {
+        mutateJsonFileLocked(wiPath, data => {
+          if (!Array.isArray(data)) return data;
+          const w = data.find(i => i.id === meta.item.id);
+          if (!w) return data;
+          const retries = w._retryCount || 0;
+          if (retries < ENGINE_DEFAULTS.maxRetries) {
+            w.status = WI_STATUS.PENDING;
+            w._retryCount = retries + 1;
+            delete w.dispatched_at;
+            log('warn', `plan-to-prd ${meta.item.id} completed without PRD file — auto-retry ${retries + 1}/${ENGINE_DEFAULTS.maxRetries}`);
+          } else {
+            w.status = WI_STATUS.FAILED;
+            w.failReason = 'PRD file not written after ' + ENGINE_DEFAULTS.maxRetries + ' attempts';
+            log('warn', `plan-to-prd ${meta.item.id} failed — PRD file not written after ${ENGINE_DEFAULTS.maxRetries} retries`);
+          }
+          return data;
+        });
+      }
+    }
+  }
+
   if (effectiveSuccess && meta?.item?.id && !skipDoneStatus) {
     meta._agentId = agentId;
     updateWorkItemStatus(meta, WI_STATUS.DONE, '');
@@ -1613,49 +1657,6 @@ async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, confi
         } else if (action?.type === 'needs-review') {
           log('warn', `${meta.item.id} needs review — no output after ${ENGINE_DEFAULTS.maxRetries} retries`);
         }
-      }
-    }
-  }
-
-  // Detect plan-to-prd tasks that completed without creating a PRD file
-  if (effectiveSuccess && type === WORK_TYPE.PLAN_TO_PRD && meta?.item?.planFile) {
-    // Check by stored filename first (deterministic), fall back to source_plan scan
-    let prdFound = false;
-    const expectedFile = meta.item._prdFilename;
-    if (expectedFile) {
-      prdFound = fs.existsSync(path.join(PRD_DIR, expectedFile));
-    }
-    if (!prdFound) {
-      try {
-        for (const f of fs.readdirSync(PRD_DIR)) {
-          if (!f.endsWith('.json')) continue;
-          try {
-            const prd = safeJson(path.join(PRD_DIR, f));
-            if (prd && prd.source_plan === meta.item.planFile) { prdFound = true; break; }
-          } catch {}
-        }
-      } catch {}
-    }
-    if (!prdFound) {
-      const wiPath = resolveWorkItemPath(meta);
-      if (wiPath) {
-        mutateJsonFileLocked(wiPath, data => {
-          if (!Array.isArray(data)) return data;
-          const w = data.find(i => i.id === meta.item.id);
-          if (!w) return data;
-          const retries = w._retryCount || 0;
-          if (retries < ENGINE_DEFAULTS.maxRetries) {
-            w.status = WI_STATUS.PENDING;
-            w._retryCount = retries + 1;
-            delete w.dispatched_at;
-            log('warn', `plan-to-prd ${meta.item.id} completed without PRD file — auto-retry ${retries + 1}/${ENGINE_DEFAULTS.maxRetries}`);
-          } else {
-            w.status = WI_STATUS.FAILED;
-            w.failReason = 'Completed without creating PRD file after ' + ENGINE_DEFAULTS.maxRetries + ' attempts';
-            log('warn', `plan-to-prd ${meta.item.id} failed — no PRD file after ${ENGINE_DEFAULTS.maxRetries} retries`);
-          }
-          return data;
-        });
       }
     }
   }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1503,6 +1503,23 @@ async function testPlanLifecycle() {
       'lifecycle.js should have comment explaining removal');
   });
 
+  await test('plan-to-prd sets skipDoneStatus when PRD file not written (#893)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const hookStart = src.indexOf('function runPostCompletionHooks(');
+    const hookBody = src.slice(hookStart, src.indexOf('\nfunction ', hookStart + 1) || src.length);
+    // PRD file check must set skipDoneStatus BEFORE updateWorkItemStatus(DONE)
+    const prdCheckIdx = hookBody.indexOf('WORK_TYPE.PLAN_TO_PRD && effectiveSuccess');
+    const skipDoneIdx = hookBody.indexOf('skipDoneStatus = true', prdCheckIdx);
+    const doneMarkIdx = hookBody.indexOf('updateWorkItemStatus(meta, WI_STATUS.DONE');
+    assert.ok(prdCheckIdx > -1, 'lifecycle.js should check PLAN_TO_PRD with effectiveSuccess');
+    assert.ok(skipDoneIdx > -1 && skipDoneIdx < doneMarkIdx,
+      'plan-to-prd PRD check must set skipDoneStatus BEFORE the done marking (#893)');
+    assert.ok(hookBody.includes('PRD file not written'),
+      'Should use descriptive failure reason when PRD file missing');
+    assert.ok(hookBody.includes('_prdFilename'),
+      'Should check _prdFilename for deterministic PRD file lookup');
+  });
+
   await test('plan-to-prd playbook sets PRD status to awaiting-approval', () => {
     const playbook = fs.readFileSync(path.join(MINIONS_DIR, 'playbooks', 'plan-to-prd.md'), 'utf8');
     assert.ok(playbook.includes('"status": "awaiting-approval"'),


### PR DESCRIPTION
## Summary

- **Move PRD file existence check before done status assignment** using `skipDoneStatus` flag, preventing a timing window where `checkPlanCompletion` could fire on a falsely-done plan-to-prd work item
- Plan-to-prd items that exit with code=0 but produce no PRD file are now auto-retried (up to `ENGINE_DEFAULTS.maxRetries`) or marked failed — never left as `done` without a deliverable
- Remove duplicate post-hoc check that previously tried to revert done status after the fact (now redundant)
- Add unit test verifying the `skipDoneStatus` guard runs before `updateWorkItemStatus(DONE)`

## Test plan

- [x] All 1463 unit tests pass (0 failures)
- [ ] Verify plan-to-prd with confused agent (short output, code=0) is retried, not marked done
- [ ] Verify plan-to-prd with valid PRD file created is still marked done correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)