### PR TITLE
fix(W-mnxw6zwk38g4): await discoverPipelineWork instead of fire-and-forget .catch

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -2990,7 +2990,7 @@ async function discoverWork(config) {
   // Pipeline orchestration — check stage completions and start ready stages
   try {
     const { discoverPipelineWork } = require('./engine/pipeline');
-    discoverPipelineWork(config).catch(e => log('warn', 'discover pipeline work: ' + e.message));
+    await discoverPipelineWork(config);
   } catch (e) { log('warn', 'discover pipeline work: ' + e.message); }
 
   // Periodic plan completion sweep — catch PRDs that completed while engine was down

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -11646,11 +11646,16 @@ async function testEngineAuditCritical() {
       'discoverPipelineWork must be async to use await');
   });
 
-  await test('engine.js handles async discoverPipelineWork', () => {
+  await test('engine.js awaits discoverPipelineWork inside try-catch (not fire-and-forget)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
-    assert.ok(src.includes('discoverPipelineWork(config)'), 'must call discoverPipelineWork');
-    assert.ok(src.includes('.catch(') || src.includes('await discoverPipelineWork'),
-      'must handle the async result (await or .catch)');
+    const pipelineBlock = src.slice(
+      src.indexOf('Pipeline orchestration'),
+      src.indexOf('Periodic plan completion sweep')
+    );
+    assert.ok(pipelineBlock.includes('await discoverPipelineWork(config)'),
+      'discoverPipelineWork must be awaited');
+    assert.ok(!pipelineBlock.includes('.catch('),
+      'must not use fire-and-forget .catch() — outer try-catch handles errors');
   });
 
   await test('render-pipelines.js has _renderMonitoredResources function', () => {


### PR DESCRIPTION
## Summary
- **What**: Fixed unhandled promise rejection risk in `discoverPipelineWork` call inside `discoverWork()` (engine.js ~line 2993)
- **Why**: The fire-and-forget `.catch(e => log(...))` pattern is unsafe — if `log()` throws inside the `.catch` handler, it becomes an unhandled rejection that (without a global handler) kills the process
- **Fix**: `await` the call inside the existing try-catch block, consistent with all other async phases in the tick loop (e.g., `pollPrStatus`, `processPendingRebases`, `pollPrHumanComments`)

## Files changed
- `engine.js` — replaced `discoverPipelineWork(config).catch(...)` with `await discoverPipelineWork(config)` (1 line)
- `test/unit.test.js` — updated existing test + added assertion that fire-and-forget `.catch()` is not used (1 consolidated test)

## Build & test
```bash
npm test    # 1678 passed, 1 pre-existing failure (SessionStart hook), 2 skipped
```

## Test plan
- [x] New test verifies `await discoverPipelineWork(config)` is present
- [x] New test verifies `.catch()` is NOT used in the pipeline block
- [x] All pre-existing tests still pass
- [x] No performance concern — function runs once per 60s tick, awaiting adds negligible latency

Built by Minions (Ralph — Engineer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)