### PR TITLE
feat(W-mnws7c9hhkad): add /api/work-items/reopen endpoint and reopen-work-item CC action

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -642,6 +642,7 @@ async function executeCCActions(actions) {
               mutateJsonFileLocked(dispatchPath, dispatch => {
                 dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
                 dispatch.completed = dispatch.completed.filter(d => d.meta?.dispatchKey !== dispatchKey);
+                dispatch.completed = dispatch.completed.filter(d => !d.meta?.parentKey || d.meta.parentKey !== dispatchKey);
                 return dispatch;
               }, { defaultValue: { pending: [], active: [], completed: [] } });
             } catch { /* best effort */ }

--- a/dashboard.js
+++ b/dashboard.js
@@ -23,7 +23,7 @@ const queries = require('./engine/queries');
 const teams = require('./engine/teams');
 const os = require('os');
 
-const { safeRead, safeReadDir, safeWrite, safeJson, safeJsonObj, safeJsonArr, safeUnlink, mutateJsonFileLocked, mutateWorkItems, getProjects: _getProjects, DONE_STATUSES, WI_STATUS } = shared;
+const { safeRead, safeReadDir, safeWrite, safeJson, safeJsonObj, safeJsonArr, safeUnlink, mutateJsonFileLocked, mutateWorkItems, getProjects: _getProjects, DONE_STATUSES, WI_STATUS, reopenWorkItem } = shared;
 const { getAgents, getAgentDetail, getPrdInfo, getWorkItems, getDispatchQueue,
   getSkills, getInbox, getNotesWithMeta, getPullRequests,
   getEngineLog, getMetrics, getKnowledgeBaseEntries, timeSince,
@@ -614,6 +614,40 @@ async function executeCCActions(actions) {
           if (!fs.existsSync(kbDir)) fs.mkdirSync(kbDir, { recursive: true });
           shared.safeWrite(path.join(kbDir, slug + '.md'), `# ${action.title}\n\n${action.content || action.description || ''}`);
           results.push({ type: 'knowledge', ok: true });
+          break;
+        }
+        case 'reopen-work-item': {
+          const project = action.project || '';
+          const targetProject = project ? PROJECTS.find(p => p.name?.toLowerCase() === project.toLowerCase()) : PROJECTS[0];
+          const wiPath = targetProject ? shared.projectWorkItemsPath(targetProject) : path.join(MINIONS_DIR, 'work-items.json');
+          let reopenResult = null;
+          mutateJsonFileLocked(wiPath, items => {
+            if (!Array.isArray(items)) items = [];
+            const item = items.find(i => i.id === action.id);
+            if (!item) { reopenResult = { error: 'item not found' }; return items; }
+            if (item.status !== WI_STATUS.DONE && item.status !== WI_STATUS.FAILED && !DONE_STATUSES.has(item.status)) {
+              reopenResult = { error: 'can only reopen done or failed items' }; return items;
+            }
+            reopenWorkItem(item);
+            if (action.description) item.description = action.description;
+            reopenResult = { ok: true };
+            return items;
+          }, { defaultValue: [] });
+          if (reopenResult?.ok) {
+            // Clear dispatch history outside lock
+            const sourcePrefix = targetProject ? `work-${targetProject.name}-` : 'central-work-';
+            const dispatchKey = sourcePrefix + action.id;
+            try {
+              const dispatchPath = path.join(MINIONS_DIR, 'engine', 'dispatch.json');
+              mutateJsonFileLocked(dispatchPath, dispatch => {
+                dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
+                dispatch.completed = dispatch.completed.filter(d => d.meta?.dispatchKey !== dispatchKey);
+                return dispatch;
+              }, { defaultValue: { pending: [], active: [], completed: [] } });
+            } catch { /* best effort */ }
+            invalidateStatusCache();
+          }
+          results.push({ type: 'reopen-work-item', id: action.id, ...(reopenResult || { error: 'unexpected' }) });
           break;
         }
         default:
@@ -1342,6 +1376,66 @@ const server = http.createServer(async (req, res) => {
       }
       return jsonReply(res, 200, allArchived);
     } catch (e) { console.error('Archive fetch error:', e.message); return jsonReply(res, 500, { error: e.message }); }
+  }
+
+  async function handleWorkItemsReopen(req, res) {
+    try {
+      const body = await readBody(req);
+      const { id, description } = body;
+      const project = body.project || body.source;
+      if (!id) return jsonReply(res, 400, { error: 'id required' });
+
+      // Find the right work-items file
+      let wiPath;
+      if (!project || project === 'central') {
+        wiPath = path.join(MINIONS_DIR, 'work-items.json');
+      } else {
+        const proj = PROJECTS.find(p => p.name === project);
+        if (proj) wiPath = shared.projectWorkItemsPath(proj);
+      }
+      if (!wiPath) return jsonReply(res, 404, { error: 'project not found' });
+
+      let result = null;
+      mutateJsonFileLocked(wiPath, (items) => {
+        if (!Array.isArray(items)) items = [];
+        const item = items.find(i => i.id === id);
+        if (!item) { result = { code: 404, body: { error: 'item not found' } }; return items; }
+        if (item.status !== WI_STATUS.DONE && item.status !== WI_STATUS.FAILED && !DONE_STATUSES.has(item.status)) {
+          result = { code: 400, body: { error: 'can only reopen done or failed items (current: ' + item.status + ')' } };
+          return items;
+        }
+        reopenWorkItem(item);
+        if (description !== undefined) item.description = description;
+        result = { code: 200, body: { ok: true, item } };
+        return items;
+      });
+      if (!result) return jsonReply(res, 500, { error: 'unexpected state' });
+      if (result.code !== 200) return jsonReply(res, result.code, result.body);
+
+      // Clear dispatch history and cooldowns outside lock
+      const sourcePrefix = (!project || project === 'central') ? 'central-work-' : `work-${project}-`;
+      const dispatchKey = sourcePrefix + id;
+      try {
+        const dispatchPath = path.join(MINIONS_DIR, 'engine', 'dispatch.json');
+        mutateJsonFileLocked(dispatchPath, (dispatch) => {
+          dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
+          dispatch.completed = dispatch.completed.filter(d => d.meta?.dispatchKey !== dispatchKey);
+          dispatch.completed = dispatch.completed.filter(d => !d.meta?.parentKey || d.meta.parentKey !== dispatchKey);
+          return dispatch;
+        }, { defaultValue: { pending: [], active: [], completed: [] } });
+      } catch (e) { console.error('dispatch cleanup on reopen:', e.message); }
+      try {
+        const cooldownPath = path.join(MINIONS_DIR, 'engine', 'cooldowns.json');
+        const cooldowns = safeJsonObj(cooldownPath);
+        if (cooldowns[dispatchKey]) {
+          delete cooldowns[dispatchKey];
+          safeWrite(cooldownPath, cooldowns);
+        }
+      } catch (e) { console.error('cooldown cleanup on reopen:', e.message); }
+
+      invalidateStatusCache();
+      return jsonReply(res, result.code, result.body);
+    } catch (e) { return jsonReply(res, 400, { error: e.message }); }
   }
 
   async function handleWorkItemsCreate(req, res) {
@@ -3856,6 +3950,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     { method: 'POST', path: '/api/work-items/delete', desc: 'Remove a work item, kill agent, clear dispatch', params: 'id, source?', handler: handleWorkItemsDelete },
     { method: 'POST', path: '/api/work-items/archive', desc: 'Move a completed/failed work item to archive', params: 'id, source?', handler: handleWorkItemsArchive },
     { method: 'GET', path: '/api/work-items/archive', desc: 'List archived work items', handler: handleWorkItemsArchiveList },
+    { method: 'POST', path: '/api/work-items/reopen', desc: 'Reopen a done/failed work item back to pending', params: 'id, project?, description?', handler: handleWorkItemsReopen },
     { method: 'POST', path: '/api/work-items/feedback', desc: 'Add human feedback on completed work', params: 'id, rating, comment?', handler: async (req, res) => {
       const body = await readBody(req);
       const { id, source, rating, comment } = body;

--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -1114,6 +1114,13 @@ async function ccExecuteAction(action, targetTabId) {
         status.style.color = 'var(--green)';
         break;
       }
+      case 'reopen-work-item': {
+        await _ccFetch('/api/work-items/reopen', { id: action.id, project: action.project || action.source || '', description: action.description });
+        status.innerHTML = '&#10003; Work item reopened: <strong>' + escHtml(action.id) + '</strong>';
+        status.style.color = 'var(--green)';
+        wakeEngine();
+        break;
+      }
       case 'reopen-prd-item': {
         await _ccFetch('/api/prd-items/update', { source: action.file, itemId: action.id, status: 'updated' });
         status.innerHTML = '&#10003; PRD item reopened: <strong>' + escHtml(action.id) + '</strong>';

--- a/prompts/cc-system.md
+++ b/prompts/cc-system.md
@@ -76,7 +76,7 @@ Additional actions (all take `id` or `file` as primary key):
 - Schedules: schedule (id, title, cron, workType, project, agent, description, priority, enabled), delete-schedule (id)
 - Pipelines: create-pipeline (id, title, stages[], trigger, stopWhen, monitoredResources), edit-pipeline (id, title, stages, trigger), delete-pipeline (id), trigger-pipeline (id), abort-pipeline (id), retrigger-pipeline (id)
 - Meetings: add-meeting-note (id, note), advance-meeting (id), end-meeting (id), archive-meeting (id), unarchive-meeting (id), delete-meeting (id)
-- Work item ops: delete-work-item (id, source), archive-work-item (id), work-item-feedback (id, rating: up/down, comment)
+- Work item ops: delete-work-item (id, source), archive-work-item (id), work-item-feedback (id, rating: up/down, comment), reopen-work-item (id, project[, description] — reopen a done/failed item back to pending)
 - PRD ops: edit-prd-item, remove-prd-item, reopen-prd-item (id, file — re-dispatches on existing branch)
 - KB/Inbox: promote-to-kb (file, category), kb-sweep, toggle-kb-pin (key)
 - Plan lifecycle: revise-plan (file, feedback — dispatches agent to revise)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14431,6 +14431,79 @@ async function testPrReviewFixFlows() {
     assert.ok(!engineSrc.includes('Review PR ${pr.id}'), 'Should NOT have redundant "PR" before PR-xxx');
     assert.ok(!engineSrc.includes('Fix PR ${pr.id}'), 'Should NOT have redundant "PR" before PR-xxx');
   });
+
+  // ── /api/work-items/reopen endpoint ──
+
+  const dashSrcReopen = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  await test('POST /api/work-items/reopen route is registered', () => {
+    assert.ok(dashSrcReopen.includes("'/api/work-items/reopen'"),
+      'Should register /api/work-items/reopen route');
+  });
+
+  await test('handleWorkItemsReopen uses mutateJsonFileLocked for atomic writes', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('mutateJsonFileLocked'),
+      'Reopen handler must use mutateJsonFileLocked for atomic read-modify-write');
+  });
+
+  await test('handleWorkItemsReopen uses reopenWorkItem helper', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('reopenWorkItem(item)'),
+      'Reopen handler must use shared.reopenWorkItem helper');
+  });
+
+  await test('handleWorkItemsReopen rejects non-done/failed items', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('WI_STATUS.DONE') && fn.includes('WI_STATUS.FAILED'),
+      'Reopen handler must check for done/failed status before reopening');
+    assert.ok(fn.includes('can only reopen done or failed items'),
+      'Should return error message for non-done/failed items');
+  });
+
+  await test('handleWorkItemsReopen supports optional description override', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('description') && fn.includes('item.description'),
+      'Reopen handler must support optional description override');
+  });
+
+  await test('handleWorkItemsReopen returns 404 for unknown item', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('item not found') && fn.includes('404'),
+      'Should return 404 when item is not found');
+  });
+
+  await test('handleWorkItemsReopen clears dispatch history and cooldowns', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('dispatch.json') && fn.includes('cooldowns'),
+      'Reopen handler must clear dispatch history and cooldowns outside lock');
+  });
+
+  await test('handleWorkItemsReopen invalidates status cache', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function handleWorkItemsReopen'), dashSrcReopen.indexOf('async function handleWorkItemsCreate'));
+    assert.ok(fn.includes('invalidateStatusCache'),
+      'Reopen handler must invalidate status cache after mutation');
+  });
+
+  await test('reopen-work-item CC action in executeCCActions', () => {
+    const fn = dashSrcReopen.slice(dashSrcReopen.indexOf('async function executeCCActions'), dashSrcReopen.indexOf('// ── Shared LLM call core'));
+    assert.ok(fn.includes("case 'reopen-work-item'"),
+      'executeCCActions must handle reopen-work-item action type');
+    assert.ok(fn.includes('reopenWorkItem(item)'),
+      'CC action must use reopenWorkItem helper');
+  });
+
+  await test('reopen-work-item in CC system prompt', () => {
+    const ccPrompt = fs.readFileSync(path.join(MINIONS_DIR, 'prompts', 'cc-system.md'), 'utf8');
+    assert.ok(ccPrompt.includes('reopen-work-item'),
+      'CC system prompt must document reopen-work-item action');
+  });
+
+  await test('reopen-work-item client-side action handler', () => {
+    const ccJs = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'command-center.js'), 'utf8');
+    assert.ok(ccJs.includes("case 'reopen-work-item'") && ccJs.includes('/api/work-items/reopen'),
+      'Client-side command-center.js must handle reopen-work-item action');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds `POST /api/work-items/reopen` REST endpoint to reopen done/failed standalone work items back to pending status
- Adds `reopen-work-item` CC action (server-side in `executeCCActions` + client-side rendering in `command-center.js`)
- Documents the new action in the CC system prompt (`prompts/cc-system.md`)
- Reuses existing `shared.reopenWorkItem()` helper for mutation logic — no duplication
- Clears dispatch history and cooldowns on reopen so the engine re-dispatches immediately
- 11 new unit tests covering: route registration, atomic writes, helper usage, status validation, description override, 404 handling, cleanup, cache invalidation, CC action, system prompt, client-side handler

## Test plan
- [x] All 1505 unit tests pass (0 failures, 2 skipped)
- [ ] Manual test: reopen a done work item via API
- [ ] Manual test: reopen via CC "reopen-work-item" action
- [ ] Verify reopened item gets re-dispatched by engine on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)