### PR TITLE
[E2E] Fix silent state-loss bugs in dispatch persistence, lifecycle races, and checkpoint handling

### DIFF
--- a/docs/verify-minions-2026-04-01-5.md
+++ b/docs/verify-minions-2026-04-01-5.md
@@ -1,0 +1,32 @@
+# Verification: Fix silent state-loss bugs in dispatch persistence, lifecycle races, and checkpoint handling
+
+**Plan:** minions-2026-04-01-5.json
+**Date:** 2026-04-11
+**Verified by:** Ripley
+
+## Results Summary
+
+| Item | PR | Verdict |
+|------|-----|---------|
+| P-b3c9e4f6: needs-human-review skip filter | PR-55 (merged) | PASS |
+| P-f7a2d8e1: dispatch persistence gate | PR-57 (merged) | PASS |
+| P-d5e1a7b3: TOCTOU races in lifecycle | PR-56 (merged) | PASS |
+| P-a8f4c2d9: fan-out checkpoint handling | PR-58 (merged) | REGRESSION |
+| P-e6b0d3a5: checkpoint cleanup + _pendingReason | PR-60 (merged) | REGRESSION |
+| P-c1d7f9e8: resolveWiPath export | PR-59 (closed) | NOT MERGED |
+
+**Tests:** 1463 passed, 0 failed, 2 skipped
+
+## Regressions
+
+Two items (P-a8f4c2d9, P-e6b0d3a5) were correctly merged but their changes were
+subsequently lost during engine.js refactors that rewrote `discoverCentralWorkItems`
+to use a mutations Map pattern. The original direct-item-mutation code was not carried
+forward.
+
+Affected features:
+1. Fan-out checkpoint.json reading (engine.js:2484-2487 missing `worktreePath`)
+2. Checkpoint file deletion after consumption (no `unlinkSync` calls remain)
+3. `_pendingReason` clearing on fan-out/single-agent dispatch
+
+See full report in `prd/guides/verify-minions-2026-04-01-5.md` (runtime, gitignored).


### PR DESCRIPTION
## Summary

Verification of plan `minions-2026-04-01-5.json` — 7 items covering dispatch persistence, lifecycle TOCTOU races, checkpoint handling, and code deduplication.

- **3 items PASS** (dispatch persistence, status filtering, TOCTOU races)
- **2 items REGRESSION** (checkpoint handling + cleanup lost in subsequent refactors)
- **1 item NOT MERGED** (resolveWiPath export — PR-59 closed)

### Individual PRs (all previously merged to master)
- PR-55: feat(P-b3c9e4f6): add explicit needs-human-review skip to dispatch paths ✅
- PR-57: feat(P-f7a2d8e1): fix dispatch persistence gate in central and fan-out paths ✅
- PR-56: feat(P-d5e1a7b3): fix TOCTOU races in lifecycle retry/decompose and cost ceiling ✅
- PR-58: feat(P-a8f4c2d9): add checkpoint handling to fan-out dispatch path ❌ REGRESSION
- PR-60: feat(P-e6b0d3a5): clean up checkpoint.json after consumption and fix _pendingReason ❌ REGRESSION
- PR-59: feat(P-c1d7f9e8): export resolveWiPath (CLOSED, not merged)

### Build & Test
- **1463 passed, 0 failed, 2 skipped**

### Regressions Found

Two merged PRs (58, 60) had their changes **overwritten by subsequent engine.js refactors** that restructured `discoverCentralWorkItems` from direct item manipulation to a mutations Map pattern. The original code was not carried forward:

1. **Fan-out checkpoint handling** — `buildWorkItemDispatchVars()` at engine.js:2484-2487 called WITHOUT `worktreePath`, so checkpoint.json is never read for fan-out
2. **Checkpoint file cleanup** — No `unlinkSync` for checkpoint.json exists anywhere in engine.js
3. **_pendingReason clearing** — Fan-out mutations don't include `_pendingReason` deletion

### Testing Guide
See `prd/guides/verify-minions-2026-04-01-5.md` (runtime) and `docs/verify-minions-2026-04-01-5.md` (committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)