### PR TITLE
feat(W-mnywbx9wa1yf): surface in-flight tool calls in lastAction

### DIFF
--- a/engine/queries.js
+++ b/engine/queries.js
@@ -42,6 +42,34 @@ function readHeadTail(filePath, bytes = 1024) {
   }
 }
 
+/**
+ * Detect in-flight tool calls from live-output.log tail content.
+ * Scans for task_started events with no matching task_notification (by task_id).
+ * Returns { description, taskId } for the most recent in-flight tool, or null.
+ */
+function detectInFlightTool(tail) {
+  if (!tail) return null;
+  const lines = tail.split('\n');
+  const completed = new Set();
+
+  // Reverse scan: collect task_notification ids first (most recent lines),
+  // then the first task_started not in completed is the in-flight tool.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line.includes('"task_')) continue; // fast skip non-task lines
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed.type !== 'system') continue;
+      if (parsed.subtype === 'task_notification') {
+        completed.add(parsed.task_id);
+      } else if (parsed.subtype === 'task_started' && !completed.has(parsed.task_id)) {
+        return { description: parsed.description || null, taskId: parsed.task_id };
+      }
+    } catch { /* not valid JSON — skip heartbeats, headers, partial lines */ }
+  }
+  return null;
+}
+
 // ── Paths ───────────────────────────────────────────────────────────────────
 
 const MINIONS_DIR = shared.MINIONS_DIR;
@@ -220,7 +248,7 @@ function getAgentStatus(agentId) {
     if (active._blockingToolCall) {
       result._blockingToolCall = active._blockingToolCall;
     }
-    // Detect permission-waiting: read only head+tail of live-output.log (max 2KB total)
+    // Detect permission-waiting and in-flight tools: read only head+tail of live-output.log (max 2KB total)
     try {
       const liveLogPath = path.join(AGENTS_DIR, agentId, 'live-output.log');
       const { head, tail } = readHeadTail(liveLogPath, 1024);
@@ -238,6 +266,11 @@ function getAgentStatus(agentId) {
           if (silentMs > 60000 && result._permissionMode) {
             result._warning = 'Possibly waiting for permission approval — agent is not in bypass mode';
           }
+        }
+        // Detect in-flight tool calls (task_started with no task_notification)
+        const inFlight = detectInFlightTool(tail);
+        if (inFlight && inFlight.description) {
+          result._runningToolDescription = inFlight.description;
         }
       }
     } catch { /* optional — don't block status */ }
@@ -328,7 +361,7 @@ function getAgents(config) {
     const s = getAgentStatus(a.id); // derives from dispatch.json
 
     let lastAction = 'Waiting for assignment';
-    if (s.status === 'working') lastAction = `Working: ${s.task}`;
+    if (s.status === 'working') lastAction = s._runningToolDescription ? `Running: ${s._runningToolDescription}` : `Working: ${s.task}`;
     else if (s.status === 'done') lastAction = `Done: ${s.task}`;
     else if (s.status === 'error') lastAction = `Error: ${s.task}`;
     else if (inboxFiles.length > 0) {
@@ -1033,6 +1066,7 @@ module.exports = {
   // Helpers
   timeSince,
   readHeadTail, // exported for testing
+  detectInFlightTool, // exported for testing
   resetPrdInfoCache,
 
   // Core state

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -799,6 +799,82 @@ async function testQueriesAgents() {
     assert.ok(!src.includes('safeRead(path.join(AGENTS_DIR, agentId, \'live-output.log\'))'),
       'getAgentStatus should NOT use safeRead for live-output.log');
   });
+
+  // ── detectInFlightTool ──
+
+  await test('detectInFlightTool returns null for empty input', () => {
+    assert.strictEqual(queries.detectInFlightTool(''), null);
+    assert.strictEqual(queries.detectInFlightTool(null), null);
+    assert.strictEqual(queries.detectInFlightTool(undefined), null);
+  });
+
+  await test('detectInFlightTool returns description for in-flight task_started', () => {
+    const tail = [
+      '{"type":"system","subtype":"task_started","task_id":"abc123","description":"Run unit tests","task_type":"local_bash"}',
+    ].join('\n');
+    const result = queries.detectInFlightTool(tail);
+    assert.ok(result, 'should detect in-flight tool');
+    assert.strictEqual(result.description, 'Run unit tests');
+    assert.strictEqual(result.taskId, 'abc123');
+  });
+
+  await test('detectInFlightTool returns null when task_started has matching task_notification', () => {
+    const tail = [
+      '{"type":"system","subtype":"task_started","task_id":"abc123","description":"Run unit tests","task_type":"local_bash"}',
+      '{"type":"system","subtype":"task_notification","task_id":"abc123","status":"completed","summary":"Run unit tests"}',
+    ].join('\n');
+    const result = queries.detectInFlightTool(tail);
+    assert.strictEqual(result, null, 'completed tool should not be detected as in-flight');
+  });
+
+  await test('detectInFlightTool detects in-flight tool after a completed one', () => {
+    const tail = [
+      '{"type":"system","subtype":"task_started","task_id":"task1","description":"First task","task_type":"local_bash"}',
+      '{"type":"system","subtype":"task_notification","task_id":"task1","status":"completed","summary":"First task"}',
+      '{"type":"system","subtype":"task_started","task_id":"task2","description":"Second task still running","task_type":"local_bash"}',
+    ].join('\n');
+    const result = queries.detectInFlightTool(tail);
+    assert.ok(result, 'should detect second task as in-flight');
+    assert.strictEqual(result.description, 'Second task still running');
+    assert.strictEqual(result.taskId, 'task2');
+  });
+
+  await test('detectInFlightTool ignores non-JSON lines (heartbeats, headers)', () => {
+    const tail = [
+      '# Live output for dallas',
+      '[heartbeat] running — no output for 60s',
+      '{"type":"system","subtype":"task_started","task_id":"x1","description":"Building project","task_type":"local_bash"}',
+      '[heartbeat] running — no output for 120s',
+    ].join('\n');
+    const result = queries.detectInFlightTool(tail);
+    assert.ok(result, 'should detect in-flight tool despite non-JSON lines');
+    assert.strictEqual(result.description, 'Building project');
+  });
+
+  await test('detectInFlightTool returns null when only task_notification present (task_started outside tail)', () => {
+    const tail = [
+      '{"type":"system","subtype":"task_notification","task_id":"old1","status":"completed","summary":"Old task"}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"Done"}]}}',
+    ].join('\n');
+    const result = queries.detectInFlightTool(tail);
+    assert.strictEqual(result, null, 'should return null when only notifications present');
+  });
+
+  await test('getAgentStatus surfaces _runningToolDescription from live-output.log', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
+    assert.ok(src.includes('detectInFlightTool'),
+      'getAgentStatus should call detectInFlightTool');
+    assert.ok(src.includes('_runningToolDescription'),
+      'getAgentStatus should set _runningToolDescription');
+  });
+
+  await test('getAgents uses _runningToolDescription for lastAction when available', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'queries.js'), 'utf8');
+    assert.ok(src.includes('Running:'),
+      'getAgents should use "Running:" prefix for in-flight tool descriptions');
+    assert.ok(src.includes('_runningToolDescription'),
+      'getAgents should check _runningToolDescription for lastAction');
+  });
 }
 
 async function testQueriesWorkItems() {


### PR DESCRIPTION
## Summary
- When an agent waits for a long-running tool call (Bash, Agent, etc.), `lastAction` now shows `Running: <description>` instead of going silent with just `Working: <task>`
- Adds `detectInFlightTool()` helper that parses `task_started`/`task_notification` events from the live-output.log tail to find unmatched in-flight tools
- Integrates into `getAgentStatus()` → `_runningToolDescription` field → `getAgents()` → `lastAction`

## Test plan
- [x] 6 unit tests for `detectInFlightTool()` covering: empty input, in-flight detection, matched pairs, sequential tasks, non-JSON lines, orphaned notifications
- [x] 2 integration tests verifying `getAgentStatus` and `getAgents` wire up the new field
- [x] All 1853 tests pass (1 pre-existing failure unrelated)

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)