### PR TITLE
feat(W-mnwnfciita7c): fix dep re-merge failure on retry with existing commits

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -524,7 +524,37 @@ async function spawnAgent(dispatchItem, config) {
           }
           // Merge successfully-fetched + recovered (local-only pushed) branches sequentially
           const fetched = fetchable.filter((_, i) => fetchResults[i].status === 'fulfilled' || recoveredBranches.has(fetchable[i].branch));
-          if (!depMergeFailed) {
+          // Skip dep re-merge if worktree HEAD already contains all dep commits (#973)
+          let skipDepMerge = false;
+          if (!depMergeFailed && fetched.length > 0) {
+            const ancestorChecks = await Promise.all(
+              fetched.map(async ({ branch: depBranch }) => {
+                try {
+                  await execAsync(`git merge-base --is-ancestor "origin/${depBranch}" HEAD`, { ..._gitOpts, cwd: worktreePath });
+                  return true;
+                } catch (_) { return false; }
+              })
+            );
+            if (ancestorChecks.every(Boolean)) {
+              log('info', `All ${fetched.length} dep branch(es) already merged into ${branchName} — skipping dep re-merge`);
+              skipDepMerge = true;
+            }
+          }
+          // Stash uncommitted changes before dep merge if worktree is dirty (#973)
+          let stashed = false;
+          if (!depMergeFailed && !skipDepMerge && fetched.length > 0) {
+            try {
+              const statusOut = (await execAsync('git status --porcelain', { ..._gitOpts, cwd: worktreePath })).stdout.toString().trim();
+              if (statusOut) {
+                await execAsync('git stash push --include-untracked -m "engine: stash before dep re-merge"', { ..._gitOpts, cwd: worktreePath });
+                stashed = true;
+                log('info', `Stashed uncommitted changes in ${branchName} before dep merge`);
+              }
+            } catch (stashErr) {
+              log('warn', `Failed to stash changes in ${branchName} before dep merge: ${stashErr.message}`);
+            }
+          }
+          if (!depMergeFailed && !skipDepMerge) {
             for (const { branch: depBranch, prId } of fetched) {
               try {
                 await execAsync(`git merge "origin/${depBranch}" --no-edit`, { ..._gitOpts, cwd: worktreePath });
@@ -571,6 +601,15 @@ async function spawnAgent(dispatchItem, config) {
                 }
                 break;
               }
+            }
+          }
+          // Restore stashed changes after dep merge (#973)
+          if (stashed) {
+            try {
+              await execAsync('git stash pop', { ..._gitOpts, cwd: worktreePath });
+              log('info', `Restored stashed changes in ${branchName} after dep merge`);
+            } catch (popErr) {
+              log('warn', `git stash pop failed in ${branchName}: ${popErr.message} — stash preserved for agent`);
             }
           }
           if (depMergeFailed) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6956,6 +6956,36 @@ async function testDispatchCycleIntegration() {
       'engine.js must compute merge-base for merge-tree');
   });
 
+  await test('Dep merge skips re-merge when all deps already ancestors of worktree HEAD (#973)', () => {
+    // Fix 1: Before the merge loop, check if all dep branches are already merged
+    assert.ok(engineSrc.includes('merge-base --is-ancestor'),
+      'engine.js must check if dep branches are already ancestors of HEAD');
+    assert.ok(engineSrc.includes('skipDepMerge'),
+      'engine.js must use skipDepMerge flag to skip redundant dep merges');
+    assert.ok(engineSrc.includes('skipping dep re-merge'),
+      'engine.js must log when skipping dep re-merge');
+    // The merge loop condition must respect skipDepMerge
+    assert.ok(engineSrc.includes('!skipDepMerge'),
+      'engine.js merge loop must check skipDepMerge flag');
+  });
+
+  await test('Dep merge stashes uncommitted changes before merge and restores after (#973)', () => {
+    // Fix 2: Stash dirty worktree state before dep merge, restore after
+    assert.ok(engineSrc.includes('git status --porcelain'),
+      'engine.js must check worktree dirty state before dep merge');
+    assert.ok(engineSrc.includes('git stash push --include-untracked'),
+      'engine.js must stash uncommitted changes including untracked files');
+    assert.ok(engineSrc.includes('stash before dep re-merge'),
+      'engine.js must label stash entry for traceability');
+    assert.ok(engineSrc.includes('git stash pop'),
+      'engine.js must restore stashed changes after dep merge');
+    assert.ok(engineSrc.includes('Restored stashed changes'),
+      'engine.js must log when restoring stashed changes');
+    // Stash pop failure should warn but not crash
+    assert.ok(engineSrc.includes('stash preserved for agent'),
+      'engine.js must gracefully handle stash pop failure');
+  });
+
   await test('parseConflictFiles parses CONFLICT lines from git merge output', () => {
     const { parseConflictFiles } = require(path.join(MINIONS_DIR, 'engine.js'));
     // Standard CONFLICT lines


### PR DESCRIPTION
## Summary

Closes #973.

- **Fix 1 (ancestor check):** Before the dep-merge loop in `spawnAgent()`, checks if all dependency branches are already ancestors of the worktree HEAD using `git merge-base --is-ancestor`. If all deps are already integrated (common on retry after `error_max_turns`), the merge loop is skipped entirely — preventing the "local changes would be overwritten by merge" error.
- **Fix 2 (stash/restore):** For cases where some deps still need merging but the worktree has uncommitted changes, stashes dirty state (`git stash push --include-untracked`) before the merge loop and pops after — both on success and failure paths.
- **Tests:** 2 new source-pattern tests verifying the ancestor check (`skipDepMerge` flag, `merge-base --is-ancestor`) and stash/restore logic (`git stash push --include-untracked`, `git stash pop`, graceful pop failure handling).

## Files changed

- `engine.js` — dep-merge block in `spawnAgent()` (~lines 527-614)
- `test/unit.test.js` — 2 new tests for #973 fixes

## Test plan

- [x] `npm test` passes (1240 pass, 0 fail)
- [ ] Manual: retry an agent into a worktree where all dep branches are already merged → verify "skipping dep re-merge" log and immediate agent spawn
- [ ] Manual: retry an agent into a dirty worktree with partial deps → verify stash/merge/restore cycle
- [ ] Verify `failReason: "Dependency merge failed"` no longer appears for worktrees with committed implementation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)