### PR TITLE
fix(lifecycle): syncPrdItemStatus backward-scan for PRD reset

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -135,7 +135,7 @@ const { renderPlaybook, validatePlaybookVars, PLAYBOOK_REQUIRED_VARS,
 
 // ─── Lifecycle (extracted to engine/lifecycle.js) ────────────────────────────
 
-const { runPostCompletionHooks, updateWorkItemStatus, syncPrdItemStatus, handlePostMerge, checkPlanCompletion,
+const { runPostCompletionHooks, updateWorkItemStatus, syncPrdItemStatus, reconcilePrdStatuses, handlePostMerge, checkPlanCompletion,
   syncPrsFromOutput, updatePrAfterReview, updatePrAfterFix, checkForLearnings, extractSkillsFromOutput,
   updateAgentHistory, updateMetrics, createReviewFeedbackForAuthor, parseAgentOutput, syncPrdFromPrs,
   isItemCompleted, classifyFailure, processPendingRebases } = require('./engine/lifecycle');
@@ -2692,6 +2692,7 @@ async function discoverWork(config) {
 
   // Side-effect passes: materialize plans and design docs into work-items.json
   // These write to project work queues — picked up by discoverFromWorkItems below.
+  reconcilePrdStatuses(config); // Backward-scan: correct "missing" PRD items that have done work items (#929)
   materializePlansAsWorkItems(config);
 
   for (const project of projects) {

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -8,7 +8,7 @@ const path = require('path');
 const os = require('os');
 const shared = require('./shared');
 const { safeRead, safeJson, safeWrite, mutateJsonFileLocked, mutateWorkItems, execSilent, execAsync, projectPrPath, getPrLinks, addPrLink,
-  log, ts, dateStamp, WI_STATUS, DONE_STATUSES, PLAN_TERMINAL_STATUSES, WORK_TYPE, PLAN_STATUS, PR_STATUS, DISPATCH_RESULT,
+  log, ts, dateStamp, WI_STATUS, DONE_STATUSES, PLAN_TERMINAL_STATUSES, WORK_TYPE, PLAN_STATUS, PRD_ITEM_STATUS, PR_STATUS, DISPATCH_RESULT,
   ENGINE_DEFAULTS, DEFAULT_AGENT_METRICS, FAILURE_CLASS } = shared;
 const { trackEngineUsage } = require('./llm');
 const queries = require('./queries');
@@ -635,6 +635,52 @@ function syncPrdItemStatus(itemId, status, sourcePlan) {
       }
     }
   } catch (err) { log('warn', `PRD status sync: ${err.message}`); }
+}
+
+// ─── PRD Backward-Scan Reconciliation (#929) ────────────────────────────────
+// Proactive counterpart to syncPrdItemStatus. Scans all active PRDs and promotes
+// "missing" items to "updated" when a done work item already exists for that ID.
+// This catches cases where a PRD regeneration incorrectly sets items to "missing"
+// and no subsequent work item state change triggers the reactive sync.
+
+function reconcilePrdStatuses(config) {
+  if (!fs.existsSync(PRD_DIR)) return;
+  let prdFiles;
+  try { prdFiles = fs.readdirSync(PRD_DIR).filter(f => f.endsWith('.json')); } catch { return; }
+  if (prdFiles.length === 0) return;
+
+  const allWorkItems = queries.getWorkItems(config);
+  if (allWorkItems.length === 0) return;
+
+  // Index done work items by ID for O(1) lookup
+  const doneWiById = new Map();
+  for (const wi of allWorkItems) {
+    if (wi.id && DONE_STATUSES.has(wi.status)) doneWiById.set(wi.id, wi);
+  }
+  if (doneWiById.size === 0) return;
+
+  for (const file of prdFiles) {
+    try {
+      const fpath = path.join(PRD_DIR, file);
+      const plan = safeJson(fpath);
+      if (!plan?.missing_features) continue;
+      // Skip completed/archived PRDs — no reconciliation needed
+      if (plan.status === PLAN_STATUS.COMPLETED) continue;
+
+      let modified = false;
+      for (const feature of plan.missing_features) {
+        if (feature.status === PRD_ITEM_STATUS.MISSING && doneWiById.has(feature.id)) {
+          feature.status = PRD_ITEM_STATUS.UPDATED;
+          modified = true;
+          log('info', `PRD backward-scan: promoted ${feature.id} from missing→updated in ${file} (done work item exists)`);
+        }
+      }
+
+      if (modified) {
+        safeWrite(fpath, plan);
+      }
+    } catch (err) { log('warn', `PRD backward-scan for ${file}: ${err.message}`); }
+  }
 }
 
 // ─── PR Sync from Output ─────────────────────────────────────────────────────
@@ -1876,6 +1922,7 @@ module.exports = {
   cleanupPlanWorktrees,
   updateWorkItemStatus,
   syncPrdItemStatus,
+  reconcilePrdStatuses,
   syncPrsFromOutput,
   updatePrAfterReview,
   updatePrAfterFix,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1087,6 +1087,51 @@ async function testSyncPrdItemStatus() {
     // Should not throw
     lifecycle.syncPrdItemStatus(null, 'done', 'test-plan.json');
   });
+
+  await test('reconcilePrdStatuses is exported from lifecycle', () => {
+    assert.ok(typeof lifecycle.reconcilePrdStatuses === 'function',
+      'reconcilePrdStatuses must be exported from lifecycle.js');
+  });
+
+  await test('reconcilePrdStatuses is called before materializePlansAsWorkItems in discovery (#929)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    // Scope search to discoverWork function to avoid matching the function definition
+    const discoverFn = src.slice(src.indexOf('async function discoverWork'));
+    const reconcileIdx = discoverFn.indexOf('reconcilePrdStatuses(config)');
+    const materializeIdx = discoverFn.indexOf('materializePlansAsWorkItems(config)');
+    assert.ok(reconcileIdx > -1, 'discoverWork must call reconcilePrdStatuses(config)');
+    assert.ok(materializeIdx > -1, 'discoverWork must call materializePlansAsWorkItems(config)');
+    assert.ok(reconcileIdx < materializeIdx,
+      'reconcilePrdStatuses must be called BEFORE materializePlansAsWorkItems in discoverWork');
+  });
+
+  await test('reconcilePrdStatuses scans for missing PRD items with done work items (#929)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function reconcilePrdStatuses'), src.indexOf('// ─── PR Sync from Output'));
+    // Must check for PRD_ITEM_STATUS.MISSING (not raw string)
+    assert.ok(fn.includes('PRD_ITEM_STATUS.MISSING'),
+      'reconcilePrdStatuses must check for PRD_ITEM_STATUS.MISSING');
+    // Must promote to PRD_ITEM_STATUS.UPDATED (not raw string)
+    assert.ok(fn.includes('PRD_ITEM_STATUS.UPDATED'),
+      'reconcilePrdStatuses must promote to PRD_ITEM_STATUS.UPDATED');
+    // Must check done work items via DONE_STATUSES
+    assert.ok(fn.includes('DONE_STATUSES'),
+      'reconcilePrdStatuses must check DONE_STATUSES for done work item lookup');
+    // Must skip completed PRDs
+    assert.ok(fn.includes('PLAN_STATUS.COMPLETED'),
+      'reconcilePrdStatuses must skip completed PRDs');
+    // Must use queries.getWorkItems for WI lookup
+    assert.ok(fn.includes('queries.getWorkItems'),
+      'reconcilePrdStatuses must use queries.getWorkItems to scan all work items');
+    // Must write back modified PRD files
+    assert.ok(fn.includes('safeWrite'),
+      'reconcilePrdStatuses must write back modified PRD files');
+  });
+
+  await test('reconcilePrdStatuses does not crash when no PRD files exist (#929)', () => {
+    // Should not throw — PRD_DIR might not exist or be empty
+    lifecycle.reconcilePrdStatuses({});
+  });
 }
 
 // ─── Consolidation Tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `reconcilePrdStatuses()` in `engine/lifecycle.js` — a proactive backward-scan that promotes "missing" PRD items to "updated" when a done work item already exists for that ID
- Called before `materializePlansAsWorkItems()` in each discovery tick, ensuring PRD statuses are corrected before materialization processes them
- Skips completed PRDs; uses O(1) lookup via Map for done work items; per-file try-catch for fault isolation

Closes #929

## Why

When a PRD is regenerated, the plan-to-prd agent may incorrectly mark items as "missing" when done work items already exist. The existing `syncPrdItemStatus` is purely reactive (fires only on WI state changes), so these mismatches persist silently. The materializer treats "missing" differently from "updated" — "updated" dispatches to the existing branch while "missing" may create from scratch. This backward-scan ensures the correct semantics.

## Test plan

- [x] `reconcilePrdStatuses` exported from lifecycle.js
- [x] Called before `materializePlansAsWorkItems` in `discoverWork` 
- [x] Source-pattern tests verify correct constant usage (PRD_ITEM_STATUS, DONE_STATUSES, PLAN_STATUS)
- [x] No-crash test for empty/missing PRD directory
- [x] All 1488 unit tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)