### PR TITLE
feat(W-mnv2w476i55a): add red dot notification on CC tab when response completes (#934)

### DIFF
--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -661,7 +661,9 @@ async function _ccDoSend(message, skipUserMsg) {
     ccRenderTabBar();
     try { clearInterval(phaseTimer); } catch { /* may not be defined if error before reader */ }
     try { localStorage.removeItem('cc-sending'); } catch {}
-    if (!_ccOpen) showNotifBadge(document.getElementById('cc-toggle-btn'));
+    // Show red dot badge on CC button when response completes while drawer is closed.
+    // Skip badge on user-initiated abort — they don't need notification for their own action.
+    if (!_ccOpen && !_wasAborted) showNotifBadge(document.getElementById('cc-toggle-btn'));
   }
   return _wasAborted;
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -12167,6 +12167,32 @@ async function testDashboardResilience() {
       'toggleCommandCenter must toggle overlay display');
   });
 
+  // ── CC notification badge on response completion (#934) ──
+
+  await test('CC shows red dot badge when response completes while drawer closed', () => {
+    const fn = ccSrc.slice(ccSrc.indexOf('async function _ccDoSend'), ccSrc.indexOf('\nfunction', ccSrc.indexOf('async function _ccDoSend') + 1));
+    assert.ok(fn.includes('!_ccOpen') && fn.includes("showNotifBadge(document.getElementById('cc-toggle-btn'))"),
+      '_ccDoSend finally block must show badge on CC button when drawer is closed');
+  });
+
+  await test('CC badge skips user-initiated abort', () => {
+    const fn = ccSrc.slice(ccSrc.indexOf('async function _ccDoSend'), ccSrc.indexOf('\nfunction', ccSrc.indexOf('async function _ccDoSend') + 1));
+    assert.ok(fn.includes('!_wasAborted') && fn.includes("showNotifBadge(document.getElementById('cc-toggle-btn'))"),
+      'Badge condition must include !_wasAborted to skip badge on user abort');
+  });
+
+  await test('CC clears badge when drawer opens', () => {
+    const fn = ccSrc.slice(ccSrc.indexOf('function toggleCommandCenter'), ccSrc.indexOf('\nfunction', ccSrc.indexOf('function toggleCommandCenter') + 1));
+    assert.ok(fn.includes("clearNotifBadge(document.getElementById('cc-toggle-btn'))"),
+      'toggleCommandCenter must clear badge when drawer opens');
+  });
+
+  await test('CC shows processing badge when drawer closed while sending', () => {
+    const fn = ccSrc.slice(ccSrc.indexOf('function toggleCommandCenter'), ccSrc.indexOf('\nfunction', ccSrc.indexOf('function toggleCommandCenter') + 1));
+    assert.ok(fn.includes("showNotifBadge(document.getElementById('cc-toggle-btn'), 'processing')"),
+      'toggleCommandCenter must show processing badge when closing drawer during active request');
+  });
+
   // ── Safety net: no safeWrite targeting work-items.json or pull-requests.json ──
 
   await test('dashboard.js: no safeWrite calls target work-items.json or pull-requests.json', () => {


### PR DESCRIPTION
## Summary
- Skip showing the CC notification badge when the user deliberately aborts a request (`!_wasAborted` guard) — previously, aborting still showed a red dot
- Add 4 unit tests covering the full CC badge lifecycle: show on completion, skip on abort, clear when drawer opens, and processing badge when drawer closes during active request

Fixes #934

## Test plan
- [x] `npm test` — 1488 passed, 0 failed
- [ ] Open CC drawer, send a message, close drawer → verify blue processing dots appear on CC button
- [ ] Wait for response → verify red dot badge replaces processing dots
- [ ] Click CC button to reopen → verify badge clears
- [ ] Open CC, send message, close drawer, click Stop → verify NO red dot appears (abort skips badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)