### PR TITLE
fix(W-mnyxt1ofcv1y): defer setCooldown to post-gating in discoverWork

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1981,7 +1981,7 @@ async function discoverFromPrs(config, project) {
         pr_id: pr.id, pr_number: prNumber, pr_title: pr.title || '', pr_branch: pr.branch || '',
         pr_author: pr.agent || '', pr_url: pr.url || '',
       }, `Review ${pr.id}: ${pr.title}`, { dispatchKey: key, source: 'pr', pr, branch: pr.branch, project: projMeta });
-      if (item) { newWork.push(item); setCooldown(key); }
+      if (item) { newWork.push(item); }
     }
 
     // PRs with changes requested → route back to author for fix
@@ -1997,7 +1997,7 @@ async function discoverFromPrs(config, project) {
         review_note: pr.minionsReview?.note || pr.reviewNote || 'See PR thread comments',
       }, `Fix ${pr.id}: ${pr.title || ''} — review feedback`, { dispatchKey: key, source: 'pr', pr, branch: pr.branch, project: projMeta });
       if (item) {
-        newWork.push(item); setCooldown(key); fixDispatched = true;
+        newWork.push(item); fixDispatched = true;
         // Increment review→fix cycle counter
         try {
           mutatePullRequests(projectPrPath(project), prs => {
@@ -2035,7 +2035,7 @@ async function discoverFromPrs(config, project) {
         reviewer: 'Human Reviewer',
         review_note: reviewNote,
       }, `Fix ${pr.id}: ${pr.title || ''} — human feedback`, { dispatchKey: key, source: 'pr-human-feedback', pr, branch: pr.branch, project: projMeta });
-      if (item) { newWork.push(item); setCooldown(key); fixDispatched = true; }
+      if (item) { newWork.push(item); fixDispatched = true; }
     }
 
     // PRs with build failures — route to author (has session context from implementing)
@@ -2084,7 +2084,7 @@ async function discoverFromPrs(config, project) {
         review_note: reviewNote,
       }, `Fix build failure on ${pr.id}: ${pr.title || ''}`, { dispatchKey: key, source: 'pr', pr, branch: pr.branch, project: projMeta });
       if (item) {
-        newWork.push(item); setCooldown(key);
+        newWork.push(item);
         // Increment build fix attempts counter
         try {
           const prPath = projectPrPath(project);
@@ -2141,7 +2141,6 @@ async function discoverFromPrs(config, project) {
           }, `Fix merge conflicts on ${pr.id}: ${pr.title || ''}`, { dispatchKey: key, source: 'pr', pr, branch: pr.branch, project: projMeta });
           if (item) {
             newWork.push(item);
-            setCooldown(key);
             // Record dispatch timestamp so re-dispatch is suppressed during ADO lag window
             try {
               mutatePullRequests(projectPrPath(project), prs => {
@@ -3042,6 +3041,7 @@ async function discoverWork(config) {
 
   for (const item of allWork) {
     addToDispatch(item);
+    if (item.meta?.dispatchKey) setCooldown(item.meta.dispatchKey);
     if (item.meta?.source === 'pr-human-feedback') {
       clearPendingHumanFeedbackFlag(item.meta.project, item.meta.pr?.id);
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4572,6 +4572,38 @@ async function testBuildFixRetryCap() {
       'Should reference DEFAULTS.maxBuildFixAttempts for the cap');
   });
 
+  // ─── Cooldown deferred to post-gating (#setCooldown-gating) ─────────────
+
+  await test('discoverFromPrs does NOT call setCooldown for review items', () => {
+    // Extract only the discoverFromPrs function body (ends where discoverFromWorkItems begins)
+    const fnStart = engineSrc.indexOf('async function discoverFromPrs(');
+    const fnEnd = engineSrc.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = engineSrc.slice(fnStart, fnEnd);
+    // setCooldown should not appear in discoverFromPrs — it is deferred to discoverWork post-gating
+    assert.ok(!fnBody.includes('setCooldown(key)'),
+      'discoverFromPrs must NOT call setCooldown(key) — cooldown must be deferred to post-gating in discoverWork');
+  });
+
+  await test('discoverWork calls setCooldown after gating check via dispatchKey', () => {
+    const fnStart = engineSrc.indexOf('async function discoverWork(');
+    const fnBody = engineSrc.slice(fnStart);
+    // The post-gating dispatch loop should call setCooldown using item.meta.dispatchKey
+    assert.ok(fnBody.includes('setCooldown(item.meta') || fnBody.includes('setCooldown(item.meta?.dispatchKey)') || fnBody.includes("setCooldown(item.meta.dispatchKey)"),
+      'discoverWork post-gating loop must call setCooldown using item.meta.dispatchKey');
+  });
+
+  await test('setCooldown for gated reviews/fixes is not set when gated', () => {
+    // Verify that when items are gated (allReviews = [], allFixes = []),
+    // they don't end up in allWork, so setCooldown is never called for them
+    const fnStart = engineSrc.indexOf('async function discoverWork(');
+    const fnBody = engineSrc.slice(fnStart);
+    // The gating check clears allReviews and allFixes BEFORE the dispatch loop
+    const gateIdx = fnBody.indexOf('allReviews = []');
+    const dispatchLoopIdx = fnBody.indexOf('for (const item of allWork)');
+    assert.ok(gateIdx > -1 && dispatchLoopIdx > -1 && gateIdx < dispatchLoopIdx,
+      'Gating (allReviews = []) must happen BEFORE the dispatch loop where setCooldown is called');
+  });
+
   await test('ado.js resets buildFixAttempts when build passes', () => {
     assert.ok(adoSrc.includes('delete pr.buildFixAttempts'),
       'ADO poll should clear buildFixAttempts when build status recovers');


### PR DESCRIPTION
## Summary

- **Bug**: `setCooldown(key)` was called at item-build time in `discoverFromPrs()`, before the gating check in `discoverWork()` could clear `allReviews`/`allFixes`. PRs discovered during a gating period had their 30-min cooldown set even though no review/fix was dispatched — blocking re-discovery for 30 minutes after the gate lifted.
- **Fix**: Removed all `setCooldown(key)` calls from `discoverFromPrs()` (5 locations: review, changes-requested fix, human-feedback fix, build-failure fix, merge-conflict fix). Added a single `setCooldown` call in the post-gating dispatch loop in `discoverWork()`, using `item.meta.dispatchKey`.
- **Tests**: 3 new tests verify (1) `discoverFromPrs` no longer calls `setCooldown(key)`, (2) `discoverWork` calls it via `dispatchKey` post-gating, (3) gating clears reviews/fixes before the dispatch loop.

## Files changed

- `engine.js` — removed 5 `setCooldown(key)` calls from `discoverFromPrs`, added 1 in `discoverWork` post-gating loop
- `test/unit.test.js` — 3 new tests for cooldown-gating correctness

## Build & test

```bash
npm test   # 1853 passed, 1 failed (pre-existing), 2 skipped
```

## Test plan

- [x] Verify `setCooldown` is not called in `discoverFromPrs` function body
- [x] Verify `setCooldown` is called in `discoverWork` after gating check
- [x] Verify gated items (allReviews=[], allFixes=[]) never reach `setCooldown`
- [x] Verify `setCooldownWithContext` for feedback coalescing is unaffected
- [x] Verify work-item and central-work-item cooldowns are unaffected

Built by Minions (Dallas — Engineer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)