### PR TITLE
feat(P-a9c5d7e3): add missing branch_name to central dispatch vars

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -2485,6 +2485,7 @@ function discoverCentralWorkItems(config) {
 
         const ap = assignedProject || (projects.length > 0 ? projects[0] : null);
         if (!ap) { log('warn', `Fan-out: skipping ${fanKey} — no projects configured`); continue; }
+        const fanBranch = `fan/${item.id}/${agent.id}`;
         const vars = {
           ...buildBaseVars(agent.id, config, ap),
           item_id: item.id,
@@ -2495,6 +2496,7 @@ function discoverCentralWorkItems(config) {
           additional_context: item.prompt ? `## Additional Context\n\n${item.prompt}` : '',
           scope_section: buildProjectContext(projects, assignedProject, true, agent.name, agent.role),
           project_path: ap?.localPath || '',
+          branch_name: fanBranch,
         };
 
         // Build common vars: references, acceptance criteria, notes (ASK only), task context
@@ -2519,7 +2521,7 @@ function discoverCentralWorkItems(config) {
           prompt,
           meta: {
             dispatchKey: fanKey, source: 'central-work-item-fanout', item, parentKey: key,
-            branch: `fan/${item.id}/${agent.id}`,
+            branch: fanBranch,
             deadline: item.timeout ? Date.now() + item.timeout : Date.now() + (config.engine?.fanOutTimeout || config.engine?.agentTimeout || DEFAULTS.agentTimeout)
           }
         });
@@ -2564,6 +2566,7 @@ function discoverCentralWorkItems(config) {
         additional_context: item.prompt ? `## Additional Context\n\n${item.prompt}` : '',
         scope_section: buildProjectContext(projects, null, false, agentName, agentRole),
         project_path: firstProject?.localPath || '',
+        branch_name: centralBranch,
       };
       const centralWtPath = firstProject?.localPath
         ? path.resolve(firstProject.localPath, config.engine?.worktreeRoot || '../worktrees', centralBranch)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4108,6 +4108,24 @@ async function testBuildWorkItemDispatchVars() {
       'discoverCentralWorkItems should call buildWorkItemDispatchVars');
   });
 
+  await test('central dispatch fan-out vars include branch_name', () => {
+    const centralFn = src.slice(src.indexOf('function discoverCentralWorkItems('));
+    // Find the fan-out vars block (comes before the normal dispatch vars block)
+    const fanOutSection = centralFn.slice(0, centralFn.indexOf('// ─── Normal'));
+    assert.ok(fanOutSection.includes('branch_name: fanBranch'),
+      'Fan-out dispatch vars should include branch_name derived from fanBranch');
+    assert.ok(fanOutSection.includes("const fanBranch = `fan/${item.id}/${agent.id}`"),
+      'Fan-out should compute fanBranch from item.id and agent.id');
+  });
+
+  await test('central dispatch normal vars include branch_name', () => {
+    const centralFn = src.slice(src.indexOf('function discoverCentralWorkItems('));
+    // Find the normal dispatch section
+    const normalSection = centralFn.slice(centralFn.indexOf('// ─── Normal'));
+    assert.ok(normalSection.includes('branch_name: centralBranch'),
+      'Normal central dispatch vars should include branch_name derived from centralBranch');
+  });
+
   await test('no inline fs.readFileSync for notes.md in discovery functions', () => {
     // After extraction, discovery functions should not have inline notes.md reads
     const discoverWI = src.slice(src.indexOf('function discoverFromWorkItems('), src.indexOf('function normalizeAc('));


### PR DESCRIPTION
## Summary

- Fan-out and normal central work item dispatch paths in `discoverCentralWorkItems()` were missing `branch_name` in playbook template vars
- This caused `{{branch_name}}` to interpolate as `undefined` in `implement.md`, `implement-shared.md`, and `work-item.md` playbooks for central work items
- Added `branch_name: fanBranch` (derived from `fan/${item.id}/${agent.id}`) to fan-out vars and `branch_name: centralBranch` to normal central vars
- Extracted `fanBranch` variable to eliminate duplication with `meta.branch`
- Added 2 unit tests verifying `branch_name` presence in both dispatch paths

## Test plan

- [x] Unit tests pass (`npm test`) — 0 failures
- [x] New tests verify `branch_name` in fan-out vars (`branch_name: fanBranch`)
- [x] New tests verify `branch_name` in normal central vars (`branch_name: centralBranch`)
- [ ] Verify playbook rendering with actual central work items

🤖 Generated with [Claude Code](https://claude.com/claude-code)