### PR TITLE
feat(P-d5f8a3c7): audit and harden log buffering implementation

### DIFF
--- a/engine/shared.js
+++ b/engine/shared.js
@@ -8,7 +8,7 @@ const path = require('path');
 
 const MINIONS_DIR = process.env.MINIONS_TEST_DIR || path.resolve(__dirname, '..');
 const PR_LINKS_PATH = path.join(MINIONS_DIR, 'engine', 'pr-links.json');
-const LOG_PATH = path.join(__dirname, 'log.json');
+const LOG_PATH = path.join(MINIONS_DIR, 'engine', 'log.json');
 
 // ── Timestamps & Logging ────────────────────────────────────────────────────
 // Extracted from engine.js so engine/* modules can import directly without

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -2538,6 +2538,70 @@ async function testStateIntegrity() {
       'graceful shutdown should call shared.flushLogs() to drain buffered log entries');
   });
 
+  await test('Log buffer accumulates entries and flushLogs drains to disk', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const s = require('../engine/shared');
+      const testDir = process.env.MINIONS_TEST_DIR;
+      const logPath = path.join(testDir, 'engine', 'log.json');
+
+      // Buffer should start empty
+      s._logBuffer.length = 0;
+
+      // Push a few entries below threshold — they should stay in buffer
+      for (let i = 0; i < 5; i++) s.log('info', `test-entry-${i}`);
+      assert.strictEqual(s._logBuffer.length, 5,
+        'entries below threshold should accumulate in buffer');
+
+      // flushLogs should drain buffer to disk and clear timer
+      s.flushLogs();
+      assert.strictEqual(s._logBuffer.length, 0,
+        'flushLogs should drain the buffer completely');
+
+      // Verify entries were written to log.json
+      const logData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      assert.ok(logData.length >= 5,
+        'flushed entries should be written to log.json on disk');
+      assert.ok(logData.some(e => e.message === 'test-entry-0'),
+        'log.json should contain the buffered entries');
+    } finally {
+      restore();
+    }
+  });
+
+  await test('Log buffer auto-flushes at ENGINE_DEFAULTS.logBufferSize threshold', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const s = require('../engine/shared');
+      const bufSize = s.ENGINE_DEFAULTS.logBufferSize; // 50
+
+      // Clear any prior state
+      s._logBuffer.length = 0;
+
+      // Push exactly bufSize entries — the last push triggers auto-flush
+      for (let i = 0; i < bufSize; i++) s.log('info', `threshold-${i}`);
+      assert.strictEqual(s._logBuffer.length, 0,
+        'buffer should be empty after reaching logBufferSize threshold (auto-flushed)');
+
+      // Clean up the interval timer
+      s.flushLogs();
+    } finally {
+      restore();
+    }
+  });
+
+  await test('LOG_PATH respects MINIONS_TEST_DIR for test isolation', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const s = require('../engine/shared');
+      const testDir = process.env.MINIONS_TEST_DIR;
+      assert.strictEqual(s.LOG_PATH, path.join(testDir, 'engine', 'log.json'),
+        'LOG_PATH should use MINIONS_DIR (respects MINIONS_TEST_DIR) not __dirname');
+    } finally {
+      restore();
+    }
+  });
+
   await test('Dashboard uses lock-backed dispatch mutations for API writes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     assert.ok(src.includes('mutateJsonFileLocked'),


### PR DESCRIPTION
## Summary
- **Fix LOG_PATH test isolation**: Changed `LOG_PATH` in `engine/shared.js` from `path.join(__dirname, 'log.json')` to `path.join(MINIONS_DIR, 'engine', 'log.json')` so it respects `MINIONS_TEST_DIR` — consistent with `PR_LINKS_PATH` and `queries.js`'s own `LOG_PATH`.
- **Add behavioral tests**: 3 new tests that exercise actual log buffering behavior (buffer accumulation, threshold auto-flush at `logBufferSize`, and disk write verification via `flushLogs()`), replacing reliance on source-code string matching per team convention.
- **Audit result**: Existing implementation is solid — `ENGINE_DEFAULTS.logFlushInterval` (5s) and `logBufferSize` (50) are correctly used, `flushLogs()` is called in all 3 graceful shutdown paths in `cli.js`, log rotation (2500→2000) works correctly with batch writes, and `_logBuffer.splice(0)` is safe under Node.js single-threaded execution.

## Test plan
- [x] All 1241 existing tests pass (0 failures)
- [x] New test: `Log buffer accumulates entries and flushLogs drains to disk` — verifies entries stay in buffer below threshold, drain on `flushLogs()`, and appear in log.json on disk
- [x] New test: `Log buffer auto-flushes at ENGINE_DEFAULTS.logBufferSize threshold` — verifies buffer empties automatically when 50 entries reached
- [x] New test: `LOG_PATH respects MINIONS_TEST_DIR for test isolation` — verifies the `LOG_PATH` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)