### PR TITLE
feat(W-mnxzhoq2lsgz): certificate-based auth for Teams integration

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -3702,6 +3702,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         engine: { ...shared.ENGINE_DEFAULTS, ...(config.engine || {}) },
         claude: { ...shared.DEFAULT_CLAUDE, ...(config.claude || {}) },
         agents: config.agents || {},
+        teams: { ...shared.ENGINE_DEFAULTS.teams, ...(config.teams || {}) },
         routing,
       });
     } catch (e) { return jsonReply(res, 500, { error: e.message }); }
@@ -3793,6 +3794,22 @@ What would you like to discuss or change? When you're happy, say "approve" and I
             else config.agents[id].monthlyBudgetUsd = Math.max(0, val);
           }
         }
+      }
+
+      if (body.teams) {
+        if (!config.teams) config.teams = {};
+        const tm = body.teams;
+        if (tm.enabled !== undefined) config.teams.enabled = !!tm.enabled;
+        for (const key of ['appId', 'appPassword', 'certPath', 'privateKeyPath', 'tenantId']) {
+          if (tm[key] !== undefined) config.teams[key] = String(tm[key] || '');
+        }
+        if (tm.notifyEvents !== undefined) {
+          config.teams.notifyEvents = Array.isArray(tm.notifyEvents) ? tm.notifyEvents : String(tm.notifyEvents || '').split(',').map(s => s.trim()).filter(Boolean);
+        }
+        if (tm.inboxPollInterval !== undefined) config.teams.inboxPollInterval = Math.max(5000, Number(tm.inboxPollInterval) || 15000);
+        if (tm.ccMirror !== undefined) config.teams.ccMirror = !!tm.ccMirror;
+        // Invalidate cached adapter so credential changes take effect
+        teams._resetAdapter();
       }
 
       safeWrite(configPath, config);
@@ -4571,7 +4588,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
 
     // Settings
     { method: 'GET', path: '/api/settings', desc: 'Return current engine + claude + routing config', handler: handleSettingsRead },
-    { method: 'POST', path: '/api/settings', desc: 'Update engine + claude + agent config', params: 'engine?, claude?, agents?', handler: handleSettingsUpdate },
+    { method: 'POST', path: '/api/settings', desc: 'Update engine + claude + agent + teams config', params: 'engine?, claude?, agents?, teams?', handler: handleSettingsUpdate },
     { method: 'POST', path: '/api/settings/routing', desc: 'Update routing.md', params: 'content', handler: handleSettingsRouting },
     { method: 'POST', path: '/api/settings/reset', desc: 'Reset engine + claude + agent settings to defaults', handler: handleSettingsReset },
 

--- a/dashboard/js/settings.js
+++ b/dashboard/js/settings.js
@@ -14,6 +14,7 @@ async function openSettings() {
   const e = data.engine || {};
   const c = data.claude || {};
   const agents = data.agents || {};
+  const t = data.teams || {};
 
   const agentRows = Object.entries(agents).map(function([id, a]) {
     return '<tr>' +
@@ -94,6 +95,28 @@ async function openSettings() {
         '</select>' +
         '<div style="font-size:9px;color:var(--muted);margin-top:1px">Controls response depth and reasoning effort</div>' +
       '</div>' +
+    '</div>' +
+
+    '<h3 style="font-size:13px;color:var(--blue);margin-bottom:8px">Teams Integration</h3>' +
+    '<div style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px">' +
+      settingsToggle('Enable Teams', 'set-teams-enabled', !!t.enabled, 'Connect Minions to Microsoft Teams') +
+    '</div>' +
+    '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">' +
+      settingsField('App ID', 'set-teams-appId', t.appId || '', '', 'Microsoft App ID from Azure Bot Configuration') +
+      settingsField('App Password', 'set-teams-appPassword', t.appPassword || '', '', 'Client secret (leave blank for certificate auth)') +
+    '</div>' +
+    '<div style="font-size:10px;color:var(--muted);margin-bottom:4px;font-weight:600">Certificate Auth (alternative to client secret)</div>' +
+    '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">' +
+      settingsField('Certificate Path', 'set-teams-certPath', t.certPath || '', '', 'Path to PEM certificate file') +
+      settingsField('Private Key Path', 'set-teams-privateKeyPath', t.privateKeyPath || '', '', 'Path to PEM private key file') +
+      settingsField('Tenant ID', 'set-teams-tenantId', t.tenantId || '', '', 'Azure AD tenant ID (required for cert auth)') +
+    '</div>' +
+    '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:16px">' +
+      settingsField('Notify Events', 'set-teams-notifyEvents', (t.notifyEvents || []).join(', '), '', 'Comma-separated event types to notify') +
+      settingsField('Inbox Poll Interval', 'set-teams-inboxPollInterval', t.inboxPollInterval || 15000, 'ms', 'How often to check for Teams messages') +
+    '</div>' +
+    '<div style="display:flex;flex-direction:column;gap:6px;margin-bottom:16px">' +
+      settingsToggle('CC Mirror', 'set-teams-ccMirror', t.ccMirror !== false, 'Mirror Command Center responses to Teams') +
     '</div>' +
 
     '<h3 style="font-size:13px;color:var(--blue);margin-bottom:8px">Claude CLI</h3>' +
@@ -236,6 +259,18 @@ async function saveSettings() {
       permissionMode: document.getElementById('set-permissionMode').value,
     };
 
+    const teamsPayload = {
+      enabled: document.getElementById('set-teams-enabled').checked,
+      appId: document.getElementById('set-teams-appId').value,
+      appPassword: document.getElementById('set-teams-appPassword').value,
+      certPath: document.getElementById('set-teams-certPath').value,
+      privateKeyPath: document.getElementById('set-teams-privateKeyPath').value,
+      tenantId: document.getElementById('set-teams-tenantId').value,
+      notifyEvents: document.getElementById('set-teams-notifyEvents').value,
+      inboxPollInterval: document.getElementById('set-teams-inboxPollInterval').value,
+      ccMirror: document.getElementById('set-teams-ccMirror').checked,
+    };
+
     const agentsPayload = {};
     document.querySelectorAll('[data-agent][data-field]').forEach(function(el) {
       const id = el.dataset.agent;
@@ -247,7 +282,7 @@ async function saveSettings() {
     // Save config
     const res = await fetch('/api/settings', {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ engine: enginePayload, claude: claudePayload, agents: agentsPayload })
+      body: JSON.stringify({ engine: enginePayload, claude: claudePayload, agents: agentsPayload, teams: teamsPayload })
     });
     const result = await res.json();
     if (!res.ok) throw new Error(result.error);

--- a/docs/teams-setup.md
+++ b/docs/teams-setup.md
@@ -84,7 +84,10 @@ Add a `teams` section to your `config.json`:
 |-------|-------------|
 | `enabled` | Master switch — `true` to activate Teams integration |
 | `appId` | Microsoft App ID from the Azure Bot Configuration page |
-| `appPassword` | Client secret value from Entra ID Certificates & secrets |
+| `appPassword` | Client secret value from Entra ID Certificates & secrets (leave blank for certificate auth) |
+| `certPath` | Path to PEM certificate file (certificate auth only) |
+| `privateKeyPath` | Path to PEM private key file (certificate auth only) |
+| `tenantId` | Azure AD tenant ID (required for certificate auth) |
 | `notifyEvents` | Which events trigger Teams notifications (see below) |
 | `ccMirror` | Mirror CC dashboard responses to Teams (`true`/`false`) |
 | `inboxPollInterval` | How often to check for new Teams messages, in ms (default: 15000) |
@@ -92,6 +95,55 @@ Add a `teams` section to your `config.json`:
 **Available notification events:** `pr-merged`, `agent-completed`, `plan-completed`, `agent-failed`, `pr-abandoned`, `pr-approved`, `pr-build-failed`, `plan-approved`, `plan-rejected`, `verify-created`
 
 > **Security note:** `config.json` is gitignored by default and should never be committed. For shared machines, consider setting the app password via an environment variable and reading it in your config setup.
+
+### Certificate Auth (Alternative to Client Secret)
+
+Some tenants prohibit creating client secrets in Entra ID. Use certificate-based authentication instead — no client secret needed.
+
+#### Generate a Self-Signed Certificate
+
+```bash
+# Generate a private key and self-signed certificate (valid for 1 year)
+openssl req -x509 -newkey rsa:2048 -keyout bot-private-key.pem -out bot-cert.pem -days 365 -nodes -subj "/CN=minions-bot"
+
+# Verify the certificate
+openssl x509 -in bot-cert.pem -text -noout
+```
+
+This creates two files:
+- `bot-cert.pem` — the public certificate (upload to Entra ID)
+- `bot-private-key.pem` — the private key (keep secret, do not commit)
+
+#### Upload the Certificate to Entra ID
+
+1. In the [Azure Portal](https://portal.azure.com), go to **Entra ID** > **App registrations**.
+2. Find and click the app registration for your bot (same App ID from Step 3).
+3. Click **Certificates & secrets** in the left sidebar.
+4. Click the **Certificates** tab, then **Upload certificate**.
+5. Select your `bot-cert.pem` file and click **Add**.
+
+#### Configure Minions for Certificate Auth
+
+Use certificate fields instead of `appPassword` in your `config.json`:
+
+```json
+{
+  "teams": {
+    "enabled": true,
+    "appId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "certPath": "/path/to/bot-cert.pem",
+    "privateKeyPath": "/path/to/bot-private-key.pem",
+    "tenantId": "your-azure-ad-tenant-id",
+    "notifyEvents": ["pr-merged", "agent-completed", "plan-completed", "agent-failed"],
+    "ccMirror": true,
+    "inboxPollInterval": 15000
+  }
+}
+```
+
+> **Finding your Tenant ID:** In the Azure Portal, go to **Entra ID** > **Overview**. The **Tenant ID** is listed under Basic Information.
+
+> When both `appPassword` and cert fields are configured, certificate auth takes precedence.
 
 ## Step 4: Set the Messaging Endpoint
 

--- a/engine/preflight.js
+++ b/engine/preflight.js
@@ -193,14 +193,20 @@ function doctor(minionsHome) {
       runtimeResults.push({ name: 'Agents configured', ok: false, message: 'no agents in config.json' });
     }
 
-    // Check Teams integration
+    // Check Teams integration — supports client secret OR certificate auth
     const teams = config.teams;
     if (teams && teams.enabled === true) {
-      if (!teams.appId || !teams.appPassword) {
-        const missing = [!teams.appId && 'appId', !teams.appPassword && 'appPassword'].filter(Boolean).join(', ');
+      const hasSecret = !!teams.appId && !!teams.appPassword;
+      const hasCert = !!teams.appId && !!teams.certPath && !!teams.privateKeyPath && !!teams.tenantId;
+      if (!hasSecret && !hasCert) {
+        const missing = [
+          !teams.appId && 'appId',
+          !teams.appPassword && !teams.certPath && 'appPassword or certPath+privateKeyPath+tenantId',
+        ].filter(Boolean).join(', ');
         runtimeResults.push({ name: 'Teams integration', ok: 'warn', message: `enabled but missing: ${missing}` });
       } else {
-        runtimeResults.push({ name: 'Teams integration', ok: true, message: 'configured' });
+        const authMode = hasCert ? 'certificate' : 'client secret';
+        runtimeResults.push({ name: 'Teams integration', ok: true, message: `configured (${authMode})` });
       }
     } else {
       runtimeResults.push({ name: 'Teams integration', ok: 'warn', message: 'disabled — see docs/teams-setup.md' });

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -556,11 +556,15 @@ const ENGINE_DEFAULTS = {
   ccEffort: null, // effort level for CC/doc-chat (null, 'low', 'medium', 'high')
   heartbeatTimeouts: {}, // populated after WORK_TYPE is defined (below)
   ccMaxTurns: 50, // max tool-use turns for CC/doc-chat before CLI stops
-  // Teams integration — config.teams shape: { enabled, appId, appPassword, notifyEvents, ccMirror, inboxPollInterval }
+  // Teams integration — config.teams shape: { enabled, appId, appPassword, certPath, privateKeyPath, tenantId, notifyEvents, ccMirror, inboxPollInterval }
+  // Auth modes: (1) appId + appPassword (client secret), or (2) appId + certPath + privateKeyPath + tenantId (certificate)
   teams: {
     enabled: false,
     appId: '',
     appPassword: '',
+    certPath: '',          // PEM certificate file path (certificate auth)
+    privateKeyPath: '',    // PEM private key file path (certificate auth)
+    tenantId: '',          // Azure AD tenant ID (required for certificate auth)
     notifyEvents: ['pr-merged', 'agent-completed', 'plan-completed', 'agent-failed'],
     ccMirror: true,
     inboxPollInterval: 15000,

--- a/engine/teams.js
+++ b/engine/teams.js
@@ -8,7 +8,7 @@ const path = require('path');
 const shared = require('./shared');
 const queries = require('./queries');
 
-const { log, safeJson, mutateJsonFileLocked, ENGINE_DEFAULTS } = shared;
+const { log, safeRead, safeJson, mutateJsonFileLocked, ENGINE_DEFAULTS } = shared;
 const { ENGINE_DIR, getConfig } = queries;
 const cards = require('./teams-cards');
 
@@ -50,10 +50,16 @@ function getTeamsConfig() {
 
 /**
  * Returns true if Teams integration is enabled and has required credentials.
+ * Supports two auth modes:
+ *   (1) Client secret: appId + appPassword
+ *   (2) Certificate:   appId + certPath + privateKeyPath + tenantId
  */
 function isTeamsEnabled() {
   const cfg = getTeamsConfig();
-  return cfg.enabled === true && !!cfg.appId && !!cfg.appPassword;
+  if (cfg.enabled !== true || !cfg.appId) return false;
+  const hasSecret = !!cfg.appPassword;
+  const hasCert = !!cfg.certPath && !!cfg.privateKeyPath && !!cfg.tenantId;
+  return hasSecret || hasCert;
 }
 
 // Cached adapter instance — created once per process
@@ -62,6 +68,9 @@ let _adapter = null;
 /**
  * Create and return a BotFrameworkAdapter instance.
  * Returns null when Teams is disabled or botbuilder is not installed.
+ * Supports two auth modes:
+ *   (1) Client secret: uses ConfigurationBotFrameworkAuthentication with appPassword
+ *   (2) Certificate:   uses CertificateServiceClientCredentialsFactory with PEM cert + key
  */
 function createAdapter() {
   if (_adapter) return _adapter;
@@ -75,15 +84,43 @@ function createAdapter() {
   if (!botbuilder) return null;
 
   const cfg = getTeamsConfig();
+  const useCert = !!cfg.certPath && !!cfg.privateKeyPath && !!cfg.tenantId;
+
   try {
-    _adapter = new botbuilder.CloudAdapter(
-      new botbuilder.ConfigurationBotFrameworkAuthentication({
-        MicrosoftAppId: cfg.appId,
-        MicrosoftAppPassword: cfg.appPassword,
-        MicrosoftAppType: 'SingleTenant',
-      })
-    );
-    log('info', 'Teams adapter created successfully');
+    if (useCert) {
+      let connector;
+      try {
+        connector = require('botframework-connector');
+      } catch {
+        log('warn', 'botframework-connector not installed — certificate auth unavailable. Install via: npm install botframework-connector');
+        return null;
+      }
+      const cert = safeRead(cfg.certPath);
+      const privateKey = safeRead(cfg.privateKeyPath);
+      if (!cert || !privateKey) {
+        log('warn', `Teams cert auth failed — could not read cert (${cfg.certPath}) or key (${cfg.privateKeyPath})`);
+        return null;
+      }
+      const credentialsFactory = new connector.CertificateServiceClientCredentialsFactory(
+        cfg.appId, cert, privateKey, cfg.tenantId
+      );
+      _adapter = new botbuilder.CloudAdapter(
+        new botbuilder.ConfigurationBotFrameworkAuthentication(
+          { MicrosoftAppId: cfg.appId, MicrosoftAppType: 'SingleTenant', MicrosoftAppTenantId: cfg.tenantId },
+          credentialsFactory
+        )
+      );
+      log('info', 'Teams adapter created (certificate auth)');
+    } else {
+      _adapter = new botbuilder.CloudAdapter(
+        new botbuilder.ConfigurationBotFrameworkAuthentication({
+          MicrosoftAppId: cfg.appId,
+          MicrosoftAppPassword: cfg.appPassword,
+          MicrosoftAppType: 'SingleTenant',
+        })
+      );
+      log('info', 'Teams adapter created (client secret auth)');
+    }
     return _adapter;
   } catch (err) {
     log('warn', `Teams adapter creation failed: ${err.message}`);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -13521,6 +13521,63 @@ async function testAutoRecoveryAndAtomicity() {
     assert.strictEqual(teams._outboundQueue.length, 0, 'queue should be cleared');
   });
 
+  // ── Teams Certificate Auth ──────────────────────────────────────────────
+
+  await test('ENGINE_DEFAULTS.teams has cert auth fields', () => {
+    const teams = shared.ENGINE_DEFAULTS.teams;
+    assert.strictEqual(teams.certPath, '', 'teams.certPath default should be empty string');
+    assert.strictEqual(teams.privateKeyPath, '', 'teams.privateKeyPath default should be empty string');
+    assert.strictEqual(teams.tenantId, '', 'teams.tenantId default should be empty string');
+  });
+
+  await test('isTeamsEnabled returns true for cert-based auth', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function isTeamsEnabled'));
+    assert.ok(fn.includes('certPath'), 'isTeamsEnabled should check certPath');
+    assert.ok(fn.includes('privateKeyPath'), 'isTeamsEnabled should check privateKeyPath');
+    assert.ok(fn.includes('tenantId'), 'isTeamsEnabled should check tenantId');
+  });
+
+  await test('createAdapter uses CertificateServiceClientCredentialsFactory for cert path', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function createAdapter'));
+    assert.ok(fn.includes('CertificateServiceClientCredentialsFactory'), 'createAdapter should use CertificateServiceClientCredentialsFactory');
+    assert.ok(fn.includes('certPath'), 'createAdapter should read certPath');
+    assert.ok(fn.includes('privateKeyPath'), 'createAdapter should read privateKeyPath');
+    assert.ok(fn.includes('tenantId'), 'createAdapter should read tenantId for cert auth');
+  });
+
+  await test('createAdapter reads cert/key from disk for cert auth mode', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'teams.js'), 'utf8');
+    const fn = src.slice(src.indexOf('function createAdapter'));
+    assert.ok(fn.includes('safeRead(cfg.certPath)'), 'createAdapter should read cert via safeRead');
+    assert.ok(fn.includes('safeRead(cfg.privateKeyPath)'), 'createAdapter should read key via safeRead');
+    assert.ok(fn.includes('!cert || !privateKey'), 'createAdapter should guard against empty cert/key');
+  });
+
+  await test('preflight validates cert auth as alternative to appPassword', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'preflight.js'), 'utf8');
+    assert.ok(src.includes('certPath'), 'preflight should check certPath');
+    assert.ok(src.includes('privateKeyPath'), 'preflight should check privateKeyPath');
+  });
+
+  await test('docs/teams-setup.md has Certificate Auth section', () => {
+    const doc = fs.readFileSync(path.join(MINIONS_DIR, 'docs', 'teams-setup.md'), 'utf8');
+    assert.ok(doc.includes('Certificate Auth'), 'should have Certificate Auth section');
+    assert.ok(doc.includes('certPath'), 'should document certPath config field');
+    assert.ok(doc.includes('privateKeyPath'), 'should document privateKeyPath config field');
+    assert.ok(doc.includes('tenantId'), 'should document tenantId config field');
+    assert.ok(doc.includes('openssl'), 'should include openssl instructions');
+  });
+
+  await test('settings.js has Teams section with cert fields', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'settings.js'), 'utf8');
+    assert.ok(src.includes('Teams'), 'settings should have Teams section');
+    assert.ok(src.includes('set-teams-certPath'), 'settings should have certPath field');
+    assert.ok(src.includes('set-teams-privateKeyPath'), 'settings should have privateKeyPath field');
+    assert.ok(src.includes('set-teams-tenantId'), 'settings should have tenantId field');
+  });
+
   await test('doc-chat restricts tools — no Bash for read-only, no WebSearch', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     const docCallFn = src.slice(src.indexOf('async function ccDocCall('));


### PR DESCRIPTION
## Summary
- Add certificate-based authentication as an alternative to client secret auth in Teams integration
- Unblocks users whose Entra ID tenant policy prohibits creating client secrets
- Uses `CertificateServiceClientCredentialsFactory` from botframework-connector (transitive dep of botbuilder)

## Changes
- **engine/shared.js**: Added `certPath`, `privateKeyPath`, `tenantId` fields to `ENGINE_DEFAULTS.teams`
- **engine/teams.js**: `isTeamsEnabled()` accepts either auth mode; `createAdapter()` branches on cert vs secret with `safeRead` for graceful file error handling
- **engine/preflight.js**: Doctor check validates cert auth as alternative credential set
- **dashboard.js**: Settings API reads/writes teams config; resets adapter cache on save
- **dashboard/js/settings.js**: Full Teams Integration section in settings UI with cert auth fields
- **docs/teams-setup.md**: Certificate Auth section with openssl instructions and Entra ID upload steps
- **test/unit.test.js**: 7 new tests covering cert auth defaults, detection, adapter creation, preflight, docs, and settings UI

## Test plan
- [x] 1700 tests pass (7 new), 0 regressions
- [ ] Verify Teams settings section renders in dashboard
- [ ] Verify cert auth adapter creation with valid PEM files
- [ ] Verify graceful error when cert files are missing/unreadable

🤖 Generated with [Claude Code](https://claude.com/claude-code)