### PR TITLE
feat(W-mnzw95izpq5c): add Auto-complete PRs toggle to settings modal

### DIFF
--- a/dashboard/js/settings.js
+++ b/dashboard/js/settings.js
@@ -50,6 +50,7 @@ async function openSettings() {
       settingsToggle('Allow Temp Agents', 'set-allowTempAgents', !!e.allowTempAgents, 'Spawn ephemeral agents when all permanent agents are busy') +
       settingsToggle('Auto-archive Plans', 'set-autoArchive', !!e.autoArchive, 'Automatically archive plans after verify completes (off = manual archive via dashboard)') +
       settingsToggle('Auto-fix Conflicts', 'set-autoFixConflicts', e.autoFixConflicts !== false, 'Auto-dispatch fix agents when a PR has merge conflicts') +
+      settingsToggle('Auto-complete PRs', 'set-autoCompletePrs', !!e.autoCompletePrs, 'Auto-merge PRs when builds pass and review is approved (opt-in)') +
       settingsToggle('ADO Polling', 'set-adoPollEnabled', e.adoPollEnabled !== false, 'Poll ADO PR status and comments each tick (reconciliation always runs)') +
       settingsToggle('GitHub Polling', 'set-ghPollEnabled', e.ghPollEnabled !== false, 'Poll GitHub PR status and comments each tick (reconciliation always runs)') +
     '</div>' +
@@ -240,6 +241,7 @@ async function saveSettings() {
       allowTempAgents: document.getElementById('set-allowTempAgents').checked,
       autoArchive: document.getElementById('set-autoArchive').checked,
       autoFixConflicts: document.getElementById('set-autoFixConflicts').checked,
+      autoCompletePrs: document.getElementById('set-autoCompletePrs').checked,
       adoPollEnabled: document.getElementById('set-adoPollEnabled').checked,
       ghPollEnabled: document.getElementById('set-ghPollEnabled').checked,
       adoPollStatusEvery: document.getElementById('set-adoPollStatusEvery').value,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -16875,6 +16875,27 @@ async function testPrReviewFixFlows() {
       'GitHub should require both conditions');
   });
 
+  await test('settings UI has Auto-complete PRs toggle', () => {
+    const settingsSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'settings.js'), 'utf8');
+    assert.ok(settingsSrc.includes('set-autoCompletePrs'),
+      'Settings UI should have an autoCompletePrs toggle with id set-autoCompletePrs');
+    assert.ok(settingsSrc.includes('Auto-complete PRs') || settingsSrc.includes('Auto-complete'),
+      'Settings UI should label the toggle as Auto-complete PRs');
+  });
+
+  await test('settings UI sends autoCompletePrs to backend', () => {
+    const settingsSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'settings.js'), 'utf8');
+    assert.ok(settingsSrc.includes('autoCompletePrs:') && settingsSrc.includes('set-autoCompletePrs'),
+      'settings.js must include autoCompletePrs in enginePayload and reference set-autoCompletePrs element');
+  });
+
+  await test('ENGINE_DEFAULTS defines autoCompletePrs as boolean', () => {
+    assert.strictEqual(typeof shared.ENGINE_DEFAULTS.autoCompletePrs, 'boolean',
+      'ENGINE_DEFAULTS.autoCompletePrs must be a boolean so dynamic boolean derivation includes it');
+    assert.strictEqual(shared.ENGINE_DEFAULTS.autoCompletePrs, false,
+      'autoCompletePrs default must be false (opt-in)');
+  });
+
   await test('GitHub merge method validated against whitelist', () => {
     assert.ok(ghSrc.includes("['squash', 'merge', 'rebase']"),
       'Merge method should be validated');


### PR DESCRIPTION
## Summary
- Adds an **Auto-complete PRs** toggle to the dashboard Settings modal, placed alongside the thematically related Auto-fix Conflicts toggle
- Wires up `autoCompletePrs` in `saveSettings()` so the toggle value is sent to the backend on save
- Backend persistence works automatically — `autoCompletePrs` is already a boolean in `ENGINE_DEFAULTS` (false/opt-in), so the dynamic boolean derivation in `dashboard.js:3825` picks it up with no changes needed

## Test plan
- [x] 3 new tests added (TDD): toggle presence, payload wiring, ENGINE_DEFAULTS type check
- [x] Full test suite: 1868 passed, 2 failed (pre-existing), 2 skipped — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)