### PR TITLE
fix(W-mnxu9bvzkc5p): show doc-chat badges on Notes and KB items

### DIFF
--- a/dashboard/js/render-inbox.js
+++ b/dashboard/js/render-inbox.js
@@ -86,8 +86,9 @@ function renderNotes(notes) {
   }
 
   if (!content || !content.trim()) { el.innerHTML = '<p class="empty">No team notes yet.</p>'; return; }
-  el.innerHTML = '<div class="notes-preview" onclick="openNotesModal()" title="Click to expand">' + renderMd(content) + '</div>';
+  el.innerHTML = '<div class="notes-preview" data-file="notes.md" onclick="openNotesModal()" title="Click to expand">' + renderMd(content) + '</div>';
   el.querySelector('.notes-preview')._rawContent = content;
+  restoreNotifBadges();
 }
 
 function openNotesModal() {

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -150,7 +150,7 @@
   .kb-tab:hover { color: var(--text); border-color: var(--text); }
   .kb-tab.active { color: var(--blue); border-color: var(--blue); background: rgba(88,166,255,0.08); }
   .kb-tab .badge { background: var(--border); color: var(--text); font-size: var(--text-xs); padding: 0 5px; border-radius: var(--radius-lg); margin-left: var(--space-2); }
-  .kb-list { max-height: 400px; overflow-y: auto; }
+  .kb-list { max-height: 400px; overflow-y: auto; padding: var(--space-3) var(--space-4) 0 0; }
   .kb-item { display: flex; align-items: flex-start; gap: var(--space-5); padding: var(--space-4) 0; border-bottom: 1px solid var(--border); cursor: pointer; transition: background var(--transition-fast); }
   .kb-item:hover { background: var(--surface2); }
   .kb-item:last-child { border-bottom: none; }
@@ -164,7 +164,7 @@
   .agent-emoji { font-size: var(--text-stat); margin-right: var(--space-2); }
   .click-hint { font-size: var(--text-sm); color: var(--border); margin-top: var(--space-3); }
 
-  .inbox-list { display: flex; flex-direction: column; gap: var(--space-4); max-height: 320px; overflow-y: auto; }
+  .inbox-list { display: flex; flex-direction: column; gap: var(--space-4); max-height: 320px; overflow-y: auto; padding: var(--space-3) var(--space-4) 0 0; }
 
   /* PRD Progress */
   .prd-progress-bar { width: 100%; height: 20px; background: var(--bg); border-radius: var(--radius-xl); overflow: hidden; display: flex; margin-bottom: var(--space-6); border: 1px solid var(--border); }
@@ -226,6 +226,7 @@
 
   .notes-preview { max-height: 400px; overflow-y: auto; font-size: var(--text-md); line-height: 1.6; color: var(--muted); font-family: 'Segoe UI', system-ui, sans-serif; white-space: normal; word-wrap: break-word; background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-6) var(--space-7); cursor: pointer; transition: border-color var(--transition-base); }
   .notes-preview:hover { border-color: var(--blue); }
+  .notes-preview > .notif-badge { top: var(--space-2); right: var(--space-4); }
   .inbox-item { background: var(--surface2); border: 1px solid var(--border); border-left: 3px solid var(--purple); border-radius: var(--radius-sm); padding: var(--space-5) var(--space-6); cursor: pointer; }
   .inbox-item:hover { border-color: var(--blue); border-left-color: var(--blue); }
   .item-pinned { border-left-color: var(--yellow); background: rgba(210, 153, 34, 0.05); }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9331,6 +9331,9 @@ async function main() {
     // PR review→fix, poll→fix, merge conflict, auto-complete flows
     await testPrReviewFixFlows();
 
+    // W-mnxu9bvzkc5p: Doc-chat badge visibility on Notes/KB items
+    await testDocChatBadgeVisibility();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -16725,6 +16728,50 @@ async function testPlanPauseNoNestedLocks() {
     assert.strictEqual(filtered[0].agent, 'ralph', 'ralph (other plan) should survive');
     assert.strictEqual(items[0].status, 'done', 'Done item W1 should be untouched');
     assert.strictEqual(items[4].status, 'dispatched', 'Other plan item W5 should be untouched');
+  });
+}
+
+// ─── W-mnxu9bvzkc5p: Doc-chat badge visibility on Notes/KB items ─────────────
+
+async function testDocChatBadgeVisibility() {
+  console.log('\n── Doc-chat badge visibility on Notes/KB ──');
+
+  const inboxSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-inbox.js'), 'utf8');
+  const stylesSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'styles.css'), 'utf8');
+
+  // ── Team Notes must have data-file attribute for badge targeting ──
+
+  await test('renderNotes output includes data-file="notes.md" on .notes-preview', () => {
+    const renderFn = inboxSrc.slice(inboxSrc.indexOf('function renderNotes'));
+    assert.ok(renderFn.includes('data-file="notes.md"'),
+      'notes-preview must have data-file="notes.md" so findCardForFile can target it for badges');
+  });
+
+  // ── Scroll containers must accommodate badge overflow ──
+
+  await test('.kb-list rule has padding to prevent badge clipping by overflow-y:auto', () => {
+    // Extract just the .kb-list CSS rule (single line in this stylesheet)
+    const kbListStart = stylesSrc.indexOf('.kb-list {');
+    const kbListEnd = stylesSrc.indexOf('}', kbListStart) + 1;
+    const kbListRule = stylesSrc.slice(kbListStart, kbListEnd);
+    assert.ok(kbListRule.includes('padding'),
+      '.kb-list { } rule must include padding to accommodate notif-badge overflow (badge uses top:-5px right:-5px)');
+  });
+
+  await test('.inbox-list rule has padding to prevent badge clipping by overflow-y:auto', () => {
+    // Extract just the .inbox-list CSS rule (single line in this stylesheet)
+    const inboxListStart = stylesSrc.indexOf('.inbox-list {');
+    const inboxListEnd = stylesSrc.indexOf('}', inboxListStart) + 1;
+    const inboxListRule = stylesSrc.slice(inboxListStart, inboxListEnd);
+    assert.ok(inboxListRule.includes('padding'),
+      '.inbox-list { } rule must include padding to accommodate notif-badge overflow');
+  });
+
+  // ── Notes preview badge position override ──
+
+  await test('.notes-preview .notif-badge has position override to avoid self-clipping', () => {
+    assert.ok(stylesSrc.includes('.notes-preview > .notif-badge'),
+      'Must have CSS rule .notes-preview > .notif-badge for badge position override (notes-preview has overflow-y:auto)');
   });
 }
 


### PR DESCRIPTION
## Summary

- **Team Notes** had no `data-file` attribute on `.notes-preview`, so `findCardForFile('notes.md')` returned null — badges never attached. Added `data-file="notes.md"` and `restoreNotifBadges()` call.
- **KB items** (`.kb-list`) and **Inbox items** (`.inbox-list`) are inside scroll containers with `overflow-y: auto` that clipped the badge positioned at `top:-5px; right:-5px` outside their bounds. Added padding using CSS variables to accommodate the badge overflow.
- **Notes preview** is its own scroll container (`overflow-y: auto`), so added a `.notes-preview > .notif-badge` position override placing the badge inside the padding area.

## Test plan

- [x] 4 new unit tests in `testDocChatBadgeVisibility()` — all passing (1671/0/2)
- [ ] Open a KB item → send a doc-chat message → close modal → verify blue '...' processing dots appear on the KB card
- [ ] Open Team Notes → send a doc-chat message → close modal → verify blue processing dots appear on the notes preview
- [ ] Open an inbox item → send a doc-chat message → close modal → verify processing dots appear, then red notification dot after response

🤖 Generated with [Claude Code](https://claude.com/claude-code)