### PR TITLE
fix(P-f7c2a1b9): fix steering system-prompt bug

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -848,7 +848,7 @@ async function spawnAgent(dispatchItem, config) {
       const childEnv = shared.cleanChildEnv();
       let resumeProc;
       try {
-        resumeProc = runFile(process.execPath, [spawnScript, steerPromptPath, steerPromptPath, ...resumeArgs], {
+        resumeProc = runFile(process.execPath, [spawnScript, steerPromptPath, sysPromptPath, ...resumeArgs], {
           cwd,
           stdio: ['pipe', 'pipe', 'pipe'],
           env: childEnv,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6356,6 +6356,16 @@ async function testAgentSteering() {
       'Re-spawn prompt should tell agent to continue after responding');
   });
 
+  await test('steering resume spawn passes sysPromptPath (not steerPromptPath) as system prompt', () => {
+    // The steering resume spawn should use: [spawnScript, steerPromptPath, sysPromptPath, ...resumeArgs]
+    // NOT: [spawnScript, steerPromptPath, steerPromptPath, ...resumeArgs]
+    // steerPromptPath is the prompt, sysPromptPath is the original agent system prompt
+    const steerSpawnLine = engineSrc.match(/resumeProc\s*=\s*runFile\([^,]+,\s*\[spawnScript,\s*steerPromptPath,\s*(\w+)/);
+    assert.ok(steerSpawnLine, 'Should find steering resume spawn line');
+    assert.strictEqual(steerSpawnLine[1], 'sysPromptPath',
+      'Second arg to spawn-agent in steering resume must be sysPromptPath (the original system prompt), not steerPromptPath');
+  });
+
   // Stale steering recovery: if kill didn't terminate agent within 30s, retry
   await test('checkSteering has stale steering recovery with retry', () => {
     const timeoutSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'timeout.js'), 'utf8');


### PR DESCRIPTION
## What

Fixed a bug in `engine.js:851` where the steering resume spawn passed `steerPromptPath` as **both** the prompt and system-prompt arguments to `spawn-agent.js`. This caused every steered agent to lose all playbook context, team rules, and conventions — the steering message replaced the system prompt entirely.

**Root cause:** `[spawnScript, steerPromptPath, steerPromptPath, ...resumeArgs]` — second arg should be `sysPromptPath`, matching the normal spawn pattern at `engine.js:684`.

**Fix:** One-line change — `steerPromptPath` → `sysPromptPath` as the second argument.

## Files changed

- `engine.js` — fixed steering resume spawn args (line 851)
- `test/unit.test.js` — added test verifying steering resume uses `sysPromptPath` as second arg

## Build & test

```bash
npm test   # 0 failures
```

## Test plan

- [x] New unit test verifies the steering resume spawn args array has `sysPromptPath` as the second element (regex match on source)
- [x] All existing tests pass (0 failures)
- [ ] Manual: steer a running agent and verify it retains playbook/team context after resume

Built by Minions (Dallas — Engineer)