### PR TITLE
fix(W-mnx9g9hjc1pi): add MAX_TURNS failure class and fix enum count test

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -627,6 +627,28 @@ async function spawnAgent(dispatchItem, config) {
 
   updateAgentStatus(id, AGENT_STATUS.READY, 'Worktree ready, preparing to spawn process');
 
+  // Inject dirty file list when worktree has uncommitted changes (e.g., max_turns retry)
+  // This signals to the respawned agent that prior work exists in the worktree (#960)
+  if (worktreePath && fs.existsSync(worktreePath)) {
+    try {
+      const dirtyResult = await execAsync('git status --porcelain', { ..._gitOpts, cwd: worktreePath, timeout: 10000 });
+      const dirtyOutput = (dirtyResult.stdout || '').trim();
+      if (dirtyOutput) {
+        const dirtyFiles = dirtyOutput.split('\n').map(l => l.trim()).filter(Boolean);
+        const dirtySection = [
+          '\n## Uncommitted Work in Worktree\n',
+          'The worktree has uncommitted changes from a previous agent run. Review these files and continue from where the previous agent left off.\n',
+          '```',
+          ...dirtyFiles,
+          '```\n',
+        ].join('\n');
+        // Append dirty file list to the already-written prompt file
+        try { fs.appendFileSync(promptPath, dirtySection); } catch (e) { log('warn', `dirty files inject: ${e.message}`); }
+        log('info', `Injected ${dirtyFiles.length} dirty files into prompt for ${id}`);
+      }
+    } catch (e) { log('warn', `git status --porcelain for dirty files: ${e.message}`); }
+  }
+
   // Safety check: warn if a write-capable task is running in the main repo without a worktree
   if (cwd === rootDir && ['implement', 'implement:large', 'fix', 'test', 'verify', 'plan-to-prd'].includes(type)) {
     log('warn', `Agent ${agentId} running ${type} task in main repo (no worktree) for ${id} — changes may land on master directly`);

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1893,8 +1893,14 @@ function classifyFailure(code, stdout = '', stderr = '') {
     return FAILURE_CLASS.MERGE_CONFLICT;
   }
 
-  // Context window / max turns exhausted
-  if (/context window|max.*turns.*reached|error_max_turns|terminal_reason.*max_turns|token limit|conversation.*too long|context.*length.*exceeded/i.test(combined)) {
+  // Max turns exhausted (error_max_turns) — work in progress, retryable
+  // Must be checked BEFORE OUT_OF_CONTEXT to avoid misclassification as non-retryable
+  if (/error_max_turns|"subtype"\s*:\s*"error_max_turns"|terminal_reason.*max_turns|max.*turns.*reached/i.test(combined)) {
+    return FAILURE_CLASS.MAX_TURNS;
+  }
+
+  // Context window exhausted (token limit, context length — NOT max turns)
+  if (/context window|token limit|conversation.*too long|context.*length.*exceeded/i.test(combined)) {
     return FAILURE_CLASS.OUT_OF_CONTEXT;
   }
 

--- a/engine/recovery.js
+++ b/engine/recovery.js
@@ -64,6 +64,12 @@ const RECOVERY_RECIPES = new Map([
     freshSession: false,
     description: 'Network/API error — retry with exponential backoff',
   }],
+  [FAILURE_CLASS.MAX_TURNS, {
+    maxAttempts: 3,
+    escalation: ESCALATION_POLICY.RETRY_SAME,
+    freshSession: false,
+    description: 'Max turns reached — work in progress, retry same agent to continue',
+  }],
   [FAILURE_CLASS.OUT_OF_CONTEXT, {
     maxAttempts: 1,
     escalation: ESCALATION_POLICY.HUMAN_REVIEW,

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -672,12 +672,13 @@ const FAILURE_CLASS = {
   EMPTY_OUTPUT: 'empty-output',           // Agent produced no meaningful output
   SPAWN_ERROR: 'spawn-error',             // Process failed to start or crashed immediately
   NETWORK_ERROR: 'network-error',         // API rate limit, DNS, connectivity
-  OUT_OF_CONTEXT: 'out-of-context',       // Context window exhausted, max turns reached
+  OUT_OF_CONTEXT: 'out-of-context',       // Context window exhausted (token limit, context length)
+  MAX_TURNS: 'max-turns',                 // Claude CLI error_max_turns — work in progress, retryable
   UNKNOWN: 'unknown',                     // Unclassified failure
 };
 const ESCALATION_POLICY = {
   NO_RETRY: 'no-retry',         // CONFIG_ERROR, PERMISSION_BLOCKED — never retry
-  RETRY_SAME: 'retry-same',     // MERGE_CONFLICT, BUILD_FAILURE — retry same agent
+  RETRY_SAME: 'retry-same',     // MERGE_CONFLICT, BUILD_FAILURE, MAX_TURNS — retry same agent
   RETRY_FRESH: 'retry-fresh',   // TIMEOUT, SPAWN_ERROR — retry with fresh session
   HUMAN_REVIEW: 'human-review', // EMPTY_OUTPUT, OUT_OF_CONTEXT — flag for human
   AUTO: 'auto',                 // UNKNOWN, NETWORK_ERROR — use default retry logic

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -13306,7 +13306,7 @@ async function testFailureClassEnum() {
   console.log('\n── FAILURE_CLASS enum and classifyFailure() ──');
   const lifecycle = require('../engine/lifecycle');
 
-  await test('FAILURE_CLASS enum has all 10 required values', () => {
+  await test('FAILURE_CLASS enum has all 11 required values', () => {
     const { FAILURE_CLASS } = shared;
     assert.ok(FAILURE_CLASS, 'FAILURE_CLASS should be exported from shared.js');
     assert.strictEqual(FAILURE_CLASS.CONFIG_ERROR, 'config-error');
@@ -13318,8 +13318,9 @@ async function testFailureClassEnum() {
     assert.strictEqual(FAILURE_CLASS.SPAWN_ERROR, 'spawn-error');
     assert.strictEqual(FAILURE_CLASS.NETWORK_ERROR, 'network-error');
     assert.strictEqual(FAILURE_CLASS.OUT_OF_CONTEXT, 'out-of-context');
+    assert.strictEqual(FAILURE_CLASS.MAX_TURNS, 'max-turns');
     assert.strictEqual(FAILURE_CLASS.UNKNOWN, 'unknown');
-    assert.strictEqual(Object.keys(FAILURE_CLASS).length, 10, 'FAILURE_CLASS should have exactly 10 values');
+    assert.strictEqual(Object.keys(FAILURE_CLASS).length, 11, 'FAILURE_CLASS should have exactly 11 values');
   });
 
   await test('ESCALATION_POLICY enum has all 5 values', () => {
@@ -13371,9 +13372,12 @@ async function testFailureClassEnum() {
       shared.FAILURE_CLASS.NETWORK_ERROR);
   });
 
-  await test('classifyFailure: context exhausted → OUT_OF_CONTEXT', () => {
+  await test('classifyFailure: max turns reached → MAX_TURNS', () => {
     assert.strictEqual(lifecycle.classifyFailure(1, 'Error: max turns reached', ''),
-      shared.FAILURE_CLASS.OUT_OF_CONTEXT);
+      shared.FAILURE_CLASS.MAX_TURNS);
+  });
+
+  await test('classifyFailure: context exhausted → OUT_OF_CONTEXT', () => {
     assert.strictEqual(lifecycle.classifyFailure(1, 'context window exceeded', ''),
       shared.FAILURE_CLASS.OUT_OF_CONTEXT);
   });
@@ -14338,18 +14342,18 @@ async function testIssue716HeartbeatFeedbackLoop() {
   console.log('\n── #716: Heartbeat feedback loop + max_turns lifecycle cleanup ──');
   const lifecycle = require('../engine/lifecycle');
 
-  // 1. classifyFailure with exact Claude CLI error_max_turns output
-  await test('classifyFailure: exact error_max_turns JSON → OUT_OF_CONTEXT', () => {
+  // 1. classifyFailure with exact Claude CLI error_max_turns output → MAX_TURNS (retryable)
+  await test('classifyFailure: exact error_max_turns JSON → MAX_TURNS', () => {
     // Exact format from Claude CLI when agent exhausts turn limit
     const exactOutput = '{"type":"result","subtype":"error_max_turns","is_error":true,"terminal_reason":"max_turns"}';
     assert.strictEqual(lifecycle.classifyFailure(1, exactOutput, ''),
-      shared.FAILURE_CLASS.OUT_OF_CONTEXT,
-      'Exact error_max_turns JSON from Claude CLI should classify as OUT_OF_CONTEXT');
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'Exact error_max_turns JSON from Claude CLI should classify as MAX_TURNS');
   });
 
-  await test('classifyFailure: terminal_reason max_turns in stderr → OUT_OF_CONTEXT', () => {
+  await test('classifyFailure: terminal_reason max_turns in stderr → MAX_TURNS', () => {
     assert.strictEqual(lifecycle.classifyFailure(1, '', 'terminal_reason: max_turns'),
-      shared.FAILURE_CLASS.OUT_OF_CONTEXT);
+      shared.FAILURE_CLASS.MAX_TURNS);
   });
 
   // 2. realActivityMap tracked in engine.js (prevents heartbeat feedback loop)


### PR DESCRIPTION
## Summary

- **Splits `MAX_TURNS` out of `OUT_OF_CONTEXT`** as a separate retryable failure class. `error_max_turns` from Claude CLI means the agent ran out of turns but may have made progress — retrying the same agent continues the work in the existing worktree with dirty files.
- **Adds recovery recipe** for `MAX_TURNS`: retry same agent up to 3 times (not fresh session), so the agent can pick up where it left off.
- **Injects dirty file list** into the prompt when a worktree has uncommitted changes from a prior run, so the retried agent knows what work already exists.
- **Fixes failing test** `FAILURE_CLASS enum has all 10 required values` — updated enum count assertion from 10 to 11 and added `MAX_TURNS` value assertion.

## Files changed
- `engine/shared.js` — Added `FAILURE_CLASS.MAX_TURNS`, updated comment on `RETRY_SAME`
- `engine/lifecycle.js` — Split `classifyFailure` regex: `MAX_TURNS` checked before `OUT_OF_CONTEXT`
- `engine/recovery.js` — Added `RECOVERY_RECIPES` entry for `MAX_TURNS`
- `engine.js` — Dirty file injection into prompt for worktree retries
- `test/unit.test.js` — Updated enum count, `MAX_TURNS` assertions, reclassified `error_max_turns` tests

## Test plan
- [x] `npm test` — 1520 passed, 0 failed, 2 skipped
- [x] Verified `FAILURE_CLASS` now has 11 values
- [x] Verified `classifyFailure` routes `error_max_turns` → `MAX_TURNS` (not `OUT_OF_CONTEXT`)
- [x] Verified `context window` still routes to `OUT_OF_CONTEXT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)