### PR TITLE
fix(W-mnxw6zwv7hh2): prevent _consolidationInFlight race from stale force-reset timeout

### DIFF
--- a/engine/consolidation.js
+++ b/engine/consolidation.js
@@ -18,6 +18,7 @@ const { getInboxFiles, getNotes, INBOX_DIR, ENGINE_DIR, MINIONS_DIR,
 // Track in-flight LLM consolidation to prevent concurrent runs
 let _consolidationInFlight = false;
 let _consolidationStartedAt = 0;
+let _forceResetTimeout = null; // force-reset handle; cancelled by _clearProcessingState
 const _processingFiles = new Set(); // files currently being consolidated (race guard)
 
 function consolidateInbox(config) {
@@ -113,6 +114,9 @@ Use today's date: ${dateStamp()}`;
 
 function consolidateWithLLM(items, existingNotes, files, config) {
 
+  // Cancel any stale force-reset from a prior run before starting fresh
+  clearTimeout(_forceResetTimeout);
+  _forceResetTimeout = null;
   _consolidationInFlight = true;
   _consolidationStartedAt = Date.now();
   for (const f of files) _processingFiles.add(f);
@@ -180,18 +184,21 @@ function consolidateWithLLM(items, existingNotes, files, config) {
   const timeout = setTimeout(() => {
     log('warn', 'LLM consolidation timed out after 3m — killing and falling back to regex');
     shared.killGracefully(proc, 10000);
-    setTimeout(() => {
-      if (_consolidationInFlight) {
-        _consolidationInFlight = false;
-        _processingFiles.clear();
-        log('warn', 'Consolidation flag force-reset after SIGKILL');
-      }
+    _forceResetTimeout = setTimeout(() => {
+      if (!_cleared) log('warn', 'Consolidation flag force-reset after SIGKILL');
+      _clearProcessingState();
     }, 10000);
   }, 180000);
 
+  let _cleared = false; // idempotency guard — both 'error' and 'close' can fire for the same process
   function _clearProcessingState() {
+    if (_cleared) return;
+    _cleared = true;
+    clearTimeout(_forceResetTimeout);
+    _forceResetTimeout = null;
     for (const f of files) _processingFiles.delete(f);
     _consolidationInFlight = false;
+    _consolidationStartedAt = 0;
   }
 
   proc.on('close', (code) => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1308,6 +1308,64 @@ async function testContentHashCircuitBreaker() {
   });
 }
 
+// ─── Consolidation Force-Reset Race Condition Tests ─────────────────────────
+
+async function testConsolidationForceResetRace() {
+  console.log('\n── consolidation.js — Force-Reset Timeout Race Condition ──');
+
+  const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'consolidation.js'), 'utf8');
+
+  await test('consolidation.js: force-reset timeout handle is stored in a clearable variable', () => {
+    // The inner 10s setTimeout in the timeout handler must be stored so it can be cancelled
+    // Look for a module-level variable to hold the force-reset timeout handle
+    assert.ok(src.includes('_forceResetTimeout'), 'Should have a _forceResetTimeout variable to store the inner timeout handle');
+  });
+
+  await test('consolidation.js: _clearProcessingState cancels the force-reset timeout', () => {
+    // _clearProcessingState must call clearTimeout on the force-reset handle
+    // to prevent it from firing against a subsequent consolidation
+    const match = src.match(/function _clearProcessingState\(\)\s*\{[\s\S]*?\n  \}/);
+    assert.ok(match, '_clearProcessingState function must exist');
+    assert.ok(match[0].includes('clearTimeout(_forceResetTimeout)'),
+      '_clearProcessingState must call clearTimeout(_forceResetTimeout) to prevent race with new consolidation');
+  });
+
+  await test('consolidation.js: force-reset setTimeout result is assigned to _forceResetTimeout', () => {
+    // The inner setTimeout (10s force-reset after SIGKILL) must be assigned to _forceResetTimeout
+    // so _clearProcessingState can cancel it
+    assert.ok(src.includes('_forceResetTimeout = setTimeout'),
+      'Inner force-reset setTimeout must be assigned to _forceResetTimeout');
+  });
+
+  await test('consolidation.js: _clearProcessingState is idempotent (double-fire guard)', () => {
+    // Both 'error' and 'close' can fire for the same child process.
+    const match = src.match(/function _clearProcessingState\(\)\s*\{[\s\S]*?\n  \}/);
+    assert.ok(match, '_clearProcessingState function must exist');
+    assert.ok(match[0].includes('_cleared'),
+      '_clearProcessingState must have an idempotency guard (_cleared flag) to prevent double-fire from error+close events');
+  });
+
+  await test('consolidation.js: consolidateWithLLM clears stale _forceResetTimeout on entry', () => {
+    // A stale force-reset timeout from a prior run could fire during a new run.
+    // consolidateWithLLM must clearTimeout(_forceResetTimeout) before setting _consolidationInFlight = true.
+    const fnMatch = src.match(/function consolidateWithLLM[\s\S]*?_consolidationInFlight = true/);
+    assert.ok(fnMatch, 'consolidateWithLLM must exist and set _consolidationInFlight');
+    assert.ok(fnMatch[0].includes('clearTimeout(_forceResetTimeout)'),
+      'consolidateWithLLM must clear stale _forceResetTimeout before starting a new consolidation');
+  });
+
+  await test('consolidation.js: force-reset callback delegates to _clearProcessingState (no duplicate cleanup)', () => {
+    // The 10s force-reset callback should call _clearProcessingState() instead of
+    // duplicating the same state mutations inline.
+    const forceResetMatch = src.match(/_forceResetTimeout = setTimeout\(\(\)\s*=>\s*\{[\s\S]*?\}, 10000\)/);
+    assert.ok(forceResetMatch, 'force-reset setTimeout must exist');
+    assert.ok(forceResetMatch[0].includes('_clearProcessingState()'),
+      'force-reset callback must call _clearProcessingState() instead of duplicating cleanup logic');
+    assert.ok(!forceResetMatch[0].includes('_processingFiles.clear()'),
+      'force-reset callback must not have inline _processingFiles.clear() — delegates to _clearProcessingState');
+  });
+}
+
 // ─── Reconciliation Tests ───────────────────────────────────────────────────
 
 async function testReconciliation() {
@@ -9161,6 +9219,7 @@ async function main() {
     // consolidation.js tests
     await testConsolidationHelpers();
     await testContentHashCircuitBreaker();
+    await testConsolidationForceResetRace();
 
     // github.js tests
     await testGithubHelpers();


### PR DESCRIPTION
## Summary

- Store force-reset setTimeout handle in `_forceResetTimeout` and cancel it in `_clearProcessingState()` so it never fires against a subsequent consolidation
- Add `_cleared` idempotency guard to `_clearProcessingState()` so double-fire from error+close events on the same process doesn't clear a new consolidation's state
- Clear stale `_forceResetTimeout` at the top of `consolidateWithLLM()` to prevent timer leak from a prior run firing during a new one
- De-duplicated force-reset callback by delegating to `_clearProcessingState()` instead of inline cleanup

## Test plan

- [x] 6 new structural tests verify all race condition guards are in place
- [x] Full test suite: 1684 passed, 1 pre-existing failure (unrelated SessionStart hook test), 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)