### PR TITLE
fix(W-mnywbse3jz13): cancel steering kill watcher on resume spawn

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1051,8 +1051,12 @@ async function spawnAgent(dispatchItem, config) {
         return;
       }
 
-      // Re-attach to existing tracking
-      activeProcesses.set(id, { proc: resumeProc, agentId, startedAt: procInfo.startedAt, sessionId: steerSessionId, _steeringAt: Date.now(), lastRealOutputAt: Date.now() });
+      // Re-attach to existing tracking — do NOT carry _steeringAt forward (#1052).
+      // The kill watcher in timeout.js fires 30s after _steeringAt is set. If we carry it
+      // into the resumed process, it kills the resumed session. The kill watcher only exists
+      // to handle cases where the original kill didn't take effect — once the process has
+      // exited and the resume is spawned, _steeringAt must not be present.
+      activeProcesses.set(id, { proc: resumeProc, agentId, startedAt: procInfo.startedAt, sessionId: steerSessionId, lastRealOutputAt: Date.now() });
 
       // Reset output buffers so post-completion parsing only sees the resumed session
       stdout = '';

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7154,6 +7154,34 @@ async function testAgentSteering() {
       'spawn-agent should close stdin after writing prompt');
   });
 
+  // ── Steering kill watcher cancellation on resume (#1052) ───────────────────
+
+  await test('resumed process tracking does NOT carry _steeringAt (#1052)', () => {
+    // Bug: when the engine re-attaches after a successful steering resume spawn,
+    // it sets _steeringAt: Date.now() on the new tracking object. This causes
+    // checkSteering's 30s kill watcher to fire against the resumed session.
+    // Fix: the re-attached tracking must NOT have _steeringAt.
+    const resumeAttachLine = engineSrc.match(/activeProcesses\.set\(id,\s*\{[^}]*proc:\s*resumeProc[^}]*\}/);
+    assert.ok(resumeAttachLine, 'Should find activeProcesses.set for resumed process');
+    assert.ok(!resumeAttachLine[0].includes('_steeringAt'),
+      'Resumed process tracking must NOT include _steeringAt — kill watcher must not fire against resumed session');
+  });
+
+  await test('checkSteering kill watcher only fires when _steeringAt is set (#1052)', () => {
+    const timeoutSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'timeout.js'), 'utf8');
+    // The kill watcher guard: info._steeringAt must be truthy for kill to fire
+    assert.ok(timeoutSrc.includes('info._steeringAt && Date.now()'),
+      'Kill watcher must check _steeringAt before computing elapsed time');
+  });
+
+  await test('checkSteering skip guard prevents double-steering on resumed process (#1052)', () => {
+    const timeoutSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'timeout.js'), 'utf8');
+    // Without _steeringAt on the resumed process, the skip guard (line 80) won't block
+    // new steering, which is correct — a resumed process should be steerable again.
+    assert.ok(timeoutSrc.includes('_steeringMessage || info._steeringAt'),
+      'Skip guard should check both _steeringMessage and _steeringAt');
+  });
+
   // Functional test: checkSteering with mock activeProcesses
   await test('checkSteering functional: finds steer.md and sets flags', () => {
     const restore = createTestMinionsDir();


### PR DESCRIPTION
## Summary

- **Bug**: The 30s kill watcher in `checkSteering` (timeout.js) was not cancelled when the `--resume` process was successfully spawned. The re-attach line in `engine.js:1055` set `_steeringAt: Date.now()` on the new tracking object, causing the watcher to fire 30s later — killing the resumed session and marking the task as error.
- **Fix**: Removed `_steeringAt` from the re-attached tracking object for the resumed process. The kill watcher only exists to handle cases where the original kill didn't take effect. Once the old process has exited and the resume is spawned, `_steeringAt` must not be present.
- **Tests**: Added 3 regression tests verifying that resumed process tracking does not carry `_steeringAt`, and that the kill watcher/skip guard logic remains correct.

Closes #1052

## Test plan

- [x] 3 new unit tests pass (`#1052` tag)
- [x] Full test suite: 1848 passed, 1 failed (pre-existing, unrelated)
- [ ] Manual: steer a running agent, confirm resumed session is NOT killed after 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)