### PR TITLE
feat(P-b1f6c8d4): replace magic string 'active' with PR_STATUS.ACTIVE in lifecycle.js

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -962,7 +962,7 @@ function findDependentActivePrs(mergedItemId, config) {
   for (const p of projects) {
     const prs = safeJson(projectPrPath(p)) || [];
     for (const pr of prs) {
-      if (!pr.branch || pr.status !== 'active') continue;
+      if (!pr.branch || pr.status !== PR_STATUS.ACTIVE) continue;
       const linked = (pr.prdItems || []).some(id => dependentWis.some(wi => wi.id === id));
       if (linked && !results.some(r => r.pr.id === pr.id)) {
         const wi = dependentWis.find(w => (pr.prdItems || []).includes(w.id));
@@ -1038,7 +1038,7 @@ async function processPendingRebases(config) {
     if (!project) continue;
 
     const prs = safeJson(projectPrPath(project)) || [];
-    const pr = prs.find(p => p.id === entry.prId && p.status === 'active');
+    const pr = prs.find(p => p.id === entry.prId && p.status === PR_STATUS.ACTIVE);
     if (!pr) continue; // PR closed/merged since queuing
 
     const result = await rebaseBranchOntoMain(pr, project, config);


### PR DESCRIPTION
## Summary
- Replace raw string `'active'` with `PR_STATUS.ACTIVE` constant at two locations in `engine/lifecycle.js` (lines 965 and 1041)
- `findDependentActivePrs` and `processPendingRebases` now use the constant, consistent with the no-magic-strings convention
- `PR_STATUS` was already imported at line 11 — no new imports needed

## Test plan
- [x] All unit tests pass (`npm test` — 0 failures)
- [x] Verified no other raw `'active'` strings used for PR status comparisons in lifecycle.js
- [x] Verified `PR_STATUS.ACTIVE` resolves to `'active'` (shared.js:602)

🤖 Generated with [Claude Code](https://claude.com/claude-code)