### PR TITLE
fix(queries): PRD updated status not overridden by work item done

### DIFF
--- a/engine/queries.js
+++ b/engine/queries.js
@@ -11,7 +11,7 @@ const shared = require('./shared');
 
 const { safeRead, safeReadDir, safeJson, safeWrite, getProjects,
   projectWorkItemsPath, projectPrPath, parseSkillFrontmatter, KB_CATEGORIES,
-  WI_STATUS, ENGINE_DEFAULTS } = shared;
+  WI_STATUS, DONE_STATUSES, PRD_ITEM_STATUS, ENGINE_DEFAULTS } = shared;
 
 /**
  * Read the first `bytes` and last `bytes` of a file efficiently using byte offsets.
@@ -955,9 +955,12 @@ function getPrdInfo(config) {
   const statusDisplay = { pending: 'missing' };
   for (const item of items) {
     const wi = wiById[item.id];
-    // Work item status is source of truth when available (PRD JSON may lag behind)
+    // PRD 'updated'/'missing' = intentional rework signal — takes priority over a done work item (#930).
+    // Otherwise work item status is source of truth when available (PRD JSON may lag behind).
     // If PRD says dispatched/failed but no work item exists, treat as pending (orphaned — #779)
-    const rawStatus = wi ? (wi.status || item.status)
+    const prdFlaggedForRework = item.status === PRD_ITEM_STATUS.UPDATED || item.status === PRD_ITEM_STATUS.MISSING;
+    const rawStatus = (wi && !(prdFlaggedForRework && DONE_STATUSES.has(wi.status)))
+      ? (wi.status || item.status)
       : ((item.status === WI_STATUS.DISPATCHED || item.status === WI_STATUS.FAILED) ? WI_STATUS.PENDING : item.status);
     item.status = statusDisplay[rawStatus] || rawStatus || 'missing';
     // Attach execution metadata for display (agent, PR link, fail reason)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -11567,6 +11567,20 @@ async function testAutoRecoveryAndAtomicity() {
       'getPrdInfo must also reset orphaned failed PRD items when work item is missing');
   });
 
+  await test('getPrdInfo: PRD updated/missing status takes priority over work item done (#930)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
+    const prdFn = src.slice(src.indexOf('function getPrdInfo'));
+    // PRD 'updated' must override done work item status
+    assert.ok(prdFn.includes('PRD_ITEM_STATUS.UPDATED'),
+      'getPrdInfo must check for PRD_ITEM_STATUS.UPDATED to detect rework signal');
+    assert.ok(prdFn.includes('PRD_ITEM_STATUS.MISSING'),
+      'getPrdInfo must check for PRD_ITEM_STATUS.MISSING to detect rework signal');
+    assert.ok(prdFn.includes('DONE_STATUSES.has'),
+      'getPrdInfo must use DONE_STATUSES to guard against done overriding rework');
+    assert.ok(prdFn.includes('prdFlaggedForRework'),
+      'getPrdInfo must compute prdFlaggedForRework before rawStatus');
+  });
+
   await test('areDependenciesMet returns failed when dep item is failed', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
     const fn = src.slice(src.indexOf('function areDependenciesMet'));


### PR DESCRIPTION
## Summary

- **Fixes #930**: PRD items marked `updated` or `missing` (rework signals from plan resume / diff-aware PRD regeneration) were hidden in the dashboard because `getPrdInfo()` unconditionally preferred work item `done` status over the PRD item status.
- Added `prdFlaggedForRework` guard: when the PRD item is `updated` or `missing` AND the work item is in a done state (`DONE_STATUSES`), the PRD status now takes precedence in the display.
- Imported `PRD_ITEM_STATUS` and `DONE_STATUSES` constants into `queries.js`.

## Changes

- `engine/queries.js` — status resolution loop (~line 960): added rework-flag check before `rawStatus` computation; updated imports
- `test/unit.test.js` — source-pattern test verifying the fix uses correct constants

## Test plan

- [x] `npm test` — 1485 passed, 0 failed
- [ ] Manual: create a plan, complete items, edit plan to trigger diff-aware PRD update → verify dashboard shows `updated` not `done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)