### PR TITLE
feat(W-mnzvsswlwk77): gate review auto-dispatch on adoPollEnabled and evalLoop config flags

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1898,6 +1898,13 @@ async function discoverFromPrs(config, project) {
 
   const projMeta = { name: project?.name, localPath: project?.localPath };
 
+  // Resolve poll-enabled per project — stale reviewStatus is untrustworthy without poller
+  const isAdoProject = project?.repoHost !== 'github';
+  const pollEnabled = isAdoProject
+    ? (config.engine?.adoPollEnabled ?? DEFAULTS.adoPollEnabled)
+    : (config.engine?.ghPollEnabled ?? DEFAULTS.ghPollEnabled);
+  const evalLoopEnabled = config.engine?.evalLoop !== false;
+
   // Collect active PR dispatches to prevent simultaneous review+fix on same PR
   const dispatch = getDispatch();
   const activePrIds = new Set(
@@ -1946,7 +1953,7 @@ async function discoverFromPrs(config, project) {
     }
 
     // PRs needing review: pending review status and not already reviewed without new commits
-    const autoReview = config.engine?.autoReview !== false;
+    const autoReview = config.engine?.autoReview !== false && pollEnabled;
     const alreadyReviewed = pr.lastReviewedAt && (!pr.lastPushedAt || pr.lastPushedAt <= pr.lastReviewedAt);
     const needsReview = autoReview && reviewStatus === 'pending' && !alreadyReviewed && !evalEscalated;
     if (needsReview) {
@@ -1972,7 +1979,7 @@ async function discoverFromPrs(config, project) {
           } catch {}
           continue;
         }
-      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message}`); }
+      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message} — skipping dispatch`); continue; }
 
       const agentId = resolveAgent('review', config);
       if (!agentId) continue;
@@ -1988,7 +1995,7 @@ async function discoverFromPrs(config, project) {
     // fallback — that caused infinite re-review loops on GitHub where self-approval is blocked)
     const fixedAfterReview = !!(pr.minionsReview?.fixedAt &&
       pr.lastReviewedAt && pr.minionsReview.fixedAt > pr.lastReviewedAt);
-    const needsReReview = autoReview && reviewStatus === 'waiting' &&
+    const needsReReview = autoReview && evalLoopEnabled && reviewStatus === 'waiting' &&
       fixedAfterReview && !evalEscalated;
     if (needsReReview) {
       const key = `review-${project?.name || 'default'}-${pr.id}`;
@@ -2013,7 +2020,7 @@ async function discoverFromPrs(config, project) {
           } catch {}
           continue;
         }
-      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message}`); }
+      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message} — skipping dispatch`); continue; }
 
       const agentId = resolveAgent('review', config);
       if (!agentId) continue;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4536,6 +4536,47 @@ async function testDiscoverFromPrs() {
     assert.ok(src.includes('fixedAfterReview && !evalEscalated'),
       'needsReReview should use fixedAfterReview directly (fixedAt > lastReviewedAt)');
   });
+
+  // ─── Poll-gated review dispatch (W-mnzvsswlwk77) ─────────────────────────
+
+  await test('discoverFromPrs gates autoReview on pollEnabled', () => {
+    // When adoPollEnabled:false (ADO) or ghPollEnabled:false (GitHub), reviewStatus is stale
+    // (never updated because polling is off). autoReview must be gated on pollEnabled.
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('pollEnabled'),
+      'discoverFromPrs must resolve pollEnabled per project');
+    assert.ok(fnBody.includes('autoReview') && fnBody.includes('pollEnabled'),
+      'autoReview must be gated on pollEnabled — stale reviewStatus is untrustworthy without poller');
+  });
+
+  await test('discoverFromPrs gates needsReReview on evalLoopEnabled', () => {
+    // evalLoop:false should suppress re-review cycles
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('evalLoopEnabled'),
+      'discoverFromPrs must read evalLoop config flag');
+    assert.ok(fnBody.includes('needsReReview') && fnBody.includes('evalLoopEnabled'),
+      'needsReReview must be gated on evalLoopEnabled — evalLoop:false suppresses re-review cycles');
+  });
+
+  await test('discoverFromPrs pre-dispatch live check catch blocks skip dispatch on error', () => {
+    // When pre-dispatch live ADO/GitHub check fails, must skip dispatch (continue) not fall through
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    // Both pre-dispatch catch blocks should have 'continue' — skipping dispatch on error
+    // Pattern: "skipping dispatch`); continue;" inside catch blocks after live vote checks
+    const skipPattern = /skipping dispatch.*continue/g;
+    const matches = fnBody.match(skipPattern) || [];
+    assert.ok(matches.length >= 2,
+      `Both pre-dispatch vote check catch blocks must skip dispatch (continue) on error (found ${matches.length})`);
+    // Also verify no catch blocks fall through without continue
+    assert.ok(!fnBody.includes("Pre-dispatch vote check for ${pr.id}: ${e.message}`); }"),
+      'No pre-dispatch catch block should fall through without continue');
+  });
 }
 
 // ─── Build Fix Retry Cap Tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Gate autoReview on pollEnabled**: When `adoPollEnabled:false` (ADO) or `ghPollEnabled:false` (GitHub), `reviewStatus` is stale since polling is disabled. `autoReview` now requires `pollEnabled` to be true, preventing dispatch based on stale vote data.
- **Gate needsReReview on evalLoopEnabled**: `evalLoop:false` now correctly suppresses re-review cycles by gating `needsReReview` on the config flag.
- **Pre-dispatch live check catch blocks skip dispatch**: Both pre-dispatch live vote check catch blocks now `continue` on error instead of falling through to dispatch, preventing review dispatch when the ADO/GitHub API is unreachable.

Closes #1091

## Test plan

- [x] 3 new source-code assertions in `testDiscoverFromPrs`
- [x] Full test suite: 1 pre-existing failure only (setCooldown in re-review block — unrelated)
- [ ] Manual: set `adoPollEnabled: false` → verify no review agents dispatched
- [ ] Manual: set `evalLoop: false` → verify no re-review cycles triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)