### PR TITLE
feat(P-c7d3e1a6): fix dispatch.js mutator fallback to use nullish coalescing

### DIFF
--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -30,7 +30,7 @@ function mutateDispatch(mutator) {
     dispatch.pending = Array.isArray(dispatch.pending) ? dispatch.pending : [];
     dispatch.active = Array.isArray(dispatch.active) ? dispatch.active : [];
     dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
-    return mutator(dispatch) || dispatch;
+    return mutator(dispatch) ?? dispatch;
   }, { defaultValue: defaultDispatch });
   // Invalidate the read cache so next getDispatch() sees fresh data
   try { require('./queries').invalidateDispatchCache(); } catch {}

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2424,6 +2424,56 @@ async function testStateIntegrity() {
       'engine dispatch writes should use lock-backed mutation');
   });
 
+  await test('mutateDispatch uses nullish coalescing (??) not OR (||) for mutator fallback', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');
+    // Find the mutateDispatch function definition
+    const fnStart = src.indexOf('function mutateDispatch(');
+    assert.ok(fnStart > -1, 'mutateDispatch function should exist');
+    const fnEnd = src.indexOf('\n}', fnStart);
+    const fnBody = src.slice(fnStart, fnEnd + 2);
+    // Must use ?? (nullish coalescing) — not || which treats 0, false, '' as falsy
+    assert.ok(fnBody.includes('mutator(dispatch) ?? dispatch'),
+      'mutateDispatch must use ?? (nullish coalescing) for mutator fallback, not ||');
+    assert.ok(!fnBody.includes('mutator(dispatch) || dispatch'),
+      'mutateDispatch must NOT use || for mutator fallback — || treats falsy returns incorrectly');
+  });
+
+  await test('mutateDispatch falls back to dispatch when mutator returns undefined (in-place mutation)', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const testDispatch = require('../engine/dispatch');
+      const testQueries = require('../engine/queries');
+
+      // Mutator that modifies in-place and returns undefined (implicit return)
+      testDispatch.mutateDispatch((dp) => {
+        dp.pending.push({ id: 'test-undef-1', agent: 'test', type: 'implement' });
+        // no return — undefined
+      });
+
+      const dp = testQueries.getDispatch();
+      assert.strictEqual(dp.pending.length, 1, 'Should have 1 pending item after in-place mutation');
+      assert.strictEqual(dp.pending[0].id, 'test-undef-1', 'Pending item should be the one we added');
+    } finally { restore(); }
+  });
+
+  await test('mutateDispatch uses returned value when mutator returns a dispatch object', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const testDispatch = require('../engine/dispatch');
+      const testQueries = require('../engine/queries');
+
+      // Mutator that returns a new dispatch object
+      testDispatch.mutateDispatch((dp) => {
+        dp.pending.push({ id: 'test-return-1', agent: 'test', type: 'implement' });
+        return dp;
+      });
+
+      const dp = testQueries.getDispatch();
+      assert.strictEqual(dp.pending.length, 1, 'Should have 1 pending item from returned dispatch');
+      assert.strictEqual(dp.pending[0].id, 'test-return-1', 'Pending item should be the one we added');
+    } finally { restore(); }
+  });
+
   await test('All mutateDispatch callbacks return dispatch object on every path', () => {
     const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
     const dispatchSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');


### PR DESCRIPTION
## Summary
- Changes `mutator(dispatch) || dispatch` to `mutator(dispatch) ?? dispatch` in `mutateDispatch()` (engine/dispatch.js:33)
- The `||` operator incorrectly treats any falsy mutator return (0, false, '') as "no return" and falls back to `dispatch`. The `??` operator only falls back when the mutator returns `null` or `undefined`, which is the correct behavior for in-place mutation patterns.
- Adds 3 unit tests: source pattern check for `??`, behavioral test for undefined return fallback, and behavioral test for explicit return value usage

## Test plan
- [x] Source pattern test verifies `??` is used, not `||`
- [x] Behavioral test: mutator returning `undefined` (in-place mutation) falls back to dispatch
- [x] Behavioral test: mutator returning a dispatch object uses the returned value
- [x] All 1241 existing tests pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)