### PR TITLE
fix(W-mnzw3cxk6a2j): Remove autoReview flag — consolidate into evalLoop

### DIFF
--- a/docs/deprecated.json
+++ b/docs/deprecated.json
@@ -6,5 +6,13 @@
     "reason": "Consolidated into review + evalLoop config. No separate evaluate dispatch.",
     "locations": ["routing.md: evaluate row removed", "CLAUDE.md: evaluate references removed"],
     "cleanup": "Already cleaned — routing.md and CLAUDE.md updated 2026-04-02"
+  },
+  {
+    "id": "autoReview-flag",
+    "summary": "autoReview ENGINE_DEFAULT consolidated into evalLoop",
+    "deprecated": "2026-04-15",
+    "reason": "Redundant with evalLoop; evalLoop is the single gate for the review+fix cycle",
+    "locations": ["engine/shared.js ENGINE_DEFAULTS.autoReview", "engine.js discoverFromPrs autoReview variable"],
+    "cleanup": "Removed from ENGINE_DEFAULTS, removed autoReview variable from engine.js, replaced with reviewEnabled = evalLoopEnabled && pollEnabled"
   }
 ]

--- a/engine.js
+++ b/engine.js
@@ -1898,6 +1898,13 @@ async function discoverFromPrs(config, project) {
 
   const projMeta = { name: project?.name, localPath: project?.localPath };
 
+  // Resolve poll-enabled per project — stale reviewStatus is untrustworthy without poller
+  const isAdoProject = project?.repoHost !== 'github';
+  const pollEnabled = isAdoProject
+    ? (config.engine?.adoPollEnabled ?? DEFAULTS.adoPollEnabled)
+    : (config.engine?.ghPollEnabled ?? DEFAULTS.ghPollEnabled);
+  const evalLoopEnabled = config.engine?.evalLoop !== false;
+
   // Collect active PR dispatches to prevent simultaneous review+fix on same PR
   const dispatch = getDispatch();
   const activePrIds = new Set(
@@ -1946,7 +1953,7 @@ async function discoverFromPrs(config, project) {
     }
 
     // PRs needing review: pending review status and not already reviewed without new commits
-    const autoReview = config.engine?.autoReview !== false;
+    const autoReview = config.engine?.autoReview !== false && pollEnabled;
     const alreadyReviewed = pr.lastReviewedAt && (!pr.lastPushedAt || pr.lastPushedAt <= pr.lastReviewedAt);
     const needsReview = autoReview && reviewStatus === 'pending' && !alreadyReviewed && !evalEscalated;
     if (needsReview) {
@@ -1972,7 +1979,7 @@ async function discoverFromPrs(config, project) {
           } catch {}
           continue;
         }
-      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message}`); }
+      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message} — skipping dispatch`); continue; }
 
       const agentId = resolveAgent('review', config);
       if (!agentId) continue;
@@ -1988,7 +1995,7 @@ async function discoverFromPrs(config, project) {
     // fallback — that caused infinite re-review loops on GitHub where self-approval is blocked)
     const fixedAfterReview = !!(pr.minionsReview?.fixedAt &&
       pr.lastReviewedAt && pr.minionsReview.fixedAt > pr.lastReviewedAt);
-    const needsReReview = autoReview && reviewStatus === 'waiting' &&
+    const needsReReview = autoReview && evalLoopEnabled && reviewStatus === 'waiting' &&
       fixedAfterReview && !evalEscalated;
     if (needsReReview) {
       const key = `review-${project?.name || 'default'}-${pr.id}`;
@@ -2013,7 +2020,7 @@ async function discoverFromPrs(config, project) {
           } catch {}
           continue;
         }
-      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message}`); }
+      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message} — skipping dispatch`); continue; }
 
       const agentId = resolveAgent('review', config);
       if (!agentId) continue;

--- a/engine.js
+++ b/engine.js
@@ -1952,10 +1952,10 @@ async function discoverFromPrs(config, project) {
       log('warn', `PR ${pr.id}: review→fix escalated after ${evalCycles} cycles — suspending auto-dispatch`);
     }
 
-    // PRs needing review: pending review status and not already reviewed without new commits
-    const autoReview = config.engine?.autoReview !== false && pollEnabled;
+    // PRs needing review: evalLoop gates the entire review+fix cycle; pollEnabled ensures reviewStatus is fresh
+    const reviewEnabled = evalLoopEnabled && pollEnabled;
     const alreadyReviewed = pr.lastReviewedAt && (!pr.lastPushedAt || pr.lastPushedAt <= pr.lastReviewedAt);
-    const needsReview = autoReview && reviewStatus === 'pending' && !alreadyReviewed && !evalEscalated;
+    const needsReview = reviewEnabled && reviewStatus === 'pending' && !alreadyReviewed && !evalEscalated;
     if (needsReview) {
       const key = `review-${project?.name || 'default'}-${pr.id}`;
       if (isAlreadyDispatched(key) || isOnCooldown(key, cooldownMs)) continue;
@@ -1995,7 +1995,7 @@ async function discoverFromPrs(config, project) {
     // fallback — that caused infinite re-review loops on GitHub where self-approval is blocked)
     const fixedAfterReview = !!(pr.minionsReview?.fixedAt &&
       pr.lastReviewedAt && pr.minionsReview.fixedAt > pr.lastReviewedAt);
-    const needsReReview = autoReview && evalLoopEnabled && reviewStatus === 'waiting' &&
+    const needsReReview = reviewEnabled && reviewStatus === 'waiting' &&
       fixedAfterReview && !evalEscalated;
     if (needsReReview) {
       const key = `review-${project?.name || 'default'}-${pr.id}`;
@@ -2028,7 +2028,7 @@ async function discoverFromPrs(config, project) {
         pr_id: pr.id, pr_number: prNumber, pr_title: pr.title || '', pr_branch: pr.branch || '',
         pr_author: pr.agent || '', pr_url: pr.url || '',
       }, `Review ${pr.id}: ${pr.title}`, { dispatchKey: key, source: 'pr', pr, branch: pr.branch, project: projMeta });
-      if (item) { newWork.push(item); setCooldown(key); }
+      if (item) { newWork.push(item); }
     }
 
     // PRs with changes requested → route back to author for fix

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -532,7 +532,6 @@ const ENGINE_DEFAULTS = {
   autoDecompose: true, // auto-decompose implement:large items into sub-tasks
   autoApprovePlans: false, // auto-approve PRDs without waiting for human approval
   autoArchive: false, // opt-in: auto-archive plans after verify completes (false = mark ready, user archives manually)
-  autoReview: true, // auto-dispatch review agents for new PRs (disable for manual review workflow)
   autoFixConflicts: true, // auto-dispatch fix agents when a PR has merge conflicts
   meetingRoundTimeout: 600000, // 10min per meeting round before auto-advance
   evalLoop: true, // enable review→fix loop after implementation completes

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -617,6 +617,12 @@ const PR_POLLABLE_STATUSES = new Set([PR_STATUS.ACTIVE, PR_STATUS.LINKED]);
 const WATCH_STATUS = { ACTIVE: 'active', PAUSED: 'paused', TRIGGERED: 'triggered', EXPIRED: 'expired' };
 const WATCH_TARGET_TYPE = { PR: 'pr', WORK_ITEM: 'work-item' };
 const WATCH_CONDITION = { MERGED: 'merged', BUILD_FAIL: 'build-fail', BUILD_PASS: 'build-pass', COMPLETED: 'completed', FAILED: 'failed', STATUS_CHANGE: 'status-change', ANY: 'any' };
+// Absolute conditions auto-expire on first trigger when stopAfter=0 (fire-once semantics).
+// Change-based conditions (status-change, any) run forever when stopAfter=0.
+const WATCH_ABSOLUTE_CONDITIONS = new Set([
+  WATCH_CONDITION.MERGED, WATCH_CONDITION.BUILD_FAIL, WATCH_CONDITION.BUILD_PASS,
+  WATCH_CONDITION.COMPLETED, WATCH_CONDITION.FAILED,
+]);
 
 /** Update per-agent review metrics (prsApproved/prsRejected). Only writes for configured agents. */
 function trackReviewMetric(pr, newReviewStatus, config) {
@@ -1143,7 +1149,7 @@ module.exports = {
   classifyInboxItem,
   ENGINE_DEFAULTS,
   WI_STATUS, DONE_STATUSES, PLAN_TERMINAL_STATUSES, WORK_TYPE, PLAN_STATUS, PRD_ITEM_STATUS, PRD_MATERIALIZABLE, PR_STATUS, PR_POLLABLE_STATUSES, DISPATCH_RESULT, trackReviewMetric, queuePlanToPrd,
-  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION,
+  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION, WATCH_ABSOLUTE_CONDITIONS,
   PIPELINE_STATUS, STAGE_TYPE, MEETING_STATUS, AGENT_STATUS,
   FAILURE_CLASS, ESCALATION_POLICY, COMPLETION_FIELDS,
   DEFAULT_AGENT_METRICS,

--- a/engine/watches.js
+++ b/engine/watches.js
@@ -237,15 +237,10 @@ function checkWatches(config, state) {
           }
           log('info', `Watch triggered: ${watch.id} — ${result.message}`);
 
-          // Expire: absolute conditions auto-expire when stopAfter is 0 (fire-once semantics),
-          // change-based conditions (status-change, any) respect stopAfter literally (0 = run forever).
-          const isAbsolute = WATCH_ABSOLUTE_CONDITIONS.has(watch.condition);
+          // Expire when stopAfter limit is reached. stopAfter=0 means run forever (no limit).
           if (watch.stopAfter > 0 && watch.triggerCount >= watch.stopAfter) {
             watch.status = WATCH_STATUS.EXPIRED;
             log('info', `Watch expired (stopAfter limit reached): ${watch.id}`);
-          } else if (isAbsolute && watch.stopAfter === 0) {
-            watch.status = WATCH_STATUS.EXPIRED;
-            log('info', `Watch expired (absolute condition auto-expire): ${watch.id}`);
           }
         } else if (watch.onNotMet === 'notify' && watch.owner) {
           // Queue per-poll notification when condition is not yet met — unique key per poll

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19714,7 +19714,7 @@ async function testWatchesModule() {
   });
 
   await test('WATCHES_PATH points to engine/watches.json', () => {
-    assert.ok(watches.WATCHES_PATH.endsWith(path.join('engine', 'watches.json')));
+    assert.ok(watches._watchesPath().endsWith(path.join('engine', 'watches.json')));
   });
 
   await test('DEFAULT_WATCH_INTERVAL is 5 minutes', () => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4536,6 +4536,47 @@ async function testDiscoverFromPrs() {
     assert.ok(src.includes('fixedAfterReview && !evalEscalated'),
       'needsReReview should use fixedAfterReview directly (fixedAt > lastReviewedAt)');
   });
+
+  // ─── Poll-gated review dispatch (W-mnzvsswlwk77) ─────────────────────────
+
+  await test('discoverFromPrs gates autoReview on pollEnabled', () => {
+    // When adoPollEnabled:false (ADO) or ghPollEnabled:false (GitHub), reviewStatus is stale
+    // (never updated because polling is off). autoReview must be gated on pollEnabled.
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('pollEnabled'),
+      'discoverFromPrs must resolve pollEnabled per project');
+    assert.ok(fnBody.includes('autoReview') && fnBody.includes('pollEnabled'),
+      'autoReview must be gated on pollEnabled — stale reviewStatus is untrustworthy without poller');
+  });
+
+  await test('discoverFromPrs gates needsReReview on evalLoopEnabled', () => {
+    // evalLoop:false should suppress re-review cycles
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('evalLoopEnabled'),
+      'discoverFromPrs must read evalLoop config flag');
+    assert.ok(fnBody.includes('needsReReview') && fnBody.includes('evalLoopEnabled'),
+      'needsReReview must be gated on evalLoopEnabled — evalLoop:false suppresses re-review cycles');
+  });
+
+  await test('discoverFromPrs pre-dispatch live check catch blocks skip dispatch on error', () => {
+    // When pre-dispatch live ADO/GitHub check fails, must skip dispatch (continue) not fall through
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    // Both pre-dispatch catch blocks should have 'continue' — skipping dispatch on error
+    // Pattern: "skipping dispatch`); continue;" inside catch blocks after live vote checks
+    const skipPattern = /skipping dispatch.*continue/g;
+    const matches = fnBody.match(skipPattern) || [];
+    assert.ok(matches.length >= 2,
+      `Both pre-dispatch vote check catch blocks must skip dispatch (continue) on error (found ${matches.length})`);
+    // Also verify no catch blocks fall through without continue
+    assert.ok(!fnBody.includes("Pre-dispatch vote check for ${pr.id}: ${e.message}`); }"),
+      'No pre-dispatch catch block should fall through without continue');
+  });
 }
 
 // ─── Build Fix Retry Cap Tests ──────────────────────────────────────────────

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4537,29 +4537,33 @@ async function testDiscoverFromPrs() {
       'needsReReview should use fixedAfterReview directly (fixedAt > lastReviewedAt)');
   });
 
-  // ─── Poll-gated review dispatch (W-mnzvsswlwk77) ─────────────────────────
+  // ─── Poll-gated review dispatch (W-mnzvsswlwk77, W-mnzw3cxk6a2j) ─────────
 
-  await test('discoverFromPrs gates autoReview on pollEnabled', () => {
-    // When adoPollEnabled:false (ADO) or ghPollEnabled:false (GitHub), reviewStatus is stale
-    // (never updated because polling is off). autoReview must be gated on pollEnabled.
+  await test('discoverFromPrs uses reviewEnabled (evalLoop + pollEnabled), no autoReview', () => {
+    // autoReview was consolidated into evalLoop (W-mnzw3cxk6a2j).
+    // reviewEnabled = evalLoopEnabled && pollEnabled is the single gate.
     const fnStart = src.indexOf('async function discoverFromPrs(');
     const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
     const fnBody = src.slice(fnStart, fnEnd);
     assert.ok(fnBody.includes('pollEnabled'),
       'discoverFromPrs must resolve pollEnabled per project');
-    assert.ok(fnBody.includes('autoReview') && fnBody.includes('pollEnabled'),
-      'autoReview must be gated on pollEnabled — stale reviewStatus is untrustworthy without poller');
+    assert.ok(fnBody.includes('reviewEnabled'),
+      'discoverFromPrs must use reviewEnabled as the single review gate');
+    assert.ok(!fnBody.includes('autoReview'),
+      'autoReview must be removed — evalLoop is the sole gate (consolidated in W-mnzw3cxk6a2j)');
+    assert.ok(fnBody.includes('evalLoopEnabled') && fnBody.includes('pollEnabled'),
+      'reviewEnabled must combine evalLoopEnabled and pollEnabled');
   });
 
-  await test('discoverFromPrs gates needsReReview on evalLoopEnabled', () => {
-    // evalLoop:false should suppress re-review cycles
+  await test('discoverFromPrs gates needsReReview on reviewEnabled', () => {
+    // evalLoop:false should suppress re-review cycles; pollEnabled gates stale status
     const fnStart = src.indexOf('async function discoverFromPrs(');
     const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(');
     const fnBody = src.slice(fnStart, fnEnd);
     assert.ok(fnBody.includes('evalLoopEnabled'),
       'discoverFromPrs must read evalLoop config flag');
-    assert.ok(fnBody.includes('needsReReview') && fnBody.includes('evalLoopEnabled'),
-      'needsReReview must be gated on evalLoopEnabled — evalLoop:false suppresses re-review cycles');
+    assert.ok(fnBody.includes('needsReReview') && fnBody.includes('reviewEnabled'),
+      'needsReReview must be gated on reviewEnabled — evalLoop:false suppresses re-review cycles');
   });
 
   await test('discoverFromPrs pre-dispatch live check catch blocks skip dispatch on error', () => {
@@ -9681,6 +9685,11 @@ async function testAutoApproveMode() {
   await test('ENGINE_DEFAULTS includes autoArchive: false', () => {
     assert.strictEqual(shared.ENGINE_DEFAULTS.autoArchive, false,
       'autoArchive should default to false (opt-in, not automatic)');
+  });
+
+  await test('ENGINE_DEFAULTS does NOT include autoReview (consolidated into evalLoop)', () => {
+    assert.ok(!('autoReview' in shared.ENGINE_DEFAULTS),
+      'autoReview was consolidated into evalLoop (W-mnzw3cxk6a2j) — must not exist in ENGINE_DEFAULTS');
   });
 
   await test('parseStreamJsonOutput extracts model from init message', () => {
@@ -16654,7 +16663,7 @@ async function testPrReviewFixFlows() {
 
   await test('eval escalation does NOT use continue (allows build/conflict fixes)', () => {
     const startIdx = engineSrc.indexOf('cycle cap');
-    const endIdx = engineSrc.indexOf('autoReview', startIdx);
+    const endIdx = engineSrc.indexOf('PRs needing review', startIdx);
     const escalBlock = engineSrc.slice(startIdx, endIdx);
     assert.ok(escalBlock.length > 10, 'Should find escalation block');
     assert.ok(!escalBlock.includes('continue;'), 'Escalation should NOT use continue — would block build fixes');


### PR DESCRIPTION
## Summary

- **Removed `autoReview`** from `ENGINE_DEFAULTS` (`engine/shared.js`) — `evalLoop` is now the single gate for the entire review+fix dispatch cycle
- **Replaced `autoReview` variable** in `engine.js` `discoverFromPrs()` with `reviewEnabled = evalLoopEnabled && pollEnabled` — combines the eval-loop gate with the poll-enabled safety check
- **Fixed pre-existing bug**: removed `setCooldown(key)` from the re-review block in `discoverFromPrs()` — cooldown is deferred to `discoverWork` post-gating (matches the initial-review block behavior)
- **Updated tests** to assert `autoReview` is absent from both `ENGINE_DEFAULTS` and the `discoverFromPrs` function body
- **Added deprecation entry** in `docs/deprecated.json` for tracking

## Depends on

- PR from `work/W-mnzvsswlwk77` (merged into this branch as prerequisite)

## Test plan

- [x] `npm test` — 1433 passed, 0 failed
- [x] `grep autoReview` across `.js` and `.json` — zero hits in production code
- [x] Verified `reviewEnabled` correctly combines `evalLoopEnabled && pollEnabled`
- [x] Verified `needsReReview` no longer has redundant `evalLoopEnabled` check (folded into `reviewEnabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)