### PR TITLE
fix(dashboard): visual treatment for updated PRD item status

### DIFF
--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -95,6 +95,7 @@ function renderPrdProgress(prog) {
     const inProgress = items.filter(i => i.status === 'dispatched').length;
     const failed = items.filter(i => i.status === 'failed').length;
     const paused = items.filter(i => i.status === 'paused').length;
+    const updated = items.filter(i => i.status === 'updated').length;
     const missing = items.filter(i => i.status === 'missing' || !i.status).length;
     const pct = (n) => total > 0 ? ((n / total) * 100).toFixed(1) : 0;
 
@@ -103,6 +104,7 @@ function renderPrdProgress(prog) {
       '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--yellow)">' + inProgress + '</div><div class="prd-stat-label">Active</div></div>' +
       (failed ? '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--red)">' + failed + '</div><div class="prd-stat-label">Failed</div></div>' : '') +
       (paused ? '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--muted)">' + paused + '</div><div class="prd-stat-label">Paused</div></div>' : '') +
+      (updated ? '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--purple)">' + updated + '</div><div class="prd-stat-label">Needs Redo</div></div>' : '') +
       '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--muted)">' + missing + '</div><div class="prd-stat-label">To Do</div></div>' +
       '<div class="prd-stat"><div class="prd-stat-num" style="color:var(--text)">' + total + '</div><div class="prd-stat-label">Total</div></div>' +
     '</div>';
@@ -110,6 +112,7 @@ function renderPrdProgress(prog) {
     const bar = '<div class="prd-progress-bar">' +
       '<div class="seg complete" style="width:' + pct(done) + '%"></div>' +
       '<div class="seg dispatched" style="width:' + pct(inProgress) + '%"></div>' +
+      '<div class="seg updated" style="width:' + pct(updated) + '%"></div>' +
       '<div class="seg paused" style="width:' + pct(paused) + '%"></div>' +
       '<div class="seg missing" style="width:' + pct(missing) + '%"></div>' +
     '</div>';
@@ -131,8 +134,9 @@ function renderPrdProgress(prog) {
       'dispatched': 'background:rgba(210,153,34,0.15);color:var(--yellow);animation:wipPulse 1.5s infinite',
       'failed':      'background:rgba(248,81,73,0.15);color:var(--red)',
       'paused':      'background:rgba(139,148,158,0.15);color:var(--muted)',
+      'updated':     'background:rgba(188,140,255,0.15);color:var(--purple)',
     };
-    const labels = { 'done': 'DONE', 'dispatched': 'WIP', 'failed': 'FAIL', 'paused': 'PAUSED', 'missing': '\u2014' };
+    const labels = { 'done': 'DONE', 'dispatched': 'WIP', 'failed': 'FAIL', 'paused': 'PAUSED', 'missing': '\u2014', 'updated': 'REDO' };
     const style = styles[s] || 'background:var(--surface);color:var(--muted)';
     const label = labels[s] || '—';
     return '<span style="font-size:9px;font-weight:700;padding:2px 6px;border-radius:3px;letter-spacing:0.5px;white-space:nowrap;' + style + '">' + label + '</span>';
@@ -370,6 +374,7 @@ function renderPrdProgress(prog) {
       if (s === 'done') return 'var(--green)';
       if (s === 'dispatched') return 'var(--yellow)';
       if (s === 'failed') return 'var(--red)';
+      if (s === 'updated') return 'var(--purple)';
       if (s === 'paused') return 'var(--muted)';
       return 'var(--border)';
     };

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -171,6 +171,7 @@
   .prd-progress-bar .seg { height: 100%; transition: width 0.5s ease; }
   .prd-progress-bar .seg.complete { background: var(--green); }
   .prd-progress-bar .seg.dispatched { background: var(--yellow); }
+  .prd-progress-bar .seg.updated { background: var(--purple); }
   .prd-progress-bar .seg.paused { background: var(--muted); opacity: 0.5; }
   .prd-progress-bar .seg.missing { background: var(--border); }
   .prd-progress-pct { font-size: 22px; font-weight: 700; color: var(--green); margin-bottom: var(--space-4); }
@@ -179,6 +180,7 @@
   .prd-legend-dot { width: 10px; height: 10px; border-radius: 2px; }
   .prd-legend-dot.complete { background: var(--green); }
   .prd-legend-dot.dispatched { background: var(--yellow); }
+  .prd-legend-dot.updated { background: var(--purple); }
   .prd-legend-dot.missing { background: var(--border); }
 
   /* Pipeline Step-Progress */
@@ -212,6 +214,7 @@
   @keyframes prdWipPulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(210,153,34,0); } 50% { box-shadow: 0 0 0 4px rgba(210,153,34,0.2); } }
   .prd-item-row.st-failed { border-left-color: var(--red); }
   .prd-item-row.st-needs-human-review { border-left-color: var(--orange); }
+  .prd-item-row.st-updated { border-left-color: var(--purple); }
   .prd-item-row.st-paused { border-left-color: var(--muted); opacity: 0.5; }
   .prd-item-id { font-family: Consolas, monospace; color: var(--muted); min-width: 36px; font-size: 0.9em; }
   .prd-item-name { flex: 1; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
## Summary

Closes yemi33/minions#931

- Added purple `REDO` badge in `statusBadge()` for `'updated'` PRD items
- Added `Needs Redo` counter in `renderGroupStats()` stats row (conditionally shown when > 0)
- Added purple `seg.updated` segment in the PRD progress bar
- Added `var(--purple)` border color in `statusColor()` for wave/column dependency view
- Added CSS rules: `.seg.updated`, `.st-updated`, `.prd-legend-dot.updated`

Color: `--purple` (`#bc8cff`) — avoids conflicts with orange (needs-human-review), yellow (WIP/dispatched), green (done), red (failed).

## Test plan

- [x] `npm test` — 1484 passed, 0 failed, 2 skipped
- [ ] Visual check: open dashboard PRD page with a PRD containing `"updated"` items → verify purple REDO badge, purple left border, purple progress bar segment, and "Needs Redo" stat counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)