### PR TITLE
fix(W-mnxon8y3cec7): show actionable failure context instead of Unknown error

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1141,7 +1141,12 @@ async function spawnAgent(dispatchItem, config) {
     // autoRecovered: agent failed (e.g. heartbeat timeout) but created PRs — treat as success
     const effectiveResult = (code === 0 || autoRecovered) ? DISPATCH_RESULT.SUCCESS : DISPATCH_RESULT.ERROR;
     const completeOpts = effectiveResult === DISPATCH_RESULT.ERROR && failureClass ? { failureClass } : {};
-    completeDispatch(id, effectiveResult, '', resultSummary, completeOpts);
+    // Extract last 5 non-empty stderr lines as error context when exit code is non-zero
+    let errorReason = '';
+    if (effectiveResult === DISPATCH_RESULT.ERROR) {
+      errorReason = stderr.split('\n').filter(l => l.trim()).slice(-5).join(' | ').trim().slice(0, 300);
+    }
+    completeDispatch(id, effectiveResult, errorReason, resultSummary, completeOpts);
 
     // Cleanup temp files (including PID file now that dispatch is complete)
     try { fs.unlinkSync(sysPromptPath); } catch { /* cleanup */ }

--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -172,9 +172,26 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
           }
         } catch (e) { log('warn', 'increment retry counter: ' + e.message); }
       } else {
+        // Human-readable labels for each failure class — used as fallback when reason is empty
+        const CLASS_LABELS = {
+          [FAILURE_CLASS.EMPTY_OUTPUT]: 'agent produced no output \u2014 likely crashed on startup',
+          [FAILURE_CLASS.BUILD_FAILURE]: 'build/test/lint failure in output',
+          [FAILURE_CLASS.MERGE_CONFLICT]: 'merge conflict',
+          [FAILURE_CLASS.MAX_TURNS]: 'reached max turn limit',
+          [FAILURE_CLASS.TIMEOUT]: 'timed out waiting for agent',
+          [FAILURE_CLASS.SPAWN_ERROR]: 'agent process failed to start',
+          [FAILURE_CLASS.NETWORK_ERROR]: 'network or API error',
+          [FAILURE_CLASS.OUT_OF_CONTEXT]: 'context window exhausted',
+          [FAILURE_CLASS.CONFIG_ERROR]: 'configuration error',
+          [FAILURE_CLASS.PERMISSION_BLOCKED]: 'permission or auth failure',
+          [FAILURE_CLASS.UNKNOWN]: 'unknown error',
+        };
+        const classLabel = failureClass ? (CLASS_LABELS[failureClass] || failureClass) : '';
+        const effectiveReason = reason || classLabel || 'Unknown error';
+        const classSuffix = failureClass ? ` [${failureClass.toUpperCase().replace(/-/g, '_')}]` : '';
         const finalReason = !retryableFailure
-          ? `Non-retryable failure: ${reason || 'Unknown error'}`
-          : (reason || `Failed after ${maxRetries} retries`);
+          ? `Non-retryable failure: ${effectiveReason}${classSuffix}`
+          : (reason || `Failed after ${maxRetries} retries${classSuffix}`);
         lifecycle().updateWorkItemStatus(item.meta, WI_STATUS.FAILED, finalReason);
         // Alert: find items blocked by this failure and write inbox note
         try {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -13672,6 +13672,38 @@ async function testRecoveryRecipes() {
       'completeDispatch should call shouldRetry from recovery module');
   });
 
+  await test('completeDispatch uses CLASS_LABELS map for human-readable failure reasons', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');
+    assert.ok(src.includes('CLASS_LABELS'),
+      'completeDispatch should define CLASS_LABELS map');
+    assert.ok(src.includes('FAILURE_CLASS.EMPTY_OUTPUT') && src.includes('agent produced no output'),
+      'CLASS_LABELS should map EMPTY_OUTPUT to descriptive label');
+    assert.ok(src.includes('FAILURE_CLASS.BUILD_FAILURE') && src.includes('build/test/lint failure'),
+      'CLASS_LABELS should map BUILD_FAILURE to descriptive label');
+    assert.ok(src.includes('FAILURE_CLASS.MERGE_CONFLICT') && src.includes('merge conflict'),
+      'CLASS_LABELS should map MERGE_CONFLICT to descriptive label');
+    assert.ok(src.includes('FAILURE_CLASS.MAX_TURNS') && src.includes('max turn limit'),
+      'CLASS_LABELS should map MAX_TURNS to descriptive label');
+  });
+
+  await test('completeDispatch appends [FAILURE_CLASS] suffix to failure reason', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'dispatch.js'), 'utf8');
+    assert.ok(src.includes("classSuffix") && src.includes("toUpperCase()") && src.includes("replace(/-/g, '_')"),
+      'Should format failureClass as uppercase with underscores for [SUFFIX]');
+    assert.ok(src.includes('effectiveReason') && src.includes('classLabel'),
+      'Should use classLabel as fallback when reason is empty');
+  });
+
+  await test('engine.js extracts stderr lines as errorReason on failure', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    assert.ok(src.includes("stderr.split('\\n').filter(l => l.trim()).slice(-5)"),
+      'Should extract last 5 non-empty stderr lines on failure');
+    assert.ok(src.includes('errorReason') && src.includes('completeDispatch(id, effectiveResult, errorReason'),
+      'Should pass errorReason to completeDispatch instead of empty string');
+    assert.ok(src.includes('effectiveResult === DISPATCH_RESULT.ERROR') && src.includes('.slice(0, 300)'),
+      'Should only extract stderr on error and trim to 300 chars');
+  });
+
   await test('recovery.js has zero external dependencies', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'recovery.js'), 'utf8');
     const requires = src.match(/require\(['"](.*?)['"]\)/g) || [];


### PR DESCRIPTION
## Summary

- **engine.js**: Extract last 5 non-empty stderr lines as `errorReason` before calling `completeDispatch()` (trimmed to 300 chars). Previously passed empty string, losing all stderr context.
- **dispatch.js**: Add `CLASS_LABELS` map that maps each `FAILURE_CLASS` to a human-readable description (e.g. `EMPTY_OUTPUT` → "agent produced no output — likely crashed on startup"). Used as fallback when `reason` is empty. Append `[FAILURE_CLASS]` suffix so the class is visible in the UI.
- **Closes #999**

### Before
```
Non-retryable failure: Unknown error
```

### After
```
Non-retryable failure: agent produced no output — likely crashed on startup [EMPTY_OUTPUT]
Non-retryable failure: build/test/lint failure in output [BUILD_FAILURE]
Non-retryable failure: <last stderr lines> [UNKNOWN]
```

## Test plan
- [x] All 1538 unit tests pass, 0 failures
- [x] 3 new tests verify CLASS_LABELS map, failure class suffix formatting, and stderr extraction
- [ ] Manual: trigger a non-retryable failure and verify the failure reason in the dashboard shows actionable context instead of "Unknown error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)