### PR TITLE
fix(W-mnxw6zvwaof6): add unhandledRejection/uncaughtException handlers to engine process

### DIFF
--- a/engine/cli.js
+++ b/engine/cli.js
@@ -493,6 +493,23 @@ const commands = {
 
     process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
     process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
+    // Crash handlers — log the error and exit cleanly so the process is detectable as crashed
+    process.on('unhandledRejection', (reason) => {
+      const msg = reason instanceof Error ? reason.stack || reason.message : String(reason);
+      console.error(`[FATAL] Unhandled promise rejection: ${msg}`);
+      try { shared.log('fatal', `Unhandled promise rejection: ${msg}`); } catch { /* best effort */ }
+      try { shared.flushLogs(); } catch { /* best effort */ }
+      process.exit(1);
+    });
+
+    process.on('uncaughtException', (err) => {
+      const msg = err instanceof Error ? err.stack || err.message : String(err);
+      console.error(`[FATAL] Uncaught exception: ${msg}`);
+      try { shared.log('fatal', `Uncaught exception: ${msg}`); } catch { /* best effort */ }
+      try { shared.flushLogs(); } catch { /* best effort */ }
+      process.exit(1);
+    });
   },
 
   stop() {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10491,6 +10491,39 @@ async function testAuxModuleBugFixes() {
     assert.ok(src.includes('fs.unlinkSync(sysTmpPath)'), 'Cleanup should delete sysTmpPath');
   });
 
+  // cli.js: unhandledRejection and uncaughtException handlers
+  await test('cli.js: registers unhandledRejection handler', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(src.includes("process.on('unhandledRejection'"), 'Should register unhandledRejection handler');
+  });
+
+  await test('cli.js: registers uncaughtException handler', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(src.includes("process.on('uncaughtException'"), 'Should register uncaughtException handler');
+  });
+
+  await test('cli.js: unhandledRejection handler logs error and flushes before exit', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    // Find the unhandledRejection handler block
+    const idx = src.indexOf("process.on('unhandledRejection'");
+    assert.ok(idx > 0, 'Must have unhandledRejection handler');
+    const block = src.slice(idx, idx + 500);
+    assert.ok(block.includes('log(') || block.includes('.log('), 'Handler must log the error');
+    assert.ok(block.includes('flushLogs'), 'Handler must flush logs before exit');
+    assert.ok(block.includes('process.exit(1)'), 'Handler must exit with code 1');
+  });
+
+  await test('cli.js: uncaughtException handler logs error and flushes before exit', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    // Find the uncaughtException handler block
+    const idx = src.indexOf("process.on('uncaughtException'");
+    assert.ok(idx > 0, 'Must have uncaughtException handler');
+    const block = src.slice(idx, idx + 500);
+    assert.ok(block.includes('log(') || block.includes('.log('), 'Handler must log the error');
+    assert.ok(block.includes('flushLogs'), 'Handler must flush logs before exit');
+    assert.ok(block.includes('process.exit(1)'), 'Handler must exit with code 1');
+  });
+
   // Bug #37: consolidation.js word length cap for ReDoS prevention
   await test('consolidation.js: fingerprint words capped at 200 chars for ReDoS prevention', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'consolidation.js'), 'utf8');


### PR DESCRIPTION
## Summary

- Adds `process.on('unhandledRejection')` and `process.on('uncaughtException')` handlers in `engine/cli.js` near the existing SIGTERM/SIGINT handlers
- Each handler logs the error via `shared.log('fatal', ...)`, flushes buffered logs via `shared.flushLogs()`, then exits with code 1
- All logging/flushing is wrapped in try-catch to ensure the process exits even if logging itself fails

## Problem

The engine process had no crash handlers. Any unhandled promise rejection or uncaught exception would kill the Node process silently — no log entry, no restart signal, the tick loop just stops.

## Test plan

- [x] 4 new source-inspection tests verifying handler registration, logging, flushing, and exit(1)
- [x] All 1682 tests pass (1 pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)