### PR TITLE
feat: Improve agent live output rendering with shared helpers

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -85,7 +85,7 @@ function buildDashboardHtml() {
 
   // Assemble JS modules (order matters: utils → state → renderers → commands → refresh)
   const jsFiles = [
-    'utils', 'state', 'detail-panel', 'live-stream',
+    'utils', 'state', 'render-utils', 'detail-panel', 'live-stream',
     'render-agents', 'render-dispatch', 'render-work-items', 'render-prd',
     'render-prs', 'render-plans', 'render-inbox', 'render-kb', 'render-skills',
     'render-other', 'render-schedules', 'render-pipelines', 'render-meetings', 'render-pinned',

--- a/dashboard.js
+++ b/dashboard.js
@@ -3441,6 +3441,18 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     } catch (e) { ccInFlightTabs.delete(tabId); return jsonReply(res, 500, { error: e.message }); }
   }
 
+  /** Build a lightweight input object for SSE tool events — keeps only the fields formatToolSummary needs, with truncated string values. */
+  function _lightToolInput(input) {
+    if (!input || typeof input !== 'object') return {};
+    const out = {};
+    for (const [k, v] of Object.entries(input)) {
+      if (Array.isArray(v)) { out[k] = v; }
+      else if (typeof v === 'string') { out[k] = v.length > 200 ? v.slice(0, 197) + '...' : v; }
+      else { out[k] = v; }
+    }
+    return out;
+  }
+
   async function handleCommandCenterStream(req, res) {
     if (checkRateLimit('command-center', 10)) { res.statusCode = 429; res.end('Rate limited'); return; }
     try {
@@ -3496,7 +3508,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
             try { res.write('data: ' + JSON.stringify({ type: 'chunk', text: display }) + '\n\n'); } catch {}
           },
           onToolUse: (name, input) => {
-            try { res.write('data: ' + JSON.stringify({ type: 'tool', name, input: typeof input === 'string' ? input.slice(0, 200) : JSON.stringify(input).slice(0, 200) }) + '\n\n'); } catch {}
+            try { res.write('data: ' + JSON.stringify({ type: 'tool', name, input: _lightToolInput(input) }) + '\n\n'); } catch {}
           }
         });
         _ccStreamAbort = llmPromise.abort;
@@ -3519,7 +3531,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
               try { res.write('data: ' + JSON.stringify({ type: 'chunk', text: display }) + '\n\n'); } catch {}
             },
             onToolUse: (name, input) => {
-              try { res.write('data: ' + JSON.stringify({ type: 'tool', name, input: typeof input === 'string' ? input.slice(0, 200) : JSON.stringify(input).slice(0, 200) }) + '\n\n'); } catch {}
+              try { res.write('data: ' + JSON.stringify({ type: 'tool', name, input: _lightToolInput(input) }) + '\n\n'); } catch {}
             }
           });
           _ccStreamAbort = retryPromise.abort;

--- a/dashboard/js/command-center.js
+++ b/dashboard/js/command-center.js
@@ -148,7 +148,11 @@ function ccSwitchTab(id) {
       var tools = tab._toolsUsed || [];
       if (tools.length > 0) {
         html += '<div style="margin-bottom:6px">';
-        tools.forEach(function(t) { html += '<div style="color:var(--blue);font-size:11px">\uD83D\uDD27 ' + escHtml(t) + '</div>'; });
+        tools.forEach(function(t) {
+          var name = typeof t === 'string' ? t : t.name;
+          var input = typeof t === 'string' ? {} : (t.input || {});
+          html += '<div style="color:var(--muted);font-size:10px;font-family:monospace"><span style="flex-shrink:0">&#9679;</span> ' + formatToolSummary(name, input) + '</div>';
+        });
         html += '</div>';
       }
       var text = tab._streamedText || '';
@@ -512,7 +516,9 @@ async function _ccDoSend(message, skipUserMsg, forceTabId) {
       if (toolsUsed.length > 0) {
         html += '<div style="margin-bottom:6px">';
         toolsUsed.forEach(function(t) {
-          html += '<div style="color:var(--blue);font-size:11px">\uD83D\uDD27 ' + escHtml(t) + '</div>';
+          var name = typeof t === 'string' ? t : t.name;
+          var input = typeof t === 'string' ? {} : (t.input || {});
+          html += '<div style="color:var(--muted);font-size:10px;font-family:monospace"><span style="flex-shrink:0">&#9679;</span> ' + formatToolSummary(name, input) + '</div>';
         });
         html += '</div>';
       }
@@ -572,7 +578,7 @@ async function _ccDoSend(message, skipUserMsg, forceTabId) {
             if (activeTab) activeTab._streamedText = streamedText;
             updateStreamDiv();
           } else if (evt.type === 'tool') {
-            toolsUsed.push(evt.name);
+            toolsUsed.push({ name: evt.name, input: evt.input || {} });
             if (activeTab) activeTab._toolsUsed = toolsUsed.slice();
             updateStreamDiv();
             if (msgs.scrollHeight - msgs.scrollTop - msgs.clientHeight < 150) msgs.scrollTop = msgs.scrollHeight;

--- a/dashboard/js/detail-panel.js
+++ b/dashboard/js/detail-panel.js
@@ -141,7 +141,7 @@ function renderDetailContent(detail, tab) {
     html += '<h4>Task History</h4><div class="section">' + renderMd(detail.history || 'No history yet.') + '</div>';
     el.innerHTML = html;
   } else if (tab === 'output') {
-    el.innerHTML = '<div class="section">' + renderMd(detail.outputLog || 'No output log. The coordinator will save agent output here when tasks complete.') + '</div>';
+    el.innerHTML = '<div class="section">' + (detail.outputLog ? renderAgentOutput(detail.outputLog) : 'No output log. The coordinator will save agent output here when tasks complete.') + '</div>';
   }
 }
 

--- a/dashboard/js/live-stream.js
+++ b/dashboard/js/live-stream.js
@@ -22,70 +22,8 @@ function _updateRuntimeCounter() {
 function renderLiveChatMessage(raw) {
   const el = document.getElementById('live-messages');
   if (!el) return;
-  const fragments = [];
-
-  function renderJsonObj(obj) {
-    if (obj.type === 'assistant' && obj.message?.content) {
-      for (const block of obj.message.content) {
-        if (block.type === 'thinking') {
-          fragments.push('<div style="font-size:10px;color:var(--muted);padding:2px 8px;font-style:italic">\u{1F4AD} Thinking...</div>');
-        }
-        if (block.type === 'text' && block.text) {
-          fragments.push('<div style="background:var(--surface2);padding:8px 12px;border-radius:12px 12px 12px 2px;max-width:90%;margin:4px 0;font-size:12px;word-break:break-word">' + renderMd(block.text) + '</div>');
-        }
-        if (block.type === 'tool_use') {
-          fragments.push('<div style="background:var(--surface);border:1px solid var(--border);padding:4px 8px;border-radius:4px;margin:2px 0;font-size:10px;color:var(--muted);cursor:pointer" onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display===\'none\'?\'block\':\'none\'">' +
-            '\u{1F527} ' + escHtml(block.name || 'tool') + '</div>' +
-            '<div style="display:none;background:var(--bg);padding:4px 8px;border-radius:4px;margin:0 0 4px;font-size:10px;font-family:monospace;white-space:pre-wrap;max-height:200px;overflow-y:auto;color:var(--muted)">' + escHtml(JSON.stringify(block.input || {}, null, 2).slice(0, 500)) + '</div>');
-        }
-      }
-    }
-    if (obj.type === 'tool_result' || (obj.type === 'user' && obj.message?.content?.[0]?.type === 'tool_result')) {
-      const content = obj.message?.content?.[0]?.content || obj.content || '';
-      const text = typeof content === 'string' ? content : JSON.stringify(content);
-      if (text.length > 10) {
-        fragments.push('<div style="background:var(--bg);border-left:2px solid var(--border);padding:2px 8px;margin:0 0 2px 16px;font-size:9px;font-family:monospace;color:var(--muted);max-height:100px;overflow-y:auto;white-space:pre-wrap;cursor:pointer" onclick="this.style.maxHeight=this.style.maxHeight===\'100px\'?\'none\':\'100px\'">' + escHtml(text.slice(0, 1000)) + (text.length > 1000 ? '...' : '') + '</div>');
-      }
-    }
-    if (obj.type === 'result') {
-      fragments.push('<div style="background:rgba(63,185,80,0.1);border:1px solid var(--green);padding:8px 12px;border-radius:8px;margin:8px 0;font-size:12px;color:var(--green)">\u2713 Task complete</div>');
-    }
-  }
-
-  const lines = raw.split('\n');
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-
-    if (trimmed.startsWith('[human-steering]')) {
-      const msg = trimmed.replace('[human-steering] ', '');
-      fragments.push('<div style="align-self:flex-end;background:var(--blue);color:#fff;padding:6px 12px;border-radius:12px 12px 2px 12px;max-width:80%;margin:4px 0;font-size:12px">' + escHtml(msg) +
-        '<div style="font-size:9px;opacity:0.7;margin-top:2px">\u2713 Queued</div></div>');
-      continue;
-    }
-    if (trimmed.startsWith('[heartbeat]')) continue;
-    if (trimmed.startsWith('[steering-failed]')) {
-      const msg = trimmed.replace('[steering-failed] ', '');
-      fragments.push('<div style="background:rgba(248,81,73,0.1);border:1px solid var(--red);color:var(--red);padding:6px 12px;border-radius:8px;margin:4px 0;font-size:11px">\u26A0 ' + escHtml(msg) + '</div>');
-      continue;
-    }
-    if (trimmed.startsWith('[')) {
-      try {
-        const arr = JSON.parse(trimmed);
-        if (Array.isArray(arr)) { for (const obj of arr) renderJsonObj(obj); continue; }
-      } catch { /* fall through */ }
-    }
-    if (trimmed.startsWith('{')) {
-      try { renderJsonObj(JSON.parse(trimmed)); continue; } catch { /* fall through */ }
-    }
-    if (trimmed.startsWith('[stderr]')) {
-      fragments.push('<div style="font-size:9px;color:var(--red);font-family:monospace;padding:1px 4px">' + escHtml(trimmed) + '</div>');
-    } else {
-      fragments.push('<div style="font-size:10px;color:var(--muted);font-family:monospace;padding:1px 4px">' + escHtml(trimmed) + '</div>');
-    }
-  }
-
-  if (fragments.length > 0) el.innerHTML += fragments.join('');
+  const html = renderAgentOutput(raw);
+  if (html) el.insertAdjacentHTML('beforeend', html);
 
   // Auto-scroll
   if (el.scrollHeight - el.scrollTop - el.clientHeight < 150) {
@@ -162,8 +100,8 @@ async function sendSteering() {
   // Immediate feedback — show the message right away
   const el = document.getElementById('live-messages');
   if (el) {
-    el.innerHTML += '<div style="align-self:flex-end;background:var(--blue);color:#fff;padding:6px 12px;border-radius:12px 12px 2px 12px;max-width:80%;margin:4px 0;font-size:12px">' + escHtml(message) +
-      '<div id="steer-pending" style="font-size:9px;opacity:0.7;margin-top:2px">\u2197 Sending...</div></div>';
+    el.insertAdjacentHTML('beforeend', '<div style="align-self:flex-end;background:var(--blue);color:#fff;padding:6px 12px;border-radius:12px 12px 2px 12px;max-width:80%;margin:4px 0;font-size:12px">' + escHtml(message) +
+      '<div id="steer-pending" style="font-size:9px;opacity:0.7;margin-top:2px">\u2197 Sending...</div></div>');
     el.scrollTop = el.scrollHeight;
   }
   showToast('cmd-toast', 'Steering message sent to ' + currentAgentId, true);

--- a/dashboard/js/render-utils.js
+++ b/dashboard/js/render-utils.js
@@ -1,0 +1,174 @@
+// dashboard/js/render-utils.js — Shared formatting helpers for agent output rendering
+// Depends on: escHtml() and renderMd() from utils.js (loaded before this file)
+
+/**
+ * Returns a one-line human-readable summary for a Claude tool call.
+ * @param {string} name - Tool name (e.g. 'Bash', 'Read', 'Edit')
+ * @param {object} input - Tool input object
+ * @returns {string} Human-readable summary (HTML-escaped)
+ */
+function formatToolSummary(name, input) {
+  var inp = input || {};
+  switch (name) {
+    case 'Bash': {
+      var cmd = String(inp.command || '');
+      if (cmd.length > 80) cmd = cmd.slice(0, 77) + '...';
+      return '$ ' + escHtml(cmd);
+    }
+    case 'Read':
+      return 'Reading ' + escHtml(inp.file_path || '');
+    case 'Edit':
+      return 'Editing ' + escHtml(inp.file_path || '');
+    case 'Write':
+      return 'Writing ' + escHtml(inp.file_path || '');
+    case 'Grep': {
+      var pat = escHtml(inp.pattern || '');
+      var gPath = escHtml(inp.path || '.');
+      return 'Searching `' + pat + '` in ' + gPath;
+    }
+    case 'Glob':
+      return 'Glob ' + escHtml(inp.pattern || '');
+    case 'Agent':
+      return 'Spawning agent: ' + escHtml(inp.description || '');
+    case 'WebFetch':
+      return 'Fetch ' + escHtml(inp.url || '');
+    case 'WebSearch':
+      return 'Search "' + escHtml(inp.query || '') + '"';
+    case 'TodoWrite': {
+      var items = Array.isArray(inp.todos) ? inp.todos : [];
+      return 'Update todos (' + items.length + ' items)';
+    }
+    default: {
+      var keys = Object.keys(inp);
+      if (keys.length === 0) return escHtml(name) + '()';
+      var firstKey = keys[0];
+      var firstVal = String(inp[firstKey] || '');
+      if (firstVal.length > 40) firstVal = firstVal.slice(0, 37) + '...';
+      return escHtml(name) + '(' + escHtml(firstKey) + ': ' + escHtml(firstVal) + ')';
+    }
+  }
+}
+
+/**
+ * Internal helper: renders a single parsed JSON object into an HTML fragment.
+ * @param {object} obj - Parsed JSON object from agent JSONL output
+ * @returns {string} HTML fragment
+ */
+function _renderJsonObj(obj) {
+  var parts = [];
+
+  if (obj.type === 'assistant' && obj.message && obj.message.content) {
+    var content = obj.message.content;
+    for (var i = 0; i < content.length; i++) {
+      var block = content[i];
+      if (block.type === 'thinking') {
+        parts.push('<div style="font-size:10px;color:var(--muted);padding:2px 8px;font-style:italic">\u{1F4AD} Thinking...</div>');
+      }
+      if (block.type === 'text' && block.text) {
+        parts.push('<div style="display:flex;align-items:baseline;gap:6px;margin:4px 0">' +
+          '<span style="color:var(--muted);font-size:10px;flex-shrink:0">&#9679;</span>' +
+          '<div style="background:var(--surface2);padding:8px 12px;border-radius:12px 12px 12px 2px;max-width:90%;font-size:12px;word-break:break-word">' + renderMd(block.text) + '</div>' +
+          '</div>');
+      }
+      if (block.type === 'tool_use') {
+        var summary = formatToolSummary(block.name || 'tool', block.input || {});
+        var rawJson = escHtml(JSON.stringify(block.input || {}, null, 2).slice(0, 500));
+        parts.push(
+          '<div style="display:flex;align-items:center;gap:4px;margin:2px 0;font-size:10px;color:var(--muted);font-family:monospace">' +
+            '<span style="flex-shrink:0">&#9679;</span>' +
+            '<span>' + summary + '</span>' +
+            '<span style="cursor:pointer;opacity:0.6;margin-left:4px" onclick="var t=this.parentElement.nextElementSibling;t.style.display=t.style.display===\'none\'?\'block\':\'none\';this.textContent=t.style.display===\'none\'?\'[+]\':\'[-]\'">[+]</span>' +
+          '</div>' +
+          '<div style="display:none;background:var(--bg);padding:4px 8px;border-radius:4px;margin:0 0 4px 16px;font-size:10px;font-family:monospace;white-space:pre-wrap;max-height:200px;overflow-y:auto;color:var(--muted)">' + rawJson + '</div>'
+        );
+      }
+    }
+  }
+
+  if (obj.type === 'tool_result' || (obj.type === 'user' && obj.message && obj.message.content && obj.message.content[0] && obj.message.content[0].type === 'tool_result')) {
+    var tc = (obj.message && obj.message.content && obj.message.content[0] && obj.message.content[0].content) || obj.content || '';
+    var text = typeof tc === 'string' ? tc : JSON.stringify(tc);
+    if (text.length > 10) {
+      var truncated = text.length > 3000;
+      var displayText = truncated ? text.slice(0, 3000) + '...' : text;
+      parts.push('<div style="background:var(--surface);border-left:2px solid var(--border);padding:2px 8px;margin:0 0 2px 16px;font-size:9px;font-family:monospace;color:var(--muted);max-height:160px;overflow-y:auto;white-space:pre-wrap;cursor:pointer" onclick="this.style.maxHeight=this.style.maxHeight===\'160px\'?\'none\':\'160px\'">' + escHtml(displayText) + '</div>');
+    }
+  }
+
+  if (obj.type === 'result') {
+    parts.push('<div style="background:rgba(63,185,80,0.1);border:1px solid var(--green);padding:8px 12px;border-radius:8px;margin:8px 0;font-size:12px;color:var(--green)">\u2713 Task complete</div>');
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Takes raw JSONL agent output text and returns an HTML string with formatted rendering.
+ * Parses JSON objects, tool summaries with ● prefix and [+] toggles for raw JSON,
+ * tool results with surface tint and 160px max-height, assistant text with ● prefix
+ * and markdown rendering, steering bubbles with ❯ prefix, completion indicator,
+ * stderr lines, and heartbeat filtering.
+ *
+ * @param {string} text - Raw JSONL agent output
+ * @returns {string} HTML string
+ */
+function renderAgentOutput(text) {
+  if (!text) return '';
+  var fragments = [];
+  var lines = text.split('\n');
+
+  for (var i = 0; i < lines.length; i++) {
+    var trimmed = lines[i].trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Heartbeat — filter out
+    if (trimmed.startsWith('[heartbeat]')) continue;
+
+    // Human steering
+    if (trimmed.startsWith('[human-steering]')) {
+      var msg = trimmed.replace('[human-steering] ', '');
+      fragments.push('<div style="align-self:flex-end;background:var(--blue);color:#fff;padding:6px 12px;border-radius:12px 12px 2px 12px;max-width:80%;margin:4px 0;font-size:12px">' +
+        '<span style="margin-right:4px">❯</span>' + escHtml(msg) +
+        '<div style="font-size:9px;opacity:0.7;margin-top:2px">\u2713 Queued</div></div>');
+      continue;
+    }
+
+    // Steering failed
+    if (trimmed.startsWith('[steering-failed]')) {
+      var failMsg = trimmed.replace('[steering-failed] ', '');
+      fragments.push('<div style="background:rgba(248,81,73,0.1);border:1px solid var(--red);color:var(--red);padding:6px 12px;border-radius:8px;margin:4px 0;font-size:11px">\u26A0 ' + escHtml(failMsg) + '</div>');
+      continue;
+    }
+
+    // JSON array line
+    if (trimmed.startsWith('[')) {
+      try {
+        var arr = JSON.parse(trimmed);
+        if (Array.isArray(arr)) {
+          for (var j = 0; j < arr.length; j++) fragments.push(_renderJsonObj(arr[j]));
+          continue;
+        }
+      } catch (e) { /* fall through */ }
+    }
+
+    // JSON object line
+    if (trimmed.startsWith('{')) {
+      try {
+        fragments.push(_renderJsonObj(JSON.parse(trimmed)));
+        continue;
+      } catch (e) { /* fall through */ }
+    }
+
+    // Stderr
+    if (trimmed.startsWith('[stderr]')) {
+      fragments.push('<div style="font-size:9px;color:var(--red);font-family:monospace;padding:1px 4px">' + escHtml(trimmed) + '</div>');
+    } else {
+      // Plain text fallback
+      fragments.push('<div style="font-size:10px;color:var(--muted);font-family:monospace;padding:1px 4px">' + escHtml(trimmed) + '</div>');
+    }
+  }
+
+  return fragments.join('');
+}
+
+window.MinionsRenderUtils = { formatToolSummary, renderAgentOutput };

--- a/dashboard/js/render-work-items.js
+++ b/dashboard/js/render-work-items.js
@@ -509,12 +509,12 @@ function viewAgentOutput(logPath) {
   document.getElementById('modal-title').textContent = 'Agent Output';
   document.getElementById('modal-body').innerHTML = '<p style="color:var(--muted)">Loading...</p>';
   document.getElementById('modal-body').style.fontFamily = 'Consolas, monospace';
-  document.getElementById('modal-body').style.whiteSpace = 'pre-wrap';
+  document.getElementById('modal-body').style.whiteSpace = 'normal';
   document.getElementById('modal').classList.add('open');
   fetch('/api/agent-output?file=' + encodeURIComponent(logPath))
     .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); })
     .then(function(content) {
-      document.getElementById('modal-body').textContent = content;
+      document.getElementById('modal-body').innerHTML = renderAgentOutput(content);
     })
     .catch(function() {
       document.getElementById('modal-body').innerHTML = '<p style="color:var(--red)">Failed to load output.</p>';

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -17297,6 +17297,68 @@ async function testRenderUtils() {
     const html = renderAgentOutput(JSON.stringify(arr));
     assert.ok(html.includes('Array item'), 'JSON array items should render');
   });
+
+  // ─── P-a1d7e9b3: command-center.js tool input capture & formatted summaries ──
+  console.log('\n── P-a1d7e9b3: command-center.js tool input capture & formatted summaries ──');
+
+  const ccSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'command-center.js'), 'utf8');
+  const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  await test('CC SSE tool handler stores { name, input } objects, not plain strings', () => {
+    // The push should use an object with name and input, not just evt.name
+    assert.ok(ccSrc.includes('toolsUsed.push({') || ccSrc.includes('toolsUsed.push({ '),
+      'toolsUsed.push should push an object, not a plain string');
+    assert.ok(!ccSrc.match(/toolsUsed\.push\(evt\.name\)/),
+      'Should not push plain evt.name — must push object with name and input');
+  });
+
+  await test('CC updateStreamDiv uses formatToolSummary for tool display', () => {
+    assert.ok(ccSrc.includes('formatToolSummary('),
+      'updateStreamDiv should use formatToolSummary for formatted tool display');
+    // Should not use the old 🔧 emoji pattern for tool display in updateStreamDiv
+    const updateStreamSection = ccSrc.slice(ccSrc.indexOf('function updateStreamDiv'));
+    assert.ok(!updateStreamSection.includes('\\uD83D\\uDD27') || !updateStreamSection.includes('🔧'),
+      'updateStreamDiv should not use old wrench emoji pattern');
+  });
+
+  await test('CC _restoreStreamHtml uses formatToolSummary for tool display', () => {
+    const restoreSection = ccSrc.slice(ccSrc.indexOf('_restoreStreamHtml'));
+    assert.ok(restoreSection.includes('formatToolSummary('),
+      '_restoreStreamHtml should use formatToolSummary for formatted tool display');
+  });
+
+  await test('CC tool display uses ● prefix (not 🔧)', () => {
+    // Both updateStreamDiv and _restoreStreamHtml should use ● prefix
+    assert.ok(ccSrc.includes('&#9679;') || ccSrc.includes('●'),
+      'Tool display should use ● (bullet) prefix');
+  });
+
+  await test('CC SSE tool handler captures evt.input', () => {
+    // The push should reference evt.input
+    assert.ok(ccSrc.includes('evt.input'),
+      'SSE tool handler should capture evt.input from the server event');
+  });
+
+  await test('Server SSE tool event sends input as object, not flat string', () => {
+    // The onToolUse handler should use _lightToolInput to send a structured object
+    // It should NOT just JSON.stringify(input).slice(0, 200) as a flat string
+    assert.ok(dashSrc.includes('_lightToolInput'),
+      'dashboard.js should have _lightToolInput helper for structured input');
+    // All onToolUse handlers should use the helper
+    const toolEventMatches = dashSrc.match(/onToolUse:.*?\n/g);
+    assert.ok(toolEventMatches && toolEventMatches.length >= 2,
+      'dashboard.js should have at least 2 onToolUse handlers (primary + retry)');
+    const allUseLightInput = toolEventMatches.every(m => m.includes('_lightToolInput') || dashSrc.slice(dashSrc.indexOf(m), dashSrc.indexOf(m) + 200).includes('_lightToolInput'));
+    assert.ok(dashSrc.includes('Object.entries'),
+      '_lightToolInput should use Object.entries to iterate input fields');
+  });
+
+  await test('CC tool display uses monospace style matching live output', () => {
+    // The tool display should use font-family:monospace like render-utils.js does
+    const updateSection = ccSrc.slice(ccSrc.indexOf('function updateStreamDiv'), ccSrc.indexOf('function updateStreamDiv') + 1500);
+    assert.ok(updateSection.includes('monospace') || updateSection.includes('font-family'),
+      'Tool display should use monospace font style');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -17394,6 +17394,52 @@ async function testRenderUtils() {
     assert.ok(outputSection.includes('class="section"') || outputSection.includes("class=\\'section\\'"),
       'Output Log content must be wrapped in a section container');
   });
+
+  // ─── P-e2a6c8d4: render-work-items.js output viewer uses renderAgentOutput ──
+  console.log('\n── P-e2a6c8d4: render-work-items.js output viewer uses renderAgentOutput ──');
+
+  const wiSrcForOutput = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-work-items.js'), 'utf8');
+
+  await test('viewAgentOutput uses renderAgentOutput instead of textContent', () => {
+    const fnMatch = wiSrcForOutput.match(/function viewAgentOutput[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'viewAgentOutput function must exist');
+    assert.ok(fnMatch[0].includes('renderAgentOutput'),
+      'viewAgentOutput must use renderAgentOutput for formatted JSONL rendering');
+    assert.ok(!fnMatch[0].includes('.textContent = content'),
+      'viewAgentOutput must NOT use textContent for raw text dump — should use renderAgentOutput');
+  });
+
+  await test('viewAgentOutput sets innerHTML (not textContent) for formatted output', () => {
+    const fnMatch = wiSrcForOutput.match(/function viewAgentOutput[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'viewAgentOutput function must exist');
+    assert.ok(fnMatch[0].includes('.innerHTML'),
+      'viewAgentOutput must use innerHTML to render formatted HTML from renderAgentOutput');
+  });
+
+  await test('viewAgentOutput does not set whiteSpace to pre-wrap (conflicts with HTML block rendering)', () => {
+    const fnMatch = wiSrcForOutput.match(/function viewAgentOutput[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'viewAgentOutput function must exist');
+    assert.ok(!fnMatch[0].includes("whiteSpace = 'pre-wrap'") && !fnMatch[0].includes('whiteSpace = "pre-wrap"'),
+      'viewAgentOutput must not set whiteSpace to pre-wrap — renderAgentOutput returns HTML with block-level divs');
+  });
+
+  await test('viewAgentOutput preserves loading and error states', () => {
+    const fnMatch = wiSrcForOutput.match(/function viewAgentOutput[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'viewAgentOutput function must exist');
+    assert.ok(fnMatch[0].includes('Loading'),
+      'viewAgentOutput must show loading state');
+    assert.ok(fnMatch[0].includes('.catch'),
+      'viewAgentOutput must have error handler');
+    assert.ok(fnMatch[0].includes('Failed to load'),
+      'viewAgentOutput must show error state on failure');
+  });
+
+  await test('viewAgentOutput preserves Consolas font family', () => {
+    const fnMatch = wiSrcForOutput.match(/function viewAgentOutput[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'viewAgentOutput function must exist');
+    assert.ok(fnMatch[0].includes('Consolas'),
+      'viewAgentOutput must keep Consolas font family for the modal');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7314,13 +7314,14 @@ async function testDashboardUIFunctions() {
   });
 
   await test('live chat renders human steering as blue bubbles', () => {
-    assert.ok(liveSrc.includes('[human-steering]') && liveSrc.includes('var(--blue)'),
-      'Should render human steering messages as right-aligned blue bubbles');
+    // Steering rendering is in sendSteering (immediate feedback) and renderAgentOutput (render-utils.js)
+    assert.ok(liveSrc.includes('var(--blue)'),
+      'sendSteering should render steering messages as blue bubbles');
   });
 
-  await test('live chat renders tool calls as collapsible blocks', () => {
-    assert.ok(liveSrc.includes('tool_use') && liveSrc.includes('display:none'),
-      'Should render tool calls as collapsible blocks');
+  await test('live chat delegates rendering to renderAgentOutput from render-utils.js', () => {
+    assert.ok(liveSrc.includes('renderAgentOutput'),
+      'renderLiveChatMessage should call renderAgentOutput from render-utils.js');
   });
 
   await test('sendSteering function exists', () => {
@@ -10355,21 +10356,31 @@ async function testDashboardBugFixes() {
       'Should handle zero-byte or missing log file');
   });
 
-  await test('live-stream.js renderLiveChatMessage parses all output formats', () => {
+  await test('live-stream.js renderLiveChatMessage delegates to renderAgentOutput', () => {
     const liveSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'live-stream.js'), 'utf8');
-    assert.ok(liveSrc.includes('"type":"assistant"') || liveSrc.includes("type === 'assistant'"),
+    assert.ok(liveSrc.includes('renderAgentOutput'),
+      'renderLiveChatMessage should delegate JSONL parsing to renderAgentOutput from render-utils.js');
+    assert.ok(!liveSrc.includes('innerHTML +='),
+      'live-stream.js must not use innerHTML += (CLAUDE.md violation) — use insertAdjacentHTML');
+    assert.ok(liveSrc.includes('insertAdjacentHTML'),
+      'Should use insertAdjacentHTML for DOM insertion');
+  });
+
+  await test('render-utils.js renderAgentOutput parses all output formats', () => {
+    const renderUtilsSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-utils.js'), 'utf8');
+    assert.ok(renderUtilsSrc.includes("type === 'assistant'") || renderUtilsSrc.includes("obj.type === 'assistant'"),
       'Should parse assistant messages from stream-json');
-    assert.ok(liveSrc.includes('"tool_use"') || liveSrc.includes("type === 'tool_use'"),
+    assert.ok(renderUtilsSrc.includes("'tool_use'") || renderUtilsSrc.includes('"tool_use"'),
       'Should parse tool_use blocks');
-    assert.ok(liveSrc.includes('[human-steering]'),
+    assert.ok(renderUtilsSrc.includes('[human-steering]'),
       'Should render human steering messages');
-    assert.ok(liveSrc.includes('[heartbeat]'),
+    assert.ok(renderUtilsSrc.includes('[heartbeat]'),
       'Should handle heartbeat lines');
-    assert.ok(liveSrc.includes('[steering-failed]') || liveSrc.includes('steering-failed'),
+    assert.ok(renderUtilsSrc.includes('[steering-failed]') || renderUtilsSrc.includes('steering-failed'),
       'Should handle steering failure notices');
-    assert.ok(liveSrc.includes('startsWith(\'{\')') || liveSrc.includes('startsWith("{")'),
+    assert.ok(renderUtilsSrc.includes('startsWith(\'{\')') || renderUtilsSrc.includes('startsWith("{")'),
       'Should parse single JSON objects (stream-json format)');
-    assert.ok(liveSrc.includes('startsWith(\'[\')') || liveSrc.includes('startsWith("[")'),
+    assert.ok(renderUtilsSrc.includes('startsWith(\'[\')') || renderUtilsSrc.includes('startsWith("[")'),
       'Should parse JSON arrays (json format)');
   });
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -17359,6 +17359,41 @@ async function testRenderUtils() {
     assert.ok(updateSection.includes('monospace') || updateSection.includes('font-family'),
       'Tool display should use monospace font style');
   });
+
+  // ─── P-d9c3b5f7: detail-panel.js Output Log tab uses renderAgentOutput ──
+  console.log('\n── P-d9c3b5f7: detail-panel.js Output Log tab uses renderAgentOutput ──');
+
+  const detailPanelSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'detail-panel.js'), 'utf8');
+
+  await test('Output Log tab uses renderAgentOutput instead of renderMd', () => {
+    // Extract the output tab branch from renderDetailContent
+    const fnMatch = detailPanelSrc.match(/function renderDetailContent[\s\S]*?^}/m);
+    assert.ok(fnMatch, 'renderDetailContent must exist');
+    // Find the output tab handler section
+    const outputTabIdx = fnMatch[0].indexOf("tab === 'output'");
+    assert.ok(outputTabIdx > -1, 'Output tab handler must exist in renderDetailContent');
+    const outputSection = fnMatch[0].slice(outputTabIdx, outputTabIdx + 300);
+    assert.ok(outputSection.includes('renderAgentOutput'),
+      'Output Log tab must use renderAgentOutput for formatted JSONL rendering');
+    assert.ok(!outputSection.includes('renderMd(detail.outputLog'),
+      'Output Log tab must NOT use renderMd for outputLog — should use renderAgentOutput');
+  });
+
+  await test('Output Log tab preserves fallback message when outputLog is falsy', () => {
+    const fnMatch = detailPanelSrc.match(/function renderDetailContent[\s\S]*?^}/m);
+    const outputTabIdx = fnMatch[0].indexOf("tab === 'output'");
+    const outputSection = fnMatch[0].slice(outputTabIdx, outputTabIdx + 400);
+    assert.ok(outputSection.includes('No output log'),
+      'Output Log tab must show fallback text when outputLog is empty');
+  });
+
+  await test('Output Log tab wraps output in section container', () => {
+    const fnMatch = detailPanelSrc.match(/function renderDetailContent[\s\S]*?^}/m);
+    const outputTabIdx = fnMatch[0].indexOf("tab === 'output'");
+    const outputSection = fnMatch[0].slice(outputTabIdx, outputTabIdx + 400);
+    assert.ok(outputSection.includes('class="section"') || outputSection.includes("class=\\'section\\'"),
+      'Output Log content must be wrapped in a section container');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9433,6 +9433,9 @@ async function main() {
     // W-mnxu9bvzkc5p: Doc-chat badge visibility on Notes/KB items
     await testDocChatBadgeVisibility();
 
+    // P-b7e3a1d9: render-utils.js shared formatting helpers
+    await testRenderUtils();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -17029,4 +17032,260 @@ async function testDocChatBadgeVisibility() {
       'Must have CSS rule .notes-preview > .notif-badge for badge position override (notes-preview has overflow-y:auto)');
   });
 }
+// ─── P-b7e3a1d9: render-utils.js shared formatting helpers ──────────────────
+
+async function testRenderUtils() {
+  console.log('\n── render-utils.js: formatToolSummary + renderAgentOutput ──');
+
+  const renderUtilsPath = path.join(MINIONS_DIR, 'dashboard', 'js', 'render-utils.js');
+
+  await test('render-utils.js file exists', () => {
+    assert.ok(fs.existsSync(renderUtilsPath), 'dashboard/js/render-utils.js must exist');
+  });
+
+  const src = fs.readFileSync(renderUtilsPath, 'utf8');
+
+  // ── Source structure assertions ──
+
+  await test('render-utils.js defines formatToolSummary function', () => {
+    assert.ok(src.includes('function formatToolSummary'), 'formatToolSummary must be defined');
+  });
+
+  await test('render-utils.js defines renderAgentOutput function', () => {
+    assert.ok(src.includes('function renderAgentOutput'), 'renderAgentOutput must be defined');
+  });
+
+  await test('render-utils.js exposes functions on window', () => {
+    assert.ok(src.includes('window.') || src.includes('window['), 'must expose helpers on window');
+  });
+
+  // ── Registration in dashboard.js ──
+
+  await test('render-utils.js is registered in dashboard.js jsFiles before detail-panel and live-stream', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const jsFilesMatch = dashSrc.match(/const jsFiles\s*=\s*\[([\s\S]*?)\]/);
+    assert.ok(jsFilesMatch, 'jsFiles array must exist in dashboard.js');
+    const items = jsFilesMatch[1];
+    const renderUtilsIdx = items.indexOf("'render-utils'");
+    const detailPanelIdx = items.indexOf("'detail-panel'");
+    const liveStreamIdx = items.indexOf("'live-stream'");
+    assert.ok(renderUtilsIdx > -1, 'render-utils must be in jsFiles array');
+    assert.ok(renderUtilsIdx < detailPanelIdx, 'render-utils must appear before detail-panel');
+    assert.ok(renderUtilsIdx < liveStreamIdx, 'render-utils must appear before live-stream');
+  });
+
+  // ── Behavioral tests: extract and run formatToolSummary ──
+
+  const utilsSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'utils.js'), 'utf8');
+  const escHtmlBody = utilsSrc.match(/function escHtml[\s\S]*?^}/m)[0];
+  const formatFnMatch = src.match(/function formatToolSummary[\s\S]*?^}/m);
+  assert.ok(formatFnMatch, 'formatToolSummary function must be extractable');
+  const formatToolSummary = new Function(escHtmlBody + '\n' + formatFnMatch[0] + '\nreturn formatToolSummary;')();
+
+  await test('formatToolSummary: Bash tool shows truncated command', () => {
+    const result = formatToolSummary('Bash', { command: 'npm test --verbose --all' });
+    assert.ok(result.includes('$'), 'Bash summary should include $ prefix');
+    assert.ok(result.includes('npm test'), 'Bash summary should include command text');
+  });
+
+  await test('formatToolSummary: Bash truncates long commands to 80 chars', () => {
+    const longCmd = 'a'.repeat(120);
+    const result = formatToolSummary('Bash', { command: longCmd });
+    assert.ok(result.length < 120, 'Should truncate long commands');
+  });
+
+  await test('formatToolSummary: Read tool shows file path', () => {
+    const result = formatToolSummary('Read', { file_path: '/src/engine.js' });
+    assert.ok(result.includes('Reading'), 'Read summary should say Reading');
+    assert.ok(result.includes('/src/engine.js'), 'Read summary should include file path');
+  });
+
+  await test('formatToolSummary: Edit tool shows file path', () => {
+    const result = formatToolSummary('Edit', { file_path: '/src/shared.js' });
+    assert.ok(result.includes('Editing'), 'Edit summary should say Editing');
+    assert.ok(result.includes('/src/shared.js'), 'Edit summary should include file path');
+  });
+
+  await test('formatToolSummary: Write tool shows file path', () => {
+    const result = formatToolSummary('Write', { file_path: '/src/new-file.js' });
+    assert.ok(result.includes('Writing'), 'Write summary should say Writing');
+    assert.ok(result.includes('/src/new-file.js'), 'Write summary should include file path');
+  });
+
+  await test('formatToolSummary: Grep tool shows pattern and path', () => {
+    const result = formatToolSummary('Grep', { pattern: 'TODO', path: 'src/' });
+    assert.ok(result.includes('Searching'), 'Grep summary should say Searching');
+    assert.ok(result.includes('TODO'), 'Grep summary should include pattern');
+    assert.ok(result.includes('src/'), 'Grep summary should include path');
+  });
+
+  await test('formatToolSummary: Glob tool shows pattern', () => {
+    const result = formatToolSummary('Glob', { pattern: '**/*.js' });
+    assert.ok(result.includes('Glob'), 'Glob summary should say Glob');
+    assert.ok(result.includes('**/*.js'), 'Glob summary should include pattern');
+  });
+
+  await test('formatToolSummary: Agent tool shows description', () => {
+    const result = formatToolSummary('Agent', { description: 'Search for config files' });
+    assert.ok(result.includes('Spawning agent'), 'Agent summary should say Spawning agent');
+    assert.ok(result.includes('Search for config files'), 'Agent summary should include description');
+  });
+
+  await test('formatToolSummary: WebFetch tool shows url', () => {
+    const result = formatToolSummary('WebFetch', { url: 'https://example.com/api' });
+    assert.ok(result.includes('Fetch'), 'WebFetch summary should say Fetch');
+    assert.ok(result.includes('https://example.com/api'), 'WebFetch summary should include url');
+  });
+
+  await test('formatToolSummary: WebSearch tool shows query', () => {
+    const result = formatToolSummary('WebSearch', { query: 'node.js async patterns' });
+    assert.ok(result.includes('Search'), 'WebSearch summary should say Search');
+    assert.ok(result.includes('node.js async patterns'), 'WebSearch summary should include query');
+  });
+
+  await test('formatToolSummary: TodoWrite tool shows item count', () => {
+    const result = formatToolSummary('TodoWrite', { todos: [{ task: 'a' }, { task: 'b' }, { task: 'c' }] });
+    assert.ok(result.includes('Update todos'), 'TodoWrite summary should say Update todos');
+    assert.ok(result.includes('3'), 'TodoWrite summary should show count');
+  });
+
+  await test('formatToolSummary: unknown tool falls back to name(firstKey: firstVal)', () => {
+    const result = formatToolSummary('CustomTool', { foo: 'bar value here' });
+    assert.ok(result.includes('CustomTool'), 'Fallback should include tool name');
+    assert.ok(result.includes('foo'), 'Fallback should include first key');
+    assert.ok(result.includes('bar value'), 'Fallback should include first value');
+  });
+
+  await test('formatToolSummary: fallback truncates long values to 40 chars', () => {
+    const longVal = 'x'.repeat(80);
+    const result = formatToolSummary('CustomTool', { key: longVal });
+    assert.ok(result.length < 100, 'Fallback should truncate long values');
+  });
+
+  await test('formatToolSummary: handles null/undefined input gracefully', () => {
+    const result = formatToolSummary('Bash', null);
+    assert.ok(typeof result === 'string', 'Should return string even with null input');
+    const result2 = formatToolSummary('Bash', undefined);
+    assert.ok(typeof result2 === 'string', 'Should return string even with undefined input');
+  });
+
+  // ── Behavioral tests: extract and run renderAgentOutput ──
+
+  // We need escHtml and renderMd for renderAgentOutput
+  const normBody = utilsSrc.match(/function _normalizeCodeFences[\s\S]*?^}/m)[0];
+  const coreBody = utilsSrc.match(/function _renderMdCore[\s\S]*?^}/m)[0];
+  const renderMdBody = utilsSrc.match(/function renderMd[\s\S]*?^}/m)[0];
+  // renderAgentOutput needs formatToolSummary + escHtml + renderMd
+  const renderFnMatch = src.match(/function renderAgentOutput[\s\S]*?^}/m);
+  assert.ok(renderFnMatch, 'renderAgentOutput function must be extractable');
+  // Also extract any helper used within renderAgentOutput (like _renderJsonObj if it exists)
+  const helperMatch = src.match(/function _renderJsonObj[\s\S]*?^}/m);
+  const helperBody = helperMatch ? helperMatch[0] : '';
+  const renderAgentOutput = new Function(
+    escHtmlBody + '\n' + normBody + '\n' + coreBody + '\n' + renderMdBody + '\n' +
+    formatFnMatch[0] + '\n' + helperBody + '\n' + renderFnMatch[0] + '\nreturn renderAgentOutput;'
+  )();
+
+  await test('renderAgentOutput: returns string', () => {
+    const html = renderAgentOutput('some text');
+    assert.ok(typeof html === 'string', 'renderAgentOutput must return a string');
+  });
+
+  await test('renderAgentOutput: handles empty input', () => {
+    const html = renderAgentOutput('');
+    assert.ok(typeof html === 'string', 'Should handle empty string');
+  });
+
+  await test('renderAgentOutput: parses assistant text with ● prefix', () => {
+    const jsonl = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello world' }] } });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('●') || html.includes('&#9679;'), 'Assistant text should have ● prefix');
+    assert.ok(html.includes('Hello world'), 'Assistant text should be rendered');
+  });
+
+  await test('renderAgentOutput: parses tool_use with ● prefix and formatToolSummary', () => {
+    const jsonl = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/foo.js' } }] } });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('●') || html.includes('&#9679;'), 'Tool use should have ● prefix');
+    assert.ok(html.includes('Reading'), 'Tool use should show formatted summary');
+    assert.ok(html.includes('/foo.js'), 'Tool use should include file path');
+  });
+
+  await test('renderAgentOutput: tool_use has [+] toggle for raw JSON', () => {
+    const jsonl = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'npm test' } }] } });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('[+]'), 'Tool use should have [+] toggle');
+    assert.ok(html.includes('display:none') || html.includes('display: none'), 'Raw JSON should be hidden by default');
+  });
+
+  await test('renderAgentOutput: tool_result with surface tint and 160px max-height', () => {
+    const jsonl = JSON.stringify({ type: 'tool_result', message: { content: [{ type: 'tool_result', content: 'some result text here that is long enough' }] } });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('160px') || html.includes('max-height'), 'Tool result should have 160px max-height');
+    assert.ok(html.includes('surface'), 'Tool result should have surface background tint');
+  });
+
+  await test('renderAgentOutput: tool_result enforces 3000 char truncation', () => {
+    const longContent = 'x'.repeat(5000);
+    const jsonl = JSON.stringify({ type: 'tool_result', message: { content: [{ type: 'tool_result', content: longContent }] } });
+    const html = renderAgentOutput(jsonl);
+    // The rendered content shouldn't contain the full 5000 chars
+    assert.ok(!html.includes('x'.repeat(4000)), 'Tool result should truncate at 3000 chars');
+    assert.ok(html.includes('...'), 'Truncated tool result should show ellipsis');
+  });
+
+  await test('renderAgentOutput: steering bubble has ❯ prefix', () => {
+    const text = '[human-steering] please check the tests';
+    const html = renderAgentOutput(text);
+    assert.ok(html.includes('❯') || html.includes('&#10095;'), 'Steering bubble should have ❯ prefix');
+    assert.ok(html.includes('please check the tests'), 'Steering message should be visible');
+  });
+
+  await test('renderAgentOutput: result type shows completion indicator', () => {
+    const jsonl = JSON.stringify({ type: 'result' });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('✓') || html.includes('&#10003;') || html.includes('complete'), 'Result should show completion indicator');
+  });
+
+  await test('renderAgentOutput: stderr lines shown in red', () => {
+    const text = '[stderr] Error: something failed';
+    const html = renderAgentOutput(text);
+    assert.ok(html.includes('red'), 'Stderr should be styled red');
+    assert.ok(html.includes('Error: something failed'), 'Stderr content should be visible');
+  });
+
+  await test('renderAgentOutput: heartbeat lines are filtered out', () => {
+    const text = '[heartbeat] ping\n' + JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Hello' }] } });
+    const html = renderAgentOutput(text);
+    assert.ok(!html.includes('[heartbeat]'), 'Heartbeat lines should be filtered out');
+    assert.ok(html.includes('Hello'), 'Non-heartbeat content should still render');
+  });
+
+  await test('renderAgentOutput: thinking blocks are rendered', () => {
+    const jsonl = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'thinking' }] } });
+    const html = renderAgentOutput(jsonl);
+    assert.ok(html.includes('Thinking'), 'Thinking block should be rendered');
+  });
+
+  await test('renderAgentOutput: steering-failed lines are rendered', () => {
+    const text = '[steering-failed] Connection lost';
+    const html = renderAgentOutput(text);
+    assert.ok(html.includes('Connection lost'), 'Steering-failed message should be visible');
+  });
+
+  await test('renderAgentOutput: handles multi-line JSONL correctly', () => {
+    const line1 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Line one' }] } });
+    const line2 = JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'Line two' }] } });
+    const html = renderAgentOutput(line1 + '\n' + line2);
+    assert.ok(html.includes('Line one'), 'First line should render');
+    assert.ok(html.includes('Line two'), 'Second line should render');
+  });
+
+  await test('renderAgentOutput: handles JSON array lines', () => {
+    const arr = [{ type: 'assistant', message: { content: [{ type: 'text', text: 'Array item' }] } }];
+    const html = renderAgentOutput(JSON.stringify(arr));
+    assert.ok(html.includes('Array item'), 'JSON array items should render');
+  });
+}
+
 main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- **New `render-utils.js`** with two shared helpers: `formatToolSummary(name, input)` for one-line tool summaries (10 tool types + fallback) and `renderAgentOutput(text)` for parsing JSONL agent output into formatted HTML
- **Refactored `live-stream.js`** to delegate JSONL parsing to `renderAgentOutput`, eliminating 70 lines of inline parsing. Fixed `innerHTML +=` violations (now uses `insertAdjacentHTML`)
- **Updated `command-center.js`** to capture tool inputs during SSE streaming and display formatted summaries via `formatToolSummary` instead of bare tool names
- **Updated `detail-panel.js`** Output Log tab to use `renderAgentOutput` instead of raw markdown rendering of JSONL
- **Updated `render-work-items.js`** output viewer modal to use `renderAgentOutput` for formatted output display

## What changed

| File | Change |
|------|--------|
| `dashboard/js/render-utils.js` | New file — `formatToolSummary()` + `renderAgentOutput()` shared helpers |
| `dashboard/js/live-stream.js` | Thin wrapper over `renderAgentOutput`, `insertAdjacentHTML` instead of `innerHTML +=` |
| `dashboard/js/command-center.js` | SSE tool events capture `{name, input}` objects, display via `formatToolSummary` |
| `dashboard/js/detail-panel.js` | Output Log tab uses `renderAgentOutput` |
| `dashboard/js/render-work-items.js` | View Output modal uses `renderAgentOutput` |
| `dashboard.js` | Register `render-utils` in jsFiles (after state, before detail-panel) + SSE tool input forwarding |
| `test/unit.test.js` | ~430 lines of new tests covering all helpers and refactored behavior |

## Visual improvements

- Tool calls show as `● Reading /src/engine.js` instead of `🔧 Read`
- Raw JSON accessible via `[+]` toggle on each tool line
- Tool results: `var(--surface)` background, 160px max-height, 3000 char limit (was 1000)
- Assistant text: `●` prefix for visual scan differentiation
- Steering bubbles: `❯` prefix
- Consistent rendering across live view, Output Log tab, CC panel, and View Output modal

## Test plan

- [x] All 1743 unit tests pass (1 pre-existing unrelated failure)
- [x] `formatToolSummary` tested for all 10 tool types + fallback + edge cases
- [x] `renderAgentOutput` tested for all JSONL message types (assistant, tool_use, tool_result, result, steering, stderr, heartbeat filtering)
- [x] Source structure tests verify file exists, functions exposed on `window`, load order in `dashboard.js`
- [ ] Manual: verify live agent output renders correctly in dashboard
- [ ] Manual: verify CC streaming shows formatted tool summaries
- [ ] Manual: verify Output Log tab and View Output modal show formatted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)