### PR TITLE
feat(W-mo09u4o72zew): fix doc-chat Clear chat not persisting session deletion to localStorage

### DIFF
--- a/dashboard/js/modal-qa.js
+++ b/dashboard/js/modal-qa.js
@@ -135,7 +135,10 @@ function clearQaConversation() {
   var expandBar = document.getElementById('qa-expand-bar');
   if (wrap) wrap.style.display = 'none';
   if (expandBar) expandBar.style.display = 'none';
-  if (_qaSessionKey) _qaSessions.delete(_qaSessionKey);
+  if (_qaSessionKey) {
+    _qaSessions.delete(_qaSessionKey);
+    _saveQaSessions();
+  }
 }
 
 function modalSend() {

--- a/engine/watches.js
+++ b/engine/watches.js
@@ -11,7 +11,7 @@
 const path = require('path');
 const shared = require('./shared');
 const { safeJson, mutateJsonFileLocked, ts, uid, log, writeToInbox,
-  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION } = shared;
+  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION, WATCH_ABSOLUTE_CONDITIONS } = shared;
 
 // Dynamic path — respects MINIONS_TEST_DIR for test isolation
 function _watchesPath() { return path.join(shared.MINIONS_DIR, 'engine', 'watches.json'); }

--- a/engine/watches.js
+++ b/engine/watches.js
@@ -11,7 +11,7 @@
 const path = require('path');
 const shared = require('./shared');
 const { safeJson, mutateJsonFileLocked, ts, uid, log, writeToInbox,
-  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION, WATCH_ABSOLUTE_CONDITIONS } = shared;
+  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION } = shared;
 
 // Dynamic path — respects MINIONS_TEST_DIR for test isolation
 function _watchesPath() { return path.join(shared.MINIONS_DIR, 'engine', 'watches.json'); }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19866,6 +19866,7 @@ async function testWatchesModule() {
     } finally { restore(); }
   });
 
+
   await test('create-watch CC action in executeCCActions creates a watch', () => {
     const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     // Find executeCCActions function — create-watch case may be far into the switch

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14820,6 +14820,18 @@ async function testDashboardResilience() {
       'clearQaSelection should hide pill');
   });
 
+  await test('clearQaConversation persists session deletion to localStorage', () => {
+    // clearQaConversation deletes from _qaSessions — must call _saveQaSessions() to persist
+    const clearFn = modalQaSrc.slice(
+      modalQaSrc.indexOf('function clearQaConversation'),
+      modalQaSrc.indexOf('function modalSend')
+    );
+    assert.ok(clearFn.includes('_qaSessions.delete'),
+      'clearQaConversation must delete session from _qaSessions map');
+    assert.ok(clearFn.includes('_saveQaSessions()'),
+      'clearQaConversation must call _saveQaSessions() after deleting session to persist to localStorage');
+  });
+
   // ── Command center overlay dismiss ──
 
   await test('CC overlay exists for click-to-dismiss', () => {


### PR DESCRIPTION
## Summary
- **Bug**: Clicking "Clear chat" in the doc-chat modal cleared the in-memory `_qaSessions` Map but never persisted the deletion to `localStorage`, causing old conversations to reappear on page reload
- **Fix**: Added `_saveQaSessions()` call immediately after `_qaSessions.delete()` in `clearQaConversation()` (`dashboard/js/modal-qa.js:138`)
- **Test**: Added unit test verifying `clearQaConversation` calls `_saveQaSessions()` after deleting the session

## Test plan
- [x] Unit test added: `clearQaConversation persists session deletion to localStorage`
- [x] `npm test` passes (1935 passed, 3 pre-existing failures unrelated to this change)
- [ ] Manual: open a doc modal → send a message → click Clear chat → reload page → reopen same doc → conversation should be empty

Closes #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)