### PR TITLE
fix(W-mnxomrllro4i): error_max_turns misclassified as permission-blocked

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1883,6 +1883,15 @@ function classifyFailure(code, stdout = '', stderr = '') {
   // Exit code 78 — configuration error (Claude CLI not found, bad setup)
   if (code === 78) return FAILURE_CLASS.CONFIG_ERROR;
 
+  // Max turns exhausted (error_max_turns) — work in progress, retryable
+  // MUST be checked FIRST (before permission-blocked, out-of-context, etc.)
+  // because hook failures (e.g. SessionStart curl timeout exit code 28) can inject
+  // permission/auth patterns into stderr even when the agent ran to turn exhaustion.
+  // The error_max_turns result subtype is the definitive stop reason from Claude CLI.
+  if (/error_max_turns|"subtype"\s*:\s*"error_max_turns"|terminal_reason.*max_turns|max.*turns.*reached/i.test(combined)) {
+    return FAILURE_CLASS.MAX_TURNS;
+  }
+
   // Permission / trust / auth failures
   if (/permission denied|access denied|unauthorized|403 forbidden|trust.*blocked|auth.*fail/i.test(combined)) {
     return FAILURE_CLASS.PERMISSION_BLOCKED;
@@ -1891,12 +1900,6 @@ function classifyFailure(code, stdout = '', stderr = '') {
   // Merge conflicts
   if (/merge conflict|conflict.*merge|automatic merge failed|fix conflicts/i.test(combined)) {
     return FAILURE_CLASS.MERGE_CONFLICT;
-  }
-
-  // Max turns exhausted (error_max_turns) — work in progress, retryable
-  // Must be checked BEFORE OUT_OF_CONTEXT to avoid misclassification as non-retryable
-  if (/error_max_turns|"subtype"\s*:\s*"error_max_turns"|terminal_reason.*max_turns|max.*turns.*reached/i.test(combined)) {
-    return FAILURE_CLASS.MAX_TURNS;
   }
 
   // Context window exhausted (token limit, context length — NOT max turns)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14484,6 +14484,29 @@ async function testIssue716HeartbeatFeedbackLoop() {
       shared.FAILURE_CLASS.MAX_TURNS);
   });
 
+  // #995: error_max_turns takes priority over permission-blocked when both patterns present
+  await test('classifyFailure: error_max_turns wins over permission-blocked hook noise (#995)', () => {
+    // Simulates: agent ran 51 turns to error_max_turns, but SessionStart hook failed with
+    // curl timeout exit code 28, injecting "access denied" / "permission denied" into stderr
+    const stdout = '{"type":"result","subtype":"error_max_turns","is_error":true,"terminal_reason":"max_turns"}';
+    const stderr = 'hook SessionStart failed: exit code 28\ncurl: (28) Connection timed out\npermission denied accessing resource';
+    assert.strictEqual(lifecycle.classifyFailure(1, stdout, stderr),
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'error_max_turns must take priority over permission-blocked patterns from hook failures');
+
+    // Also test with "access denied" variant
+    const stderr2 = 'access denied for endpoint\n' + stdout;
+    assert.strictEqual(lifecycle.classifyFailure(1, stderr2, ''),
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'error_max_turns in combined output must win even when access denied is also present');
+
+    // And with "unauthorized" variant
+    const combined = 'unauthorized request to api\n' + '{"type":"result","subtype":"error_max_turns","is_error":true}';
+    assert.strictEqual(lifecycle.classifyFailure(1, combined, ''),
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'error_max_turns must win over unauthorized pattern');
+  });
+
   // 2. realActivityMap tracked in engine.js (prevents heartbeat feedback loop)
   await test('engine.js tracks realActivityMap on stdout/stderr data', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');


### PR DESCRIPTION
## Summary

- **Reorders `classifyFailure()`** so `error_max_turns` is checked immediately after `CONFIG_ERROR` (exit code 78), before `permission-blocked` and all other pattern matches
- Fixes misclassification where hook failures (SessionStart curl timeout exit code 28) injected permission/auth patterns into stderr, causing `classifyFailure()` to return `PERMISSION_BLOCKED` instead of `MAX_TURNS` — even when the agent ran all 51 turns
- This prevented retries (`PERMISSION_BLOCKED` has `NO_RETRY` policy, while `MAX_TURNS` has `RETRY_SAME`)

## Root Cause

In `classifyFailure()` (lifecycle.js ~line 1886), the permission-blocked regex (`/permission denied|access denied|unauthorized|.../`) fired before the `error_max_turns` check. Hook startup failures write auth-related error text to stderr, but the agent subsequently ran to turn exhaustion — `error_max_turns` is the definitive stop reason from Claude CLI.

Affected runs: ralph-fix-mnxk06xq748m (51 turns), ralph-fix-mnxle13pln6b (51 turns), rebecca-fix-mnxle14gnp9s (51 turns).

## Test plan

- [x] Added regression test: `error_max_turns` wins over `permission-blocked` when both patterns present in combined output
- [x] Tests 3 variants: `permission denied`, `access denied`, `unauthorized` — all correctly yield `MAX_TURNS`
- [x] All 1536 unit tests pass, 0 failures

Fixes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)