### PR TITLE
fix(W-mnxw6zw9fuer): stop perpetual ADO poll retry when token unavailable

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -252,7 +252,8 @@ async function pollPrStatus(config) {
   const token = await getAdoToken();
   if (!token) {
     log('warn', 'Skipping PR status poll — no ADO token available');
-    _adoPollHadAuthFailure = true; // trigger retry on next tick
+    // Don't set _adoPollHadAuthFailure — getAdoToken() has its own 10-min backoff,
+    // and setting the flag would hammer pollPrStatus() every tick with no useful work.
     return;
   }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -12411,6 +12411,28 @@ async function testPrDuplicateRaceFix() {
     assert.ok(resetIdx < fetchIdx, 'reset must happen before any adoFetch calls');
   });
 
+  await test('ado.js pollPrStatus null-token early-return does NOT set _adoPollHadAuthFailure', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    const pollFn = src.match(/async function pollPrStatus[\s\S]*?^}/m);
+    assert.ok(pollFn, 'pollPrStatus must exist');
+    // Extract the null-token early-return block
+    const tokenCheckMatch = pollFn[0].match(/if \(!token\)\s*\{[\s\S]*?\}/);
+    assert.ok(tokenCheckMatch, 'pollPrStatus must have a null-token check');
+    // The null-token early-return should NOT set the retry flag — backoff in getAdoToken handles timing
+    assert.ok(!tokenCheckMatch[0].includes('_adoPollHadAuthFailure = true'),
+      'null-token early-return must NOT set _adoPollHadAuthFailure (avoids perpetual retry hammering during backoff)');
+  });
+
+  await test('ado.js pollPrStatus sets _adoPollHadAuthFailure only in auth error catch block', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    const pollFn = src.match(/async function pollPrStatus[\s\S]*?^}/m);
+    assert.ok(pollFn, 'pollPrStatus must exist');
+    // Count occurrences — should be exactly 1 (in catch block only, not in null-token early-return)
+    const setCount = (pollFn[0].match(/_adoPollHadAuthFailure = true/g) || []).length;
+    assert.strictEqual(setCount, 1,
+      '_adoPollHadAuthFailure = true should appear exactly once in pollPrStatus (in auth error catch block only)');
+  });
+
   await test('engine.js imports needsAdoPollRetry and uses it in tick cadence', () => {
     const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
     assert.ok(engineSrc.includes('needsAdoPollRetry'), 'engine.js must import needsAdoPollRetry');


### PR DESCRIPTION
## Summary

- Removed `_adoPollHadAuthFailure = true` from the null-token early-return path in `pollPrStatus()` — this flag caused `needsAdoPollRetry()` to return true on every engine tick during `getAdoToken()`'s 10-minute backoff, triggering ~10 useless `pollPrStatus()` calls that just re-set the flag and returned early
- The flag is now only set for mid-poll auth errors (line 498 catch block) where a valid token expired during PR processing and immediate retry is warranted
- Added 2 regression tests: one verifies the null-token path does NOT set the flag, another verifies the flag is set exactly once in the function (in the catch block only)

## Test plan

- [x] New test: `ado.js pollPrStatus null-token early-return does NOT set _adoPollHadAuthFailure` — passes
- [x] New test: `ado.js pollPrStatus sets _adoPollHadAuthFailure only in auth error catch block` — passes
- [x] Existing test: `ado.js pollPrStatus resets _adoPollHadAuthFailure at start` — still passes
- [x] Existing test: `ado.js pollPrStatus sets _buildStatusStale on auth error` — still passes (the `_adoPollHadAuthFailure = true` in the catch block is preserved)
- [x] Full test suite: 1680 passed, 1 failed (pre-existing SessionStart hook issue), 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)