### PR TITLE
fix(review): parse verdict from agent output for GitHub self-approval (#912)

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -779,6 +779,27 @@ function syncPrsFromOutput(output, agentId, meta, config) {
 
 // ─── Post-Completion Hooks ──────────────────────────────────────────────────
 
+/**
+ * Parse review verdict from agent output text.
+ * Looks for "VERDICT: APPROVE" or "VERDICT: REQUEST_CHANGES" markers that the
+ * review playbook instructs agents to include. This is the primary mechanism for
+ * GitHub repos where formal --approve/--request-changes votes are blocked by
+ * self-approval restrictions.
+ * @param {string} text - Agent output / resultSummary
+ * @returns {'approved'|'changes-requested'|null}
+ */
+function parseReviewVerdict(text) {
+  if (!text) return null;
+  // Match "VERDICT: APPROVE" or "VERDICT: REQUEST_CHANGES" (case-insensitive, optional markdown bold)
+  const verdictMatch = text.match(/VERDICT[:\s]+\*{0,2}(APPROVE|REQUEST[_\s-]?CHANGES)\*{0,2}/i);
+  if (verdictMatch) {
+    const v = verdictMatch[1].toUpperCase().replace(/[\s-]/g, '_');
+    if (v === 'APPROVE') return 'approved';
+    if (v.includes('CHANGES')) return 'changes-requested';
+  }
+  return null;
+}
+
 async function updatePrAfterReview(agentId, pr, project, config, resultSummary) {
 
   if (!pr?.id) return;
@@ -803,6 +824,15 @@ async function updatePrAfterReview(agentId, pr, project, config, resultSummary) 
       if (liveStatus && liveStatus !== 'pending') postReviewStatus = liveStatus;
     }
   } catch (e) { log('warn', `Post-review status check for ${pr.id}: ${e.message}`); }
+
+  // Fallback: if live check returned pending (e.g., GitHub self-approval blocked), parse verdict from agent output
+  if (!postReviewStatus) {
+    const verdict = parseReviewVerdict(resultSummary);
+    if (verdict) {
+      postReviewStatus = verdict;
+      log('info', `Parsed review verdict from agent output for ${pr.id}: ${verdict}`);
+    }
+  }
 
   const prPath = project ? shared.projectPrPath(project) : path.join(path.resolve(MINIONS_DIR, '..'), '.minions', 'pull-requests.json');
   let updatedTarget = null;
@@ -839,7 +869,7 @@ async function updatePrAfterReview(agentId, pr, project, config, resultSummary) 
     }, { defaultValue: {} });
   }
 
-  log('info', `Updated ${pr.id} → minions review: waiting by ${reviewerName}`);
+  log('info', `Updated ${pr.id} → minions review: ${postReviewStatus || 'waiting'} by ${reviewerName}`);
   if (updatedTarget) createReviewFeedbackForAuthor(agentId, updatedTarget, config);
 }
 
@@ -1665,6 +1695,35 @@ async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, confi
     }
   }
 
+  // Verify review work items include a verdict — mirrors the PRD file existence check pattern.
+  // If agent completed (exit 0) but output has no VERDICT: APPROVE/REQUEST_CHANGES, the review
+  // is incomplete. Auto-retry up to maxRetries, then fail.
+  if (effectiveSuccess && type === WORK_TYPE.REVIEW && meta?.item?.id) {
+    const verdict = parseReviewVerdict(resultSummary);
+    if (!verdict) {
+      const wiPath = resolveWorkItemPath(meta);
+      if (wiPath) {
+        mutateJsonFileLocked(wiPath, data => {
+          if (!Array.isArray(data)) return data;
+          const w = data.find(i => i.id === meta.item.id);
+          if (!w) return data;
+          const retries = w._retryCount || 0;
+          if (retries < ENGINE_DEFAULTS.maxRetries) {
+            w.status = WI_STATUS.PENDING;
+            w._retryCount = retries + 1;
+            delete w.dispatched_at;
+            log('warn', `Review ${meta.item.id} completed without verdict — auto-retry ${retries + 1}/${ENGINE_DEFAULTS.maxRetries}`);
+          } else {
+            w.status = WI_STATUS.FAILED;
+            w.failReason = 'No review verdict after ' + ENGINE_DEFAULTS.maxRetries + ' attempts';
+            log('warn', `Review ${meta.item.id} failed — no verdict after ${ENGINE_DEFAULTS.maxRetries} retries`);
+          }
+          return data;
+        });
+      }
+    }
+  }
+
   if (type === WORK_TYPE.REVIEW) await updatePrAfterReview(agentId, meta?.pr, meta?.project, config, resultSummary);
   if (type === WORK_TYPE.FIX) updatePrAfterFix(meta?.pr, meta?.project, meta?.source);
   checkForLearnings(agentId, config.agents[agentId], dispatchItem.task);
@@ -1819,6 +1878,7 @@ module.exports = {
   createReviewFeedbackForAuthor,
   updateMetrics,
   parseAgentOutput,
+  parseReviewVerdict,
   parseStructuredCompletion,
   runPostCompletionHooks,
   syncPrdFromPrs,

--- a/engine/playbook.js
+++ b/engine/playbook.js
@@ -81,13 +81,14 @@ function getPrVoteInstructions(project) {
   if (host === 'github') {
     const org = project?.adoOrg || '';
     const repo = project?.repoName || '';
-    return `Use \`gh pr review\` to submit a review on the PR:\n` +
-      `- Approve: \`gh pr review <number> --approve --body "Approval comment" --repo ${org}/${repo}\`\n` +
-      `- Request changes: \`gh pr review <number> --request-changes --body "What needs to change" --repo ${org}/${repo}\`\n` +
-      `- Comment only: \`gh pr review <number> --comment --body "Review comment" --repo ${org}/${repo}\`\n` +
+    return `**IMPORTANT: GitHub blocks self-approval** — all agents share the same credentials, so \`--approve\` and \`--request-changes\` will fail with "can't approve your own PR." Use \`--comment\` instead.\n\n` +
+      `Submit your review verdict using \`gh pr review\` with \`--comment\`:\n` +
+      `- Approve: \`gh pr review <number> --comment --body "VERDICT: APPROVE\\n\\n<your review details>" --repo ${org}/${repo}\`\n` +
+      `- Request changes: \`gh pr review <number> --comment --body "VERDICT: REQUEST_CHANGES\\n\\n<your review details>" --repo ${org}/${repo}\`\n` +
       `- Replace <number> with the PR number\n` +
       `- Always set --repo to \`${org}/${repo}\` to target the correct repository\n` +
-      `- Use --body to provide a review summary (supports Markdown)`;
+      `- **Your comment body MUST start with \`VERDICT: APPROVE\` or \`VERDICT: REQUEST_CHANGES\`** on its own line — the engine parses this to record your vote\n` +
+      `- Do NOT use \`--approve\` or \`--request-changes\` flags — they will fail`;
   }
   return `Use \`mcp__azure-ado__repo_update_pull_request_reviewers\`:\n- repositoryId: \`${repoId}\`\n- Set your reviewer vote on the PR (10=approve, 5=approve-with-suggestions, -10=reject)`;
 }

--- a/playbooks/review.md
+++ b/playbooks/review.md
@@ -40,28 +40,22 @@ Use subagents only for genuinely parallel, independent tasks (e.g., reviewing un
    - Verdict: **APPROVE**
    - Note any minor non-blocking suggestions
 
-## Post Review — Two required actions, both mandatory
+## Post Review — Submit your verdict
 
-You MUST complete BOTH steps below. The review is NOT done until both are confirmed. A comment without a vote is an incomplete review.
+You MUST post a review comment with a clear verdict. The engine parses your verdict to update PR status — **a review without a verdict line is incomplete and will be retried.**
 
-### Step 1: Post a detailed review comment
-
-{{pr_comment_instructions}}
-- content: Your full review with verdict, findings, and sign-off
-- Sign: `Review by Minions ({{agent_name}} — {{agent_role}})`
-
-### Step 2: Submit a formal review vote — THIS IS REQUIRED
-
-**This is a separate action from Step 1.** Posting a comment does NOT submit a vote. You must explicitly run the vote command:
+### Post your review with verdict
 
 {{pr_vote_instructions}}
-- If your verdict is **APPROVE**: use `--approve`
-- If your verdict is **REQUEST_CHANGES**: use `--request-changes`
-- If you have minor non-blocking suggestions only: use `--approve` with a note
 
-**Do not stop after Step 1.** The task is incomplete until Step 2 is done.
+Your review body **MUST** start with one of these verdict lines (exactly as shown):
+- `VERDICT: APPROVE` — if the code is ready to merge
+- `VERDICT: REQUEST_CHANGES` — if there are issues that must be fixed
 
-After running the vote command, confirm it succeeded (check the command output for errors). If it fails, retry once.
+Follow the verdict line with your detailed review findings, then sign off:
+- Sign: `Review by Minions ({{agent_name}} — {{agent_role}})`
+
+After running the command, confirm it succeeded (check the command output for errors). If it fails, retry once.
 
 ## Handling Merge Conflicts
 If you encounter merge conflicts (e.g., the PR shows conflicts):
@@ -71,9 +65,7 @@ If you encounter merge conflicts (e.g., the PR shows conflicts):
 
 ## When to Stop
 
-Your task is complete only when BOTH of these are true:
-1. Review comment posted (Step 1)
-2. Formal vote submitted via `gh pr review --approve` or `--request-changes` (Step 2)
+Your task is complete when your review comment (with `VERDICT: APPROVE` or `VERDICT: REQUEST_CHANGES` on the first line) has been posted successfully.
 
-Do NOT stop after only posting a comment. Do NOT continue reading unrelated files after voting.
+Do NOT stop before posting the review. Do NOT continue reading unrelated files after posting.
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -13835,6 +13835,70 @@ async function testPrReviewFixFlows() {
       'Should use resultSummary as primary note source');
   });
 
+  // ── Review verdict parsing (GitHub self-approval workaround) ──
+
+  console.log('\n── Review Verdict Parsing ──');
+
+  await test('parseReviewVerdict is exported from lifecycle.js', () => {
+    assert.ok(lifecycleSrc.includes('function parseReviewVerdict('),
+      'parseReviewVerdict function must exist');
+    assert.ok(lifecycleSrc.includes('parseReviewVerdict,'),
+      'parseReviewVerdict must be exported');
+  });
+
+  await test('parseReviewVerdict parses APPROVE verdict', () => {
+    const { parseReviewVerdict } = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
+    assert.strictEqual(parseReviewVerdict('VERDICT: APPROVE\n\nLooks good'), 'approved');
+    assert.strictEqual(parseReviewVerdict('**VERDICT: APPROVE**\n\nNice work'), 'approved');
+  });
+
+  await test('parseReviewVerdict parses REQUEST_CHANGES verdict', () => {
+    const { parseReviewVerdict } = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
+    assert.strictEqual(parseReviewVerdict('VERDICT: REQUEST_CHANGES\n\nNeeds fixes'), 'changes-requested');
+    assert.strictEqual(parseReviewVerdict('VERDICT: REQUEST CHANGES\n\nFix this'), 'changes-requested');
+  });
+
+  await test('parseReviewVerdict returns null for missing/no verdict', () => {
+    const { parseReviewVerdict } = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
+    assert.strictEqual(parseReviewVerdict(null), null);
+    assert.strictEqual(parseReviewVerdict(''), null);
+    assert.strictEqual(parseReviewVerdict('This is just a comment, no verdict'), null);
+  });
+
+  await test('updatePrAfterReview falls back to verdict parsing when live check is pending', () => {
+    const reviewFn = lifecycleSrc.slice(
+      lifecycleSrc.indexOf('function updatePrAfterReview('),
+      lifecycleSrc.indexOf('\nfunction ', lifecycleSrc.indexOf('function updatePrAfterReview(') + 1)
+    );
+    assert.ok(reviewFn.includes('parseReviewVerdict(resultSummary)'),
+      'Should parse verdict from resultSummary when live check returns pending');
+    assert.ok(reviewFn.includes('Parsed review verdict from agent output'),
+      'Should log when using parsed verdict');
+  });
+
+  await test('runPostCompletionHooks verifies review verdict exists before marking done', () => {
+    const hooksFn = lifecycleSrc.slice(
+      lifecycleSrc.indexOf('function runPostCompletionHooks('),
+      lifecycleSrc.indexOf('\nmodule.exports')
+    );
+    assert.ok(hooksFn.includes('parseReviewVerdict(resultSummary)'),
+      'Should check for verdict in review output');
+    assert.ok(hooksFn.includes('completed without verdict'),
+      'Should warn about missing verdict');
+    assert.ok(hooksFn.includes('No review verdict after'),
+      'Should fail after max retries with no verdict');
+  });
+
+  await test('getPrVoteInstructions warns about GitHub self-approval for github repos', () => {
+    const playbookSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'playbook.js'), 'utf8');
+    assert.ok(playbookSrc.includes('self-approval'),
+      'getPrVoteInstructions should warn about GitHub self-approval blocking');
+    assert.ok(playbookSrc.includes('--comment'),
+      'Should instruct using --comment for GitHub repos');
+    assert.ok(playbookSrc.includes('VERDICT: APPROVE'),
+      'Should instruct agents to include VERDICT: APPROVE in comment');
+  });
+
   // ── Build fix ──
 
   console.log('\n── Build Fix Flow ──');


### PR DESCRIPTION
## Summary

- **Root cause**: GitHub blocks self-approval — `gh pr review --approve` fails for all agents sharing the same `gh` CLI credentials. Agents fall back to `--comment`, which doesn't register as a formal vote. `checkLiveReviewStatus()` sees `reviews: []` and `reviewStatus` stays `pending` forever.
- **Fix**: Parse `VERDICT: APPROVE` / `VERDICT: REQUEST_CHANGES` from agent output as fallback when live vote check returns pending. Updated playbook to instruct `--comment` with verdict prefix. Added post-completion verification (mirroring PRD file existence check pattern) that auto-retries reviews missing a verdict line.

### Changes
- `engine/playbook.js`: `getPrVoteInstructions()` now instructs `--comment` with `VERDICT:` prefix for GitHub, warns about self-approval
- `playbooks/review.md`: Simplified to single-step review with verdict format requirement
- `engine/lifecycle.js`: Added `parseReviewVerdict()` function, verdict fallback in `updatePrAfterReview()`, and verification block in `runPostCompletionHooks()`
- `test/unit.test.js`: 7 new tests for verdict parsing, fallback logic, and playbook instructions

## Test plan
- [x] `npm test` passes (1474 passed, 0 failed)
- [ ] Verify on next review dispatch that agent uses `--comment` with VERDICT prefix
- [ ] Verify `reviewStatus` advances to `approved` from parsed verdict

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)