### PR TITLE
fix(W-mnzuhp2dapvn): link scheduled task notes back to originating item

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -394,7 +394,13 @@ function getStatus() {
     schedules: (() => {
       const scheds = CONFIG.schedules || [];
       const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
-      return scheds.map(s => ({ ...s, _lastRun: runs[s.id] || null }));
+      return scheds.map(s => {
+        const runEntry = runs[s.id];
+        // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
+        const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
+        const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
+        return { ...s, _lastRun, ...extra };
+      });
     })(),
     meetings: (() => { try { return require('./engine/meeting').getMeetings(); } catch { return []; } })(),
     pipelines: (() => { try { const pl = require('./engine/pipeline'); return pl.getPipelines().map(p => ({ ...p, runs: (pl.getPipelineRuns()[p.id] || []).slice(-5) })); } catch { return []; } })(),
@@ -3652,7 +3658,13 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     reloadConfig();
     const schedules = CONFIG.schedules || [];
     const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
-    const result = schedules.map(s => ({ ...s, _lastRun: runs[s.id] || null }));
+    const result = schedules.map(s => {
+      const runEntry = runs[s.id];
+      // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
+      const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
+      const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
+      return { ...s, _lastRun, ...extra };
+    });
     return jsonReply(res, 200, { schedules: result });
   }
 

--- a/engine/lifecycle.js
+++ b/engine/lifecycle.js
@@ -1712,6 +1712,37 @@ async function runPostCompletionHooks(dispatchItem, agentId, code, stdout, confi
 
   // Archive is manual — user archives plans from the dashboard when ready
 
+  // Scheduled task back-reference: update schedule-runs.json and write linked inbox note
+  if (meta?.item?._scheduleId) {
+    try {
+      const scheduleId = meta.item._scheduleId;
+      const itemId = meta.item.id;
+      const schedRunsPath = path.join(ENGINE_DIR, 'schedule-runs.json');
+      mutateJsonFileLocked(schedRunsPath, (runs) => {
+        runs[scheduleId] = {
+          lastRun: typeof runs[scheduleId] === 'string' ? runs[scheduleId] : (runs[scheduleId]?.lastRun || ts()),
+          lastWorkItemId: itemId,
+          lastResult: effectiveSuccess ? DISPATCH_RESULT.SUCCESS : DISPATCH_RESULT.ERROR,
+          lastCompletedAt: ts(),
+        };
+        return runs;
+      }, { defaultValue: {} });
+      // Write a completion note to inbox with back-references
+      const noteSlug = `sched-completion-${scheduleId}`;
+      const status = effectiveSuccess ? 'succeeded' : 'failed';
+      const noteContent = `# Scheduled Task ${status}: ${meta.item.title || scheduleId}\n\n` +
+        `**Schedule:** \`${scheduleId}\`\n` +
+        `**Work Item:** \`${itemId}\`\n` +
+        `**Result:** ${status}\n` +
+        (resultSummary ? `\n## Summary\n${resultSummary}\n` : '');
+      shared.writeToInbox('engine', noteSlug, noteContent, null, {
+        sourceItem: itemId,
+        scheduleId,
+      });
+      log('info', `Scheduled task ${scheduleId} (${itemId}) → ${status}, back-reference written`);
+    } catch (err) { log('warn', `Scheduled task back-reference: ${err.message}`); }
+  }
+
   // Clean up worktree for non-shared-branch tasks after completion
   if (meta?.branch && meta?.branchStrategy !== 'shared-branch') {
     try {

--- a/engine/scheduler.js
+++ b/engine/scheduler.js
@@ -116,7 +116,9 @@ function discoverScheduledWork(config) {
       if (!sched.id || !sched.cron || !sched.title) continue;
       if (!sched.enabled) continue; // truthy check — matches dashboard UI badge behavior
 
-      const lastRun = runs[sched.id] || null;
+      // Backward compat: runs[sched.id] can be a string (old format) or object (new format)
+      const runEntry = runs[sched.id] || null;
+      const lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || null);
       if (!shouldRunNow(sched, lastRun)) continue;
 
       work.push({
@@ -133,8 +135,9 @@ function discoverScheduledWork(config) {
         _scheduleId: sched.id,
       });
 
-      // Record run time inside the lock
-      runs[sched.id] = ts();
+      // Record run time inside the lock — preserve existing fields (lastWorkItemId, lastResult, etc.)
+      const existing = typeof runs[sched.id] === 'object' && runs[sched.id] ? runs[sched.id] : {};
+      runs[sched.id] = { ...existing, lastRun: ts() };
     }
   }, { defaultValue: {} });
 

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -295,18 +295,22 @@ function parseNoteId(content) {
   return m ? m[1] : null;
 }
 
-function writeToInbox(agentId, slug, content, _inboxDir) {
+function writeToInbox(agentId, slug, content, _inboxDir, metadata) {
   try {
     const inboxDir = _inboxDir || path.join(MINIONS_DIR, 'notes', 'inbox');
     const prefix = `${agentId}-${slug}-${dateStamp()}`;
     const existing = safeReadDir(inboxDir).find(f => f.startsWith(prefix));
     if (existing) return false;
     const noteId = `NOTE-${uid()}`;
+    // Build optional metadata lines for frontmatter injection
+    const metaLines = (metadata && typeof metadata === 'object')
+      ? Object.entries(metadata).filter(([, v]) => v != null).map(([k, v]) => `${k}: ${v}`).join('\n')
+      : '';
     // Inject structured ID as YAML frontmatter if content doesn't already have it
     const hasFrontmatter = /^\s*---[\r\n]/.test(content);
     const tagged = hasFrontmatter
-      ? content.replace(/^\s*---[\r\n]+/, `---\nid: ${noteId}\n`)
-      : `---\nid: ${noteId}\nagent: ${agentId}\ndate: ${dateStamp()}\n---\n\n${content}`;
+      ? content.replace(/^\s*---[\r\n]+/, `---\nid: ${noteId}\n${metaLines ? metaLines + '\n' : ''}`)
+      : `---\nid: ${noteId}\nagent: ${agentId}\ndate: ${dateStamp()}\n${metaLines ? metaLines + '\n' : ''}---\n\n${content}`;
     const filePath = path.join(inboxDir, `${prefix}.md`);
     safeWrite(filePath, tagged);
     return noteId;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9438,6 +9438,9 @@ async function main() {
     // P-h2t6r1j8: Structured completion protocol
     await testStructuredCompletion();
 
+    // W-mnzuhp2dapvn: Scheduled task note back-reference
+    await testScheduledTaskNoteBackReference();
+
     // Auto-recovery & atomicity
     await testAutoRecoveryAndAtomicity();
 
@@ -18931,6 +18934,135 @@ async function testAzureauthTimeout() {
     assert.ok(src.includes('--timeout'), 'shared-rules.md should mention --timeout for azureauth');
     assert.ok(src.includes('azureauth') && src.includes('timeout'),
       'shared-rules.md should have explicit guidance about azureauth timeout');
+  });
+}
+
+// ─── W-mnzuhp2dapvn: Scheduled task note back-reference ──────────────────────
+
+async function testScheduledTaskNoteBackReference() {
+  console.log('\n── Scheduled task note back-reference ──');
+
+  // 1. writeToInbox accepts metadata parameter and injects into frontmatter
+  await test('writeToInbox injects metadata fields into frontmatter', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const noteId = shared.writeToInbox('engine', 'sched-result', '# Scheduled result', inboxDir, {
+      sourceItem: 'sched-daily-test-123',
+      scheduleId: 'daily-test-suite'
+    });
+    assert.ok(noteId && noteId.startsWith('NOTE-'), 'Should return note ID');
+    const files = fs.readdirSync(inboxDir);
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.ok(content.includes('sourceItem: sched-daily-test-123'), 'Frontmatter should include sourceItem');
+    assert.ok(content.includes('scheduleId: daily-test-suite'), 'Frontmatter should include scheduleId');
+    assert.ok(content.includes('id: ' + noteId), 'Frontmatter should include note ID');
+    assert.ok(content.includes('# Scheduled result'), 'Should include original content');
+  });
+
+  await test('writeToInbox metadata works with existing frontmatter', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const noteId = shared.writeToInbox('engine', 'sched-fm', '---\ntitle: Custom\n---\n\n# Body', inboxDir, {
+      sourceItem: 'WI-999'
+    });
+    assert.ok(noteId && noteId.startsWith('NOTE-'), 'Should return note ID');
+    const files = fs.readdirSync(inboxDir);
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.ok(content.includes('sourceItem: WI-999'), 'Should inject sourceItem into existing frontmatter');
+    assert.ok(content.includes('title: Custom'), 'Should preserve existing fields');
+  });
+
+  await test('writeToInbox without metadata still works (backward compat)', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const noteId = shared.writeToInbox('engine', 'no-meta', '# No metadata', inboxDir);
+    assert.ok(noteId && noteId.startsWith('NOTE-'), 'Should return note ID');
+    const files = fs.readdirSync(inboxDir);
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.ok(!content.includes('sourceItem'), 'Should not include sourceItem when no metadata');
+    assert.ok(!content.includes('scheduleId'), 'Should not include scheduleId when no metadata');
+  });
+
+  await test('writeToInbox ignores empty metadata object', () => {
+    const dir = createTmpDir();
+    const inboxDir = path.join(dir, 'inbox');
+    fs.mkdirSync(inboxDir, { recursive: true });
+    const noteId = shared.writeToInbox('engine', 'empty-meta', '# Empty', inboxDir, {});
+    assert.ok(noteId && noteId.startsWith('NOTE-'), 'Should return note ID');
+    const files = fs.readdirSync(inboxDir);
+    const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf8');
+    assert.ok(!content.includes('sourceItem'), 'Should not include sourceItem for empty metadata');
+  });
+
+  // 2. runPostCompletionHooks updates schedule-runs.json for scheduled tasks
+  await test('runPostCompletionHooks updates schedule-runs.json on scheduled task completion', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    // Find the runPostCompletionHooks function
+    const fn = src.slice(
+      src.indexOf('function runPostCompletionHooks('),
+      src.indexOf('\nfunction', src.indexOf('function runPostCompletionHooks(') + 1)
+    );
+    assert.ok(fn.includes('_scheduleId'), 'runPostCompletionHooks must check for _scheduleId on work items');
+    assert.ok(fn.includes('schedule-runs'), 'runPostCompletionHooks must update schedule-runs.json');
+    assert.ok(fn.includes('mutateJsonFileLocked'), 'schedule-runs update must use mutateJsonFileLocked');
+  });
+
+  await test('runPostCompletionHooks writes completion note for scheduled tasks with back-reference', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'lifecycle.js'), 'utf8');
+    const fn = src.slice(
+      src.indexOf('function runPostCompletionHooks('),
+      src.indexOf('\nfunction', src.indexOf('function runPostCompletionHooks(') + 1)
+    );
+    assert.ok(fn.includes('writeToInbox') && fn.includes('_scheduleId'),
+      'runPostCompletionHooks must write inbox note with schedule reference');
+    assert.ok(fn.includes('sourceItem') || fn.includes('scheduleId'),
+      'scheduled task inbox note must include sourceItem or scheduleId metadata');
+  });
+
+  // 3. Behavioral test: scheduled task completion updates schedule-runs with lastWorkItemId
+  await test('scheduled task completion records lastWorkItemId in schedule-runs.json', async () => {
+    const restore = createTestMinionsDir();
+    try {
+      const lifecycle = require('../engine/lifecycle');
+      const sq = require('../engine/shared');
+
+      // Write schedule-runs.json with initial run timestamp
+      const schedRunsPath = path.join(process.env.MINIONS_TEST_DIR, 'engine', 'schedule-runs.json');
+      sq.safeWrite(schedRunsPath, { 'daily-test': '2026-04-15T00:00:00Z' });
+
+      // Create a central work-items.json with a scheduled task work item
+      const centralWiPath = path.join(process.env.MINIONS_TEST_DIR, 'work-items.json');
+      sq.safeWrite(centralWiPath, [
+        { id: 'sched-daily-test-12345', title: 'Daily Test', type: 'test', status: 'dispatched',
+          _scheduleId: 'daily-test', created: '2026-04-15T00:00:00Z' }
+      ]);
+
+      const dispatchItem = {
+        id: 'dispatch-1',
+        type: 'test',
+        meta: {
+          item: { id: 'sched-daily-test-12345', _scheduleId: 'daily-test' },
+          project: null
+        }
+      };
+
+      await lifecycle.runPostCompletionHooks(dispatchItem, 'agent1', 0, 'Test passed: 100/100', { agents: {} });
+
+      // Verify schedule-runs.json was updated with lastWorkItemId
+      const runs = sq.safeJson(schedRunsPath);
+      assert.ok(runs['daily-test'], 'Schedule run entry should exist');
+      if (typeof runs['daily-test'] === 'object') {
+        assert.strictEqual(runs['daily-test'].lastWorkItemId, 'sched-daily-test-12345',
+          'Should record lastWorkItemId');
+        assert.ok(runs['daily-test'].lastResult, 'Should record lastResult');
+        assert.ok(runs['daily-test'].lastCompletedAt, 'Should record lastCompletedAt');
+      }
+    } finally {
+      restore();
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- **Bug:** Scheduled task completion notes written to inbox had no back-reference to the originating schedule or work item
- **Fix:** `writeToInbox` now accepts optional metadata (sourceItem, scheduleId) injected into frontmatter; `runPostCompletionHooks` updates `schedule-runs.json` with lastWorkItemId/lastResult/lastCompletedAt and writes a linked completion note
- **Backward compat:** `schedule-runs.json` entries upgraded from string to object format; all consumers (scheduler.js, dashboard.js) handle both formats

## Changes

| File | Change |
|------|--------|
| `engine/shared.js` | `writeToInbox` accepts 5th `metadata` param for frontmatter injection |
| `engine/lifecycle.js` | `runPostCompletionHooks` detects `_scheduleId` on completed items → updates schedule-runs.json + writes linked inbox note |
| `engine/scheduler.js` | Reads/writes schedule-runs.json in new object format; backward-compat for old string format |
| `dashboard.js` | Extracts `_lastRun` from both string and object schedule-runs entries; surfaces `_lastWorkItemId`, `_lastResult`, `_lastCompletedAt` |
| `test/unit.test.js` | 7 new tests (TDD): metadata injection, backward compat, source-code structural checks, behavioral test |

## Test plan

- [x] 7 new tests all pass (TDD — written before implementation)
- [x] 1435 total tests pass, 0 regressions (1 pre-existing failure unrelated)
- [ ] Verify scheduled task fires → completes → schedule-runs.json has object with lastWorkItemId
- [ ] Verify inbox note has sourceItem/scheduleId in frontmatter
- [ ] Verify dashboard schedule page still shows correct "last run" time

🤖 Generated with [Claude Code](https://claude.com/claude-code)