### PR TITLE
fix(W-mnwnfmsbov7a): plan completion incorrectly overrides awaiting-approval status

### DIFF
--- a/dashboard/js/render-plans.js
+++ b/dashboard/js/render-plans.js
@@ -81,14 +81,14 @@ function derivePlanStatus(prdFile, mdFile, prdJsonStatus, workItems) {
   if (prdJsonStatus === 'rejected') return 'rejected';
   if (prdJsonStatus === 'paused' && !allDone) return 'paused';
   if (prdJsonStatus === 'revision-requested') return 'revision-requested';
+  // PRD awaiting approval overrides WI-derived completion — new items may need materialization (#970)
+  if (prdJsonStatus === 'awaiting-approval') return 'awaiting-approval';
 
   // Derive from work item progress
   if (allDone && !hasActiveWork) return 'completed';
   if (hasActiveWork) return 'dispatched';
   if (hasPendingPrd) return 'converting';
   if (hasFailed && !hasActiveWork) return 'has-failures';
-
-  if (prdJsonStatus === 'awaiting-approval' && implementWi.length === 0) return 'awaiting-approval';
   if (prdJsonStatus === 'approved' && implementWi.length === 0) return 'approved';
 
   // plan-to-prd conversion done but no implement items and PRD is gone — truly completed

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6701,9 +6701,17 @@ async function testPlanPrdStateFlow() {
       'Should have derivePlanStatus function');
   });
 
-  await test('derivePlanStatus returns awaiting-approval when no work items', () => {
-    assert.ok(plansSrc.includes("prdJsonStatus === 'awaiting-approval' && implementWi.length === 0"),
-      'Should return awaiting-approval when PRD is awaiting and no items materialized');
+  await test('derivePlanStatus returns awaiting-approval regardless of WI state', () => {
+    assert.ok(plansSrc.includes("prdJsonStatus === 'awaiting-approval'") && plansSrc.includes("return 'awaiting-approval'"),
+      'Should return awaiting-approval when PRD is awaiting — overrides WI-derived completion (#970)');
+  });
+
+  await test('derivePlanStatus checks awaiting-approval BEFORE allDone (#970)', () => {
+    const awaitIdx = plansSrc.indexOf("prdJsonStatus === 'awaiting-approval'");
+    const allDoneIdx = plansSrc.indexOf('allDone && !hasActiveWork');
+    assert.ok(awaitIdx > 0 && allDoneIdx > 0, 'Both checks must exist');
+    assert.ok(awaitIdx < allDoneIdx,
+      'awaiting-approval check must come before allDone check — prevents completed override when PRD has un-materialized items');
   });
 
   await test('derivePlanStatus returns dispatched when active work exists', () => {


### PR DESCRIPTION
## Summary

- Fixes #970: After a diff-aware plan-to-prd regeneration adds new items (status `missing`) and sets the PRD to `awaiting-approval`, the dashboard incorrectly showed the plan as "completed" because `derivePlanStatus()` checked `allDone` before `prdJsonStatus === 'awaiting-approval'`
- Moves the `awaiting-approval` check before the `allDone` guard, grouping it with other user-intent overrides (rejected, paused, revision-requested)
- Adds regression test verifying the check ordering is preserved

## Test plan

- [x] `npm test` passes (1239 tests, 0 failures)
- [ ] Verify: create a plan with all WIs done, run diff-aware regen → plan should show "Awaiting Approval" with approve button visible
- [ ] Verify: normal completed plans (all items done, no missing PRD items) still show "Completed"
- [ ] Verify: approve button works correctly after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)