### PR TITLE
fix(W-mnuviz2am9i7): show stale banner on paused PRDs (#905)

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1314,10 +1314,11 @@ function renderPrdProgress(prog) {
       : isPaused
         ? '<span style="color:var(--muted);font-weight:600;font-size:10px;padding:1px 6px;border:1px solid var(--muted);border-radius:3px">PAUSED</span>'
         : '';
-    const staleLabel = (!isBlocked && g.planStale)
+    const showStale = (!isBlocked || isPaused) && g.planStale;
+    const staleLabel = showStale
       ? '<span style="color:var(--orange);font-weight:700;font-size:10px;padding:1px 6px;border:1px solid var(--orange);border-radius:3px;background:rgba(210,153,34,0.12)" title="Source plan changed after this PRD was generated">STALE</span>'
       : '';
-    const staleRecovery = (!isBlocked && g.planStale)
+    const staleRecovery = showStale
       ? '<div style="width:100%;margin-top:4px;padding:6px 8px;border:1px solid rgba(210,153,34,0.35);border-radius:4px;background:rgba(210,153,34,0.08);display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
           '<span style="color:var(--orange);font-size:10px;font-weight:600">&#x26A0;&#xFE0F; Source plan was revised. This PRD may be outdated.</span>' +
           '<span onclick="event.stopPropagation();prdRegenerate(\'' + escHtml(g.file) + '\')" style="color:var(--green);cursor:pointer;font-size:10px;font-weight:700;padding:2px 8px;background:rgba(63,185,80,0.12);border:1px solid rgba(63,185,80,0.35);border-radius:4px" title="Regenerate PRD from latest plan">Regenerate now</span>' +

--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -271,10 +271,11 @@ function renderPrdProgress(prog) {
       : isPaused
         ? '<span style="color:var(--muted);font-weight:600;font-size:10px;padding:1px 6px;border:1px solid var(--muted);border-radius:3px">PAUSED</span>'
         : '';
-    const staleLabel = (!isBlocked && g.planStale)
+    const showStale = (!isBlocked || isPaused) && g.planStale;
+    const staleLabel = showStale
       ? '<span style="color:var(--orange);font-weight:700;font-size:10px;padding:1px 6px;border:1px solid var(--orange);border-radius:3px;background:rgba(210,153,34,0.12)" title="Source plan changed after this PRD was generated">STALE</span>'
       : '';
-    const staleRecovery = (!isBlocked && g.planStale)
+    const staleRecovery = showStale
       ? '<div style="width:100%;margin-top:4px;padding:6px 8px;border:1px solid rgba(210,153,34,0.35);border-radius:4px;background:rgba(210,153,34,0.08);display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
           '<span style="color:var(--orange);font-size:10px;font-weight:600">&#x26A0;&#xFE0F; Source plan was revised. This PRD may be outdated.</span>' +
           '<span onclick="event.stopPropagation();prdRegenerate(\'' + escHtml(g.file) + '\')" style="color:var(--green);cursor:pointer;font-size:10px;font-weight:700;padding:2px 8px;background:rgba(63,185,80,0.12);border:1px solid rgba(63,185,80,0.35);border-radius:4px" title="Compare revised plan against existing PRD and update items">Regenerate PRD</span>' +
@@ -284,7 +285,7 @@ function renderPrdProgress(prog) {
       : '';
     const isCompleted = done > 0 && done === g.items.length;
     // Hide regular action buttons when stale banner is showing — stale banner has its own actions
-    const isStale = !isBlocked && g.planStale;
+    const isStale = showStale;
     const pauseResumeBtn = isStale ? '' : isAwaitingApproval
       ? '<span onclick="event.stopPropagation();planApprove(\'' + escHtml(g.file) + '\',this)" style="color:var(--green);cursor:pointer;font-size:9px;padding:1px 6px;background:rgba(63,185,80,0.1);border:1px solid rgba(63,185,80,0.3);border-radius:3px">Approve</span>'
       : isPaused

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1642,6 +1642,25 @@ async function testPrdStaleInvalidation() {
       'engine stale alert should offer a clear restart recovery action');
   });
 
+  await test('Stale banner shown on paused PRDs (not suppressed by isBlocked)', () => {
+    const html = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.html'), 'utf8');
+    const renderPrd = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
+    // Both files should use showStale = (!isBlocked || isPaused) && g.planStale
+    assert.ok(html.includes('(!isBlocked || isPaused) && g.planStale'),
+      'dashboard.html should allow stale UI when paused');
+    assert.ok(renderPrd.includes('(!isBlocked || isPaused) && g.planStale'),
+      'render-prd.js should allow stale UI when paused');
+    // staleLabel and staleRecovery should use showStale, not the old !isBlocked guard
+    assert.ok(renderPrd.includes('const staleLabel = showStale'),
+      'render-prd.js staleLabel should use showStale variable');
+    assert.ok(renderPrd.includes('const staleRecovery = showStale'),
+      'render-prd.js staleRecovery should use showStale variable');
+    assert.ok(html.includes('const staleLabel = showStale'),
+      'dashboard.html staleLabel should use showStale variable');
+    assert.ok(html.includes('const staleRecovery = showStale'),
+      'dashboard.html staleRecovery should use showStale variable');
+  });
+
   await test('Dashboard shows immediate PRD retry feedback states', () => {
     const html = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.html'), 'utf8');
     assert.ok(html.includes('window._prdRequeueUi'),


### PR DESCRIPTION
## Summary

- **Bug:** When a PRD has `planStale: true` and `status: paused`, the STALE badge and stale recovery banner (Regenerate now) were hidden because both `staleLabel` and `staleRecovery` were gated on `!isBlocked`, and `isBlocked` is true for paused PRDs.
- **Fix:** Extracted `showStale = (!isBlocked || isPaused) && g.planStale` so paused PRDs correctly display the stale UI while awaiting-approval PRDs still suppress it.
- Fixed in both `dashboard.html` and `dashboard/js/render-prd.js` (duplicate renderGroupHeader).
- Added unit test asserting the new guard in both files.

Closes #905

## Test plan

- [x] `npm test` — 1465 passed, 0 failed
- [ ] Manual: pause a PRD, edit its source plan to trigger `planStale: true`, verify STALE badge and recovery banner appear
- [ ] Manual: verify awaiting-approval PRDs still suppress stale UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)