### PR TITLE
fix(plan-to-prd): preserve updated status across successive regenerations

### DIFF
--- a/playbooks/plan-to-prd.md
+++ b/playbooks/plan-to-prd.md
@@ -105,7 +105,7 @@ When the engine detects an existing PRD for this plan (`source_plan` match), it 
 1. **Parse the existing PRD JSON** — extract all `missing_features` items with their `id`, `status`, and metadata
 2. **Preserve item IDs** — match existing items to current plan items by name/description similarity. Each plan item that corresponds to an existing PRD item MUST reuse that item's `P-<id>`. Do NOT generate new IDs for items that already exist.
 3. **Preserve done items** — any existing item with `"status": "done"` carries forward as `"done"` with the same ID, description, and acceptance criteria. Do NOT reset done items to `"missing"`
-4. **Carry forward in-progress items** — items with `"status": "missing"` or other non-done statuses keep their existing ID and reset to `"missing"`
+4. **Carry forward in-progress items** — items with `"status": "missing"` or other non-done statuses (except `"updated"`) keep their existing ID and reset to `"missing"`. Items with `"status": "updated"` keep their existing ID and remain `"updated"` — do NOT reset to `"missing"`
 5. **New items only** — only generate new `P-<uuid>` IDs for items in the plan that have no match in the existing PRD
 6. **Removed items** — if an existing PRD item has no match in the current plan, drop it from the output
 7. **Preserve plan-level fields** — keep `branch_strategy`, `feature_branch`, and `project` from the existing PRD unless the plan explicitly changes them
@@ -118,6 +118,7 @@ If the task description contains `mode: diff-aware-update`, you are updating an 
 
 **Additional diff-aware rules** (on top of the reuse rules above):
 - **Done + modified** (plan added requirements/changed scope) → set `"status": "updated"` with same ID (engine re-opens the work item and dispatches to existing branch)
+- **Already `"updated"`** (was previously flagged for rework and still needs changes) → keep `"status": "updated"` with same ID and revised description. Do NOT reset to `"missing"` — this preserves the existing branch reference so the agent continues from prior work
 - **Pending/failed items** → reset to `"missing"` with updated description if the plan changed their scope
 
 ## Important

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1844,6 +1844,14 @@ async function testPrdStaleInvalidation() {
     assert.ok(playbook.includes('Preserve item IDs'),
       'Playbook should instruct agent to preserve existing IDs');
   });
+
+  await test('plan-to-prd playbook preserves "updated" status on successive diff-aware regenerations (#928)', () => {
+    const playbook = fs.readFileSync(path.join(MINIONS_DIR, 'playbooks', 'plan-to-prd.md'), 'utf8');
+    assert.ok(playbook.includes('Already') && playbook.includes('keep') && playbook.includes('"updated"') && playbook.includes('Do NOT reset to'),
+      'Diff-aware rules should explicitly preserve "updated" items and not reset to "missing"');
+    assert.ok(playbook.includes('except') && playbook.includes('"updated"'),
+      'Base reuse rule should exclude "updated" items from the "missing" reset');
+  });
 }
 
 // ─── Archive Path Resolution & Version Tests ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix #928: Add explicit rule to preserve `"updated"` PRD items on successive diff-aware regenerations
- Previously, items already marked `"updated"` fell through to base reuse rule 4 which reset all non-done statuses to `"missing"`, losing the distinction between rework items and new items
- Updated both the base reuse rules and the diff-aware section in `playbooks/plan-to-prd.md`

## Changes

**`playbooks/plan-to-prd.md`:**
- Base reuse rule 4: explicitly excludes `"updated"` items from the `"missing"` reset
- Diff-aware rules: added "Already `updated`" rule — items previously flagged for rework keep `"updated"` status with revised description

**`test/unit.test.js`:**
- Added test verifying both the diff-aware rule and the base reuse rule exclusion exist

## Test plan

- [x] `npm test` — 1485 passed, 0 failed
- [ ] Verify by running a successive diff-aware PRD regeneration and confirming `"updated"` items retain their status

Closes yemi33/minions#928

🤖 Generated with [Claude Code](https://claude.com/claude-code)