### PR TITLE
fix(W-mnxomnjxewdx): prioritize error_max_turns over permission-blocked in classifyFailure

### DIFF
--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1883,6 +1883,14 @@ function classifyFailure(code, stdout = '', stderr = '') {
   // Exit code 78 — configuration error (Claude CLI not found, bad setup)
   if (code === 78) return FAILURE_CLASS.CONFIG_ERROR;
 
+  // Max turns exhausted (error_max_turns) — definitive stop reason, retryable
+  // Must be checked FIRST — hook startup failures (e.g. curl exit code 28) can inject
+  // permission/auth text into stderr, but if the agent ran to turn exhaustion that's the
+  // real cause. Checked before PERMISSION_BLOCKED and OUT_OF_CONTEXT.
+  if (/error_max_turns|"subtype"\s*:\s*"error_max_turns"|terminal_reason.*max_turns|max.*turns.*reached/i.test(combined)) {
+    return FAILURE_CLASS.MAX_TURNS;
+  }
+
   // Permission / trust / auth failures
   if (/permission denied|access denied|unauthorized|403 forbidden|trust.*blocked|auth.*fail/i.test(combined)) {
     return FAILURE_CLASS.PERMISSION_BLOCKED;
@@ -1891,12 +1899,6 @@ function classifyFailure(code, stdout = '', stderr = '') {
   // Merge conflicts
   if (/merge conflict|conflict.*merge|automatic merge failed|fix conflicts/i.test(combined)) {
     return FAILURE_CLASS.MERGE_CONFLICT;
-  }
-
-  // Max turns exhausted (error_max_turns) — work in progress, retryable
-  // Must be checked BEFORE OUT_OF_CONTEXT to avoid misclassification as non-retryable
-  if (/error_max_turns|"subtype"\s*:\s*"error_max_turns"|terminal_reason.*max_turns|max.*turns.*reached/i.test(combined)) {
-    return FAILURE_CLASS.MAX_TURNS;
   }
 
   // Context window exhausted (token limit, context length — NOT max turns)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14484,6 +14484,25 @@ async function testIssue716HeartbeatFeedbackLoop() {
       shared.FAILURE_CLASS.MAX_TURNS);
   });
 
+  // #995: error_max_turns must take priority over permission-blocked when hook failure text is also present
+  await test('classifyFailure: error_max_turns wins over hook auth failure text (#995)', () => {
+    // Simulates: SessionStart hook failed with curl exit code 28 (timeout to auth endpoint)
+    // but agent ran all 51 turns to exhaustion — error_max_turns is the real cause
+    const stdout = '{"type":"result","subtype":"error_max_turns","is_error":true,"terminal_reason":"max_turns"}';
+    const stderr = 'Error: SessionStart hook failed with exit code 28\ncurl: (28) Connection timed out\nFailed to reach https://auth.example.com/session — unauthorized';
+    assert.strictEqual(lifecycle.classifyFailure(1, stdout, stderr),
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'error_max_turns should win over permission-blocked when both patterns present');
+  });
+
+  await test('classifyFailure: error_max_turns wins over access denied text (#995)', () => {
+    // Agent output contains both "access denied" (from hook) and max_turns (from agent result)
+    const stdout = 'Hook stderr: access denied for resource\n... 51 turns of agent work ...\n{"type":"result","subtype":"error_max_turns","is_error":true}';
+    assert.strictEqual(lifecycle.classifyFailure(1, stdout, ''),
+      shared.FAILURE_CLASS.MAX_TURNS,
+      'error_max_turns should take priority even when access denied text is also present');
+  });
+
   // 2. realActivityMap tracked in engine.js (prevents heartbeat feedback loop)
   await test('engine.js tracks realActivityMap on stdout/stderr data', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');


### PR DESCRIPTION
## Summary

- Reorder `classifyFailure()` in `lifecycle.js` so `error_max_turns` is checked **before** `permission-blocked`
- When a SessionStart hook fails (e.g. curl exit code 28 timeout to auth endpoint), its stderr text can match the `permission-blocked` regex — but if the agent actually ran to turn exhaustion (51 turns), `error_max_turns` is the definitive stop reason
- Affected runs: `ralph-fix-mnxk06xq748m`, `ralph-fix-mnxle13pln6b`, `rebecca-fix-mnxle14gnp9s` — all 51-turn agents misclassified as `permission-blocked`, breaking retry/recovery logic

## Changes

- `engine/lifecycle.js`: Move `MAX_TURNS` check to right after `CONFIG_ERROR` (exit code 78), before `PERMISSION_BLOCKED`
- `test/unit.test.js`: Add 2 regression tests for combined output containing both auth failure text and `error_max_turns`

## Test plan

- [x] Existing `classifyFailure` tests still pass (1537 passed, 0 failed)
- [x] New test: `error_max_turns` wins over hook auth failure text (#995)
- [x] New test: `error_max_turns` wins over access denied text (#995)
- [x] Pure permission-blocked cases (no `error_max_turns`) still classify correctly (existing test at line 13477)

Fixes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)