### PR TITLE
fix: PRD item display dispatched/in-progress status conflation

### DIFF
--- a/dashboard/js/render-prd.js
+++ b/dashboard/js/render-prd.js
@@ -92,7 +92,7 @@ function renderPrdProgress(prog) {
     const total = items.length;
     if (total === 0) return '';
     const done = items.filter(i => i.status === 'done').length;
-    const inProgress = items.filter(i => i.status === 'dispatched').length;
+    const inProgress = items.filter(i => i.status === 'in-progress').length;
     const failed = items.filter(i => i.status === 'failed').length;
     const paused = items.filter(i => i.status === 'paused').length;
     const updated = items.filter(i => i.status === 'updated').length;
@@ -111,7 +111,7 @@ function renderPrdProgress(prog) {
 
     const bar = '<div class="prd-progress-bar">' +
       '<div class="seg complete" style="width:' + pct(done) + '%"></div>' +
-      '<div class="seg dispatched" style="width:' + pct(inProgress) + '%"></div>' +
+      '<div class="seg in-progress" style="width:' + pct(inProgress) + '%"></div>' +
       '<div class="seg updated" style="width:' + pct(updated) + '%"></div>' +
       '<div class="seg paused" style="width:' + pct(paused) + '%"></div>' +
       '<div class="seg missing" style="width:' + pct(missing) + '%"></div>' +
@@ -120,23 +120,23 @@ function renderPrdProgress(prog) {
     return '<div style="margin:6px 0 8px 0;padding:0 8px">' + stats + '<div style="margin-top:8px">' + bar + '</div></div>';
   }
 
-  // PRD item statuses: missing → dispatched → done
+  // PRD item statuses: missing → in-progress → done
   const statusBadge = (s, itemId) => {
     // Decomposed: show WIP if children still running, DONE if all children done
     if (s === 'decomposed' && itemId) {
       const children = (window._lastWorkItems || []).filter(w => w.parent_id === itemId);
       const allChildrenDone = children.length > 0 && children.every(c => c.status === 'done');
       if (allChildrenDone) { s = 'done'; }
-      else { s = 'dispatched'; } // show as WIP while children are running
+      else { s = 'in-progress'; } // show as WIP while children are running
     }
     const styles = {
       'done': 'background:rgba(63,185,80,0.15);color:var(--green)',
-      'dispatched': 'background:rgba(210,153,34,0.15);color:var(--yellow);animation:wipPulse 1.5s infinite',
+      'in-progress': 'background:rgba(210,153,34,0.15);color:var(--yellow);animation:wipPulse 1.5s infinite',
       'failed':      'background:rgba(248,81,73,0.15);color:var(--red)',
       'paused':      'background:rgba(139,148,158,0.15);color:var(--muted)',
       'updated':     'background:rgba(188,140,255,0.15);color:var(--purple)',
     };
-    const labels = { 'done': 'DONE', 'dispatched': 'WIP', 'failed': 'FAIL', 'paused': 'PAUSED', 'missing': '\u2014', 'updated': 'REDO' };
+    const labels = { 'done': 'DONE', 'in-progress': 'WIP', 'failed': 'FAIL', 'paused': 'PAUSED', 'missing': '\u2014', 'updated': 'REDO' };
     const style = styles[s] || 'background:var(--surface);color:var(--muted)';
     const label = labels[s] || '—';
     return '<span style="font-size:9px;font-weight:700;padding:2px 6px;border-radius:3px;letter-spacing:0.5px;white-space:nowrap;' + style + '">' + label + '</span>';
@@ -253,7 +253,7 @@ function renderPrdProgress(prog) {
 
   const renderGroupHeader = (g) => {
     const done = g.items.filter(i => i.status === 'done').length;
-    const wip = g.items.filter(i => i.status === 'dispatched' || i.status === 'pending').length;
+    const wip = g.items.filter(i => i.status === 'in-progress' || i.status === 'missing').length;
     const summary = (g.summary || '').replace(/^Convert plan to PRD:\s*/i, '').slice(0, 80);
     const isAwaitingApproval = g.planStatus === 'awaiting-approval';
     const isPaused = g.planStatus === 'paused';
@@ -372,7 +372,7 @@ function renderPrdProgress(prog) {
         return 'var(--yellow)'; // children still running
       }
       if (s === 'done') return 'var(--green)';
-      if (s === 'dispatched') return 'var(--yellow)';
+      if (s === 'in-progress') return 'var(--yellow)';
       if (s === 'failed') return 'var(--red)';
       if (s === 'updated') return 'var(--purple)';
       if (s === 'paused') return 'var(--muted)';
@@ -394,7 +394,7 @@ function renderPrdProgress(prog) {
         const agentInfo = agentId ? (agentData.find(a => a.id === agentId) || {}) : null;
         const agentDisplay = agentInfo ? (agentInfo.emoji || '') + ' ' + escHtml(agentInfo.name || agentId) : (agentId ? escHtml(agentId) : '');
         const deps = (i.depends_on || []).join(', ');
-        const wipAnim = i.status === 'dispatched' ? 'animation:prdWipPulse 2s infinite;' : '';
+        const wipAnim = i.status === 'in-progress' ? 'animation:prdWipPulse 2s infinite;' : '';
         html += '<div onclick="prdItemEdit(\'' + src + '\',\'' + iid + '\')" ' +
           'style="background:var(--surface2);border:1px solid var(--border);border-left:3px solid ' + borderColor + ';' + wipAnim +
           'border-radius:4px;padding:6px 8px;margin-bottom:6px;cursor:pointer;font-size:11px">' +
@@ -658,7 +658,7 @@ async function prdItemEdit(source, itemId) {
   let completionHtml = '';
   const isDone = item.status === 'done';
   const isFailed = item.status === 'failed';
-  const isActive = item.status === 'dispatched' || item.status === 'pending';
+  const isActive = item.status === 'in-progress' || item.status === 'missing';
 
   if (isDone || isFailed || isActive) {
     const agent = wi?.dispatched_to || completedEntry?.agent || '';

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -170,7 +170,7 @@
   .prd-progress-bar { width: 100%; height: 20px; background: var(--bg); border-radius: var(--radius-xl); overflow: hidden; display: flex; margin-bottom: var(--space-6); border: 1px solid var(--border); }
   .prd-progress-bar .seg { height: 100%; transition: width 0.5s ease; }
   .prd-progress-bar .seg.complete { background: var(--green); }
-  .prd-progress-bar .seg.dispatched { background: var(--yellow); }
+  .prd-progress-bar .seg.in-progress { background: var(--yellow); }
   .prd-progress-bar .seg.updated { background: var(--purple); }
   .prd-progress-bar .seg.paused { background: var(--muted); opacity: 0.5; }
   .prd-progress-bar .seg.missing { background: var(--border); }
@@ -179,7 +179,7 @@
   .prd-legend-item { display: flex; align-items: center; gap: 5px; font-size: var(--text-base); color: var(--muted); }
   .prd-legend-dot { width: 10px; height: 10px; border-radius: 2px; }
   .prd-legend-dot.complete { background: var(--green); }
-  .prd-legend-dot.dispatched { background: var(--yellow); }
+  .prd-legend-dot.in-progress { background: var(--yellow); }
   .prd-legend-dot.updated { background: var(--purple); }
   .prd-legend-dot.missing { background: var(--border); }
 
@@ -210,7 +210,7 @@
   .prd-items-list { display: flex; flex-direction: column; gap: 3px; max-height: 400px; overflow-y: auto; padding: 0 8px; }
   .prd-item-row { display: flex; align-items: center; gap: 8px; padding: 4px 8px; border-radius: var(--radius-sm); font-size: var(--text-base); background: var(--surface2); border: 1px solid var(--border); border-left: 3px solid var(--border); }
   .prd-item-row.st-done { border-left-color: var(--green); }
-  .prd-item-row.st-dispatched { border-left-color: var(--yellow); animation: prdWipPulse 2s infinite; }
+  .prd-item-row.st-in-progress { border-left-color: var(--yellow); animation: prdWipPulse 2s infinite; }
   @keyframes prdWipPulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(210,153,34,0); } 50% { box-shadow: 0 0 0 4px rgba(210,153,34,0.2); } }
   .prd-item-row.st-failed { border-left-color: var(--red); }
   .prd-item-row.st-needs-human-review { border-left-color: var(--orange); }

--- a/engine/queries.js
+++ b/engine/queries.js
@@ -952,7 +952,7 @@ function getPrdInfo(config) {
   // PRD JSON status is the source of truth — kept in sync with work item by syncPrdItemStatus.
   // Map from PRD JSON values to display values (pending → missing for undispatched items)
   // Augment each item with execution metadata from the work item.
-  const statusDisplay = { pending: 'missing' };
+  const statusDisplay = { pending: 'missing', dispatched: 'in-progress' };
   for (const item of items) {
     const wi = wiById[item.id];
     // PRD 'updated'/'missing' = intentional rework signal — takes priority over a done work item (#930).
@@ -973,7 +973,7 @@ function getPrdInfo(config) {
   const byStatus = {};
   items.forEach(item => { const s = item.status || 'missing'; byStatus[s] = byStatus[s] || []; byStatus[s].push(item); });
   const complete = (byStatus['done'] || []).length + (byStatus['decomposed'] || []).length;
-  const inProgress = (byStatus['dispatched'] || []).length;
+  const inProgress = (byStatus['in-progress'] || []).length;
   const paused = (byStatus['paused'] || []).length;
   const missing = (byStatus['missing'] || []).length;
   const donePercent = total > 0 ? Math.round((complete / total) * 100) : 0;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9398,15 +9398,15 @@ async function testDashboardAuditCritical() {
       'pause must set the values that resume looks for');
   });
 
-  await test('PRD isActive check includes both dispatched and pending', () => {
+  await test('PRD isActive check includes both in-progress and missing display statuses', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-prd.js'), 'utf8');
-    // Should not have the tautology: dispatched || dispatched
-    const tautology = (src.match(/dispatched.*\|\|.*dispatched/g) || []);
+    // Should not have the tautology: in-progress || in-progress
+    const tautology = (src.match(/in-progress.*\|\|.*in-progress/g) || []);
     assert.strictEqual(tautology.length, 0,
-      'render-prd.js must not have dispatched || dispatched tautology');
-    // Should have dispatched || pending
-    assert.ok(src.includes("'dispatched' || i.status === 'pending'") || src.includes("'dispatched' || item.status === 'pending'"),
-      'isActive/wip check must include both dispatched and pending');
+      'render-prd.js must not have in-progress || in-progress tautology');
+    // Should have in-progress || missing (display-mapped statuses from statusDisplay in queries.js)
+    assert.ok(src.includes("'in-progress' || i.status === 'missing'") || src.includes("'in-progress' || item.status === 'missing'"),
+      'isActive/wip check must include both in-progress and missing display statuses');
   });
 
   await test('rerenderPrdFromCache calls renderPrdProgress', () => {


### PR DESCRIPTION
Closes yemi33/minions#950

## Summary

- Add `dispatched: 'in-progress'` to `statusDisplay` map in `engine/queries.js` so work items with internal status `dispatched` get normalized to `in-progress` for PRD display
- Update `byStatus` counter in `queries.js` to read from `in-progress` bucket
- Update all downstream display code in `dashboard/js/render-prd.js`: `statusBadge` styles/labels, progress bar stats filter, wave view WIP counter, column view animation, item detail `isActive` check
- Update CSS in `dashboard/styles.css`: `.seg.dispatched` → `.seg.in-progress`, `.prd-legend-dot.dispatched` → `.prd-legend-dot.in-progress`, `.st-dispatched` → `.st-in-progress`
- Update source-pattern test to match new display status names

## Test plan

- [x] `npm test` — 1494 passed, 0 failed, 2 skipped
- [ ] Visual: dispatch a PRD work item and verify WIP badge (yellow pulse) appears on the PRD item row
- [ ] Visual: verify Active counter increments and progress bar shows yellow segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)