### PR TITLE
feat(W-mnzw998mk5qa): fix misleading poll frequency field labels in settings modal

### DIFF
--- a/dashboard/js/settings.js
+++ b/dashboard/js/settings.js
@@ -54,8 +54,8 @@ async function openSettings() {
       settingsToggle('GitHub Polling', 'set-ghPollEnabled', e.ghPollEnabled !== false, 'Poll GitHub PR status and comments each tick (reconciliation always runs)') +
     '</div>' +
     '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:16px">' +
-      settingsField('ADO Status Poll Frequency', 'set-adoPollStatusEvery', e.adoPollStatusEvery || 6, 'ticks', 'Poll ADO PR build/review/merge status every N ticks (~6 min at default tick rate)') +
-      settingsField('ADO Comments Poll Frequency', 'set-adoPollCommentsEvery', e.adoPollCommentsEvery || 12, 'ticks', 'Poll ADO PR human comments every N ticks (~12 min at default tick rate)') +
+      settingsField('PR Status Poll Frequency', 'set-adoPollStatusEvery', e.adoPollStatusEvery || 6, 'ticks', 'Poll PR build/review/merge status every N ticks for both ADO and GitHub (~6 min at default tick rate)') +
+      settingsField('PR Comments Poll Frequency', 'set-adoPollCommentsEvery', e.adoPollCommentsEvery || 12, 'ticks', 'Poll PR human comments every N ticks for both ADO and GitHub (~12 min at default tick rate)') +
     '</div>' +
     '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:16px">' +
       settingsField('Eval Max Iterations', 'set-evalMaxIterations', e.evalMaxIterations || 3, '', 'Max review→fix cycles before escalating (1-10)') +

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10085,6 +10085,18 @@ async function testSettingsComprehensive() {
       'settings.js must include ghPollEnabled in enginePayload and reference set-ghPollEnabled element');
   });
 
+  await test('poll frequency labels say PR not ADO — they gate both ADO and GitHub', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'dashboard', 'js', 'settings.js'), 'utf8');
+    assert.ok(src.includes("PR Status Poll Frequency"),
+      'settings.js must label status poll field as "PR Status Poll Frequency" (gates both ADO and GitHub)');
+    assert.ok(src.includes("PR Comments Poll Frequency"),
+      'settings.js must label comments poll field as "PR Comments Poll Frequency" (gates both ADO and GitHub)');
+    assert.ok(!src.includes("'ADO Status Poll Frequency'") && !src.includes('"ADO Status Poll Frequency"'),
+      'settings.js must NOT use misleading "ADO Status Poll Frequency" label — field gates both providers');
+    assert.ok(!src.includes("'ADO Comments Poll Frequency'") && !src.includes('"ADO Comments Poll Frequency"'),
+      'settings.js must NOT use misleading "ADO Comments Poll Frequency" label — field gates both providers');
+  });
+
   await test('ENGINE_DEFAULTS defines adoPollEnabled and ghPollEnabled as booleans', () => {
     assert.strictEqual(typeof shared.ENGINE_DEFAULTS.adoPollEnabled, 'boolean',
       'ENGINE_DEFAULTS.adoPollEnabled must be a boolean so ?? fallback works correctly in engine.js');


### PR DESCRIPTION
## Summary
- Renamed "ADO Status Poll Frequency" → "PR Status Poll Frequency" and "ADO Comments Poll Frequency" → "PR Comments Poll Frequency" in the settings modal
- Updated hint text to clarify these fields gate polling for both ADO and GitHub providers
- Field IDs (`set-adoPollStatusEvery`, `set-adoPollCommentsEvery`) and config keys unchanged — only visible labels and hints updated
- Added regression test asserting the corrected labels and rejecting the old misleading ones

## Test plan
- [x] `npm test` passes (1935 passed, 3 pre-existing failures unrelated to this change)
- [ ] Open settings modal and confirm renamed labels appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)