### PR TITLE
fix(W-mnxu9t8uascs): steering no-session kill re-queues dispatch

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1098,6 +1098,34 @@ async function spawnAgent(dispatchItem, config) {
       return;
     }
 
+    // Check if this was a no-session steering kill (#1014) — re-queue for retry instead of erroring.
+    // timeout.js sets _steeringNoSession when it kills an agent that hasn't established a sessionId.
+    // The steering message is already saved to inbox, so re-queuing lets the engine retry and the
+    // agent picks up the message on the next dispatch.
+    if (procInfo?._steeringNoSession) {
+      log('info', `Steering no-session: re-queue ${agentId} (${id}) — dispatch moved back to pending`);
+      activeProcesses.delete(id);
+      realActivityMap.delete(id);
+      // Move dispatch item from active back to pending so engine retries
+      mutateDispatch((dp) => {
+        const idx = dp.active.findIndex(d => d.id === id);
+        if (idx >= 0) {
+          const item = dp.active.splice(idx, 1)[0];
+          delete item.started_at;
+          delete item.workerState;
+          delete item.workerStateAt;
+          delete item.workerStateDetail;
+          dp.pending.push(item);
+        }
+        return dp;
+      });
+      // Cleanup temp files
+      try { fs.unlinkSync(sysPromptPath); } catch { /* cleanup */ }
+      try { fs.unlinkSync(promptPath); } catch { /* cleanup */ }
+      try { fs.unlinkSync(promptPath.replace(/prompt-/, 'pid-').replace(/\.md$/, '.pid')); } catch { /* cleanup */ }
+      return;
+    }
+
     activeProcesses.delete(id);
     realActivityMap.delete(id); // Clean up real activity tracking
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -6955,6 +6955,43 @@ async function testAgentSteering() {
       'Should write confirmation to live-output.log so user sees it in dashboard');
   });
 
+  // ── Steering no-session re-queue (#1014) ─────────────────────────────────────
+
+  await test('close handler detects _steeringNoSession and re-queues dispatch instead of erroring', () => {
+    // When steering kills an agent with no session, the close handler should
+    // move the dispatch item back to pending instead of completing as error.
+    // This ensures the engine retries and the agent picks up the inbox message.
+    assert.ok(engineSrc.includes('_steeringNoSession'),
+      'Close handler should check _steeringNoSession flag from timeout.js');
+    // Should re-queue (move to pending), not complete as error
+    const noSessionBlock = engineSrc.slice(
+      engineSrc.indexOf('_steeringNoSession'),
+      engineSrc.indexOf('_steeringNoSession') + 600
+    );
+    assert.ok(noSessionBlock.includes('pending'),
+      'Should move dispatch item back to pending queue');
+    assert.ok(!noSessionBlock.includes('DISPATCH_RESULT.ERROR'),
+      'Should NOT complete as error — re-queue instead');
+  });
+
+  await test('steering no-session re-queue cleans up activeProcesses and realActivityMap', () => {
+    const noSessionIdx = engineSrc.indexOf('_steeringNoSession');
+    const noSessionBlock = engineSrc.slice(noSessionIdx, noSessionIdx + 600);
+    assert.ok(noSessionBlock.includes('activeProcesses.delete'),
+      'Should remove from activeProcesses on re-queue');
+    assert.ok(noSessionBlock.includes('realActivityMap.delete'),
+      'Should clean up realActivityMap on re-queue');
+  });
+
+  await test('steering no-session re-queue logs the re-queue action', () => {
+    const noSessionIdx = engineSrc.indexOf('_steeringNoSession');
+    const noSessionBlock = engineSrc.slice(noSessionIdx, noSessionIdx + 600);
+    assert.ok(noSessionBlock.includes('log(') || noSessionBlock.includes("log('"),
+      'Should log the re-queue action for observability');
+    assert.ok(noSessionBlock.includes('re-queue'),
+      'Log message should mention re-queuing');
+  });
+
   // ── Steering resume failure handling ─────────────────────────────────────────
 
   await test('steering resume non-zero exit calls onAgentClose (not SUCCESS)', () => {


### PR DESCRIPTION
## Summary

- When a steer message arrives before an agent has established a sessionId, `timeout.js` kills the agent and saves the message to inbox — but previously the close handler treated this as a normal error, consuming a retry count and eventually marking the work item as failed
- The close handler in `engine.js` now detects the `_steeringNoSession` flag and moves the dispatch item back to pending instead of completing it as error, so the engine retries and the agent picks up the inbox message on the next dispatch

Closes #1014

## Test plan

- [x] 3 new unit tests verify the close handler detects `_steeringNoSession`, re-queues to pending (not error), cleans up process maps, and logs the action
- [x] All 1670 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)