### PR TITLE
feat(W-mnzvt691dfmp): complete watches management — new conditions, CC actions, PROJECTS fix

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -709,6 +709,24 @@ async function executeCCActions(actions) {
           results.push({ type: 'create-watch', id: watch.id, ok: true });
           break;
         }
+        case 'delete-watch': {
+          const deleted = watchesMod.deleteWatch(action.id);
+          if (deleted) invalidateStatusCache();
+          results.push({ type: 'delete-watch', id: action.id, ok: deleted });
+          break;
+        }
+        case 'pause-watch': {
+          const paused = watchesMod.updateWatch(action.id, { status: shared.WATCH_STATUS.PAUSED });
+          if (paused) invalidateStatusCache();
+          results.push({ type: 'pause-watch', id: action.id, ok: !!paused });
+          break;
+        }
+        case 'resume-watch': {
+          const resumed = watchesMod.updateWatch(action.id, { status: shared.WATCH_STATUS.ACTIVE });
+          if (resumed) invalidateStatusCache();
+          results.push({ type: 'resume-watch', id: action.id, ok: !!resumed });
+          break;
+        }
         default:
           // Server didn't handle — frontend must execute
           results.push({ type: action.type });

--- a/dashboard/js/render-watches.js
+++ b/dashboard/js/render-watches.js
@@ -22,6 +22,8 @@ const _WATCH_CONDITION_LABELS = {
   failed: 'Failed',
   'status-change': 'Status Change',
   any: 'Any Change',
+  'new-comments': 'New Comments',
+  'vote-change': 'Vote Change',
 };
 
 function _intervalToHuman(ms) {
@@ -222,6 +224,8 @@ function _watchFormHtml() {
     { value: 'failed', label: 'Failed' },
     { value: 'status-change', label: 'Status Change' },
     { value: 'any', label: 'Any Change' },
+    { value: 'new-comments', label: 'New Comments' },
+    { value: 'vote-change', label: 'Vote Change' },
   ];
   var ttOpts = targetTypes.map(function(t) { return '<option value="' + t.value + '">' + t.label + '</option>'; }).join('');
   var condOpts = conditions.map(function(c) { return '<option value="' + c.value + '">' + c.label + '</option>'; }).join('');

--- a/engine.js
+++ b/engine.js
@@ -3188,11 +3188,12 @@ async function tickInner() {
   if (tickCount % 3 === 0) {
     safe('checkWatches', () => {
       const { checkWatches } = require('./engine/watches');
-      const pullRequests = PROJECTS.flatMap(p => {
+      const projects = getProjects(config);
+      const pullRequests = projects.flatMap(p => {
         const prPath = path.join(MINIONS_DIR, 'projects', p.name, 'pull-requests.json');
         return safeJson(prPath) || [];
       });
-      const workItems = PROJECTS.flatMap(p => {
+      const workItems = projects.flatMap(p => {
         const wiPath = path.join(MINIONS_DIR, 'projects', p.name, 'work-items.json');
         return safeJson(wiPath) || [];
       });

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -620,7 +620,7 @@ const PR_POLLABLE_STATUSES = new Set([PR_STATUS.ACTIVE, PR_STATUS.LINKED]);
 // Watch statuses — engine-level persistent watches that survive restarts
 const WATCH_STATUS = { ACTIVE: 'active', PAUSED: 'paused', TRIGGERED: 'triggered', EXPIRED: 'expired' };
 const WATCH_TARGET_TYPE = { PR: 'pr', WORK_ITEM: 'work-item' };
-const WATCH_CONDITION = { MERGED: 'merged', BUILD_FAIL: 'build-fail', BUILD_PASS: 'build-pass', COMPLETED: 'completed', FAILED: 'failed', STATUS_CHANGE: 'status-change', ANY: 'any' };
+const WATCH_CONDITION = { MERGED: 'merged', BUILD_FAIL: 'build-fail', BUILD_PASS: 'build-pass', COMPLETED: 'completed', FAILED: 'failed', STATUS_CHANGE: 'status-change', ANY: 'any', NEW_COMMENTS: 'new-comments', VOTE_CHANGE: 'vote-change' };
 // Absolute conditions auto-expire on first trigger when stopAfter=0 (fire-once semantics).
 // Change-based conditions (status-change, any) run forever when stopAfter=0.
 const WATCH_ABSOLUTE_CONDITIONS = new Set([

--- a/engine/watches.js
+++ b/engine/watches.js
@@ -158,6 +158,16 @@ function evaluateWatch(watch, state) {
         );
         return { triggered: anyChanged, message: anyChanged ? `PR ${target} changed` : '' };
       }
+      case WATCH_CONDITION.NEW_COMMENTS: {
+        const lastCommentDate = pr.humanFeedback?.lastProcessedCommentDate || null;
+        const prevCommentDate = prevState.lastCommentDate || null;
+        const hasNew = lastCommentDate && lastCommentDate !== prevCommentDate;
+        return { triggered: !!hasNew, message: hasNew ? `PR ${target} has a new comment (${lastCommentDate})` : '' };
+      }
+      case WATCH_CONDITION.VOTE_CHANGE: {
+        const changed = prevState.reviewStatus !== undefined && prevState.reviewStatus !== pr.reviewStatus;
+        return { triggered: changed, message: changed ? `PR ${target} vote changed: ${prevState.reviewStatus} → ${pr.reviewStatus}` : '' };
+      }
       default:
         return { triggered: false, message: `Unknown condition: ${condition}` };
     }
@@ -279,7 +289,7 @@ function _captureState(watch, state) {
     const pr = (state.pullRequests || []).find(p =>
       String(p.prNumber) === String(watch.target) || p.id === watch.target
     );
-    if (pr) return { status: pr.status, buildStatus: pr.buildStatus, reviewStatus: pr.reviewStatus };
+    if (pr) return { status: pr.status, buildStatus: pr.buildStatus, reviewStatus: pr.reviewStatus, lastCommentDate: pr.humanFeedback?.lastProcessedCommentDate || null };
   }
   if (watch.targetType === WATCH_TARGET_TYPE.WORK_ITEM) {
     const wi = (state.workItems || []).find(w => w.id === watch.target);

--- a/prompts/cc-system.md
+++ b/prompts/cc-system.md
@@ -82,9 +82,15 @@ Additional actions (all take `id` or `file` as primary key):
 - Meetings: add-meeting-note (id, note), advance-meeting (id), end-meeting (id), archive-meeting (id), unarchive-meeting (id), delete-meeting (id)
 - Work item ops: delete-work-item (id, source), archive-work-item (id), work-item-feedback (id, rating: up/down, comment), reopen-work-item (id, project[, description] — reopen a done/failed item back to pending)
 - PRD ops: edit-prd-item, remove-prd-item, reopen-prd-item (id, file — re-dispatches on existing branch)
-- **create-watch**: target, targetType (pr/work-item/branch), condition (merged/build-fail/build-pass/completed/failed/status-change/any), interval ("15m", "1h", "30s" — default "5m"), owner (agent id or "human"), description, project, stopAfter (0=run forever, 1=expire on first match, N=expire after N matches), onNotMet (null=do nothing, "notify"=write to inbox each poll while condition not met)
+- **create-watch**: target, targetType (pr/work-item), condition (merged/build-fail/build-pass/completed/failed/status-change/any/new-comments/vote-change), interval ("15m", "1h", "30s" — default "5m"), owner (agent id or "human"), description, project, stopAfter (0=run forever, 1=expire on first match, N=expire after N matches), onNotMet (null=do nothing, "notify"=write to inbox each poll while condition not met)
   Example: user says "check PR 1065 build every 15 min until green" → `{"type":"create-watch","target":"1065","targetType":"pr","condition":"build-pass","interval":"15m","stopAfter":1,"description":"Watch PR 1065 build until green"}`
   Example: user says "ping me every 15 min while build is still failing" → `{"type":"create-watch","target":"1065","targetType":"pr","condition":"build-pass","interval":"15m","stopAfter":1,"onNotMet":"notify","description":"Watch PR 1065 build — notify each poll"}`
+- **delete-watch**: id — remove a watch permanently
+  Example: user says "stop watching PR 1065" → `{"type":"delete-watch","id":"watch-abc123"}`
+- **pause-watch**: id — pause a watch without deleting it (can be resumed later)
+  Example: user says "pause the PR 1065 watch" → `{"type":"pause-watch","id":"watch-abc123"}`
+- **resume-watch**: id — resume a paused watch
+  Example: user says "resume watching PR 1065" → `{"type":"resume-watch","id":"watch-abc123"}`
 - KB/Inbox: promote-to-kb (file, category), kb-sweep, toggle-kb-pin (key)
 - Plan lifecycle: revise-plan (file, feedback — dispatches agent to revise)
 - Pipeline: continue-pipeline (id — resume past wait stage)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19684,6 +19684,9 @@ async function testWatchesModule() {
   });
 
   await test('stopAfter: 0 never expires the watch (runs forever)', () => {
+    // Use a non-absolute condition (new-comments) — absolute conditions (merged, build-fail, etc.)
+    // auto-expire when stopAfter is 0 via WATCH_ABSOLUTE_CONDITIONS (fire-once semantics).
+    // First check initializes baseline _lastState without triggering, so we need 3 checks for 2 triggers.
     const restore = createTestMinionsDir();
     try {
       delete require.cache[require.resolve('../engine/watches')];
@@ -19691,29 +19694,37 @@ async function testWatchesModule() {
       const w = testWatches.createWatch({
         target: '600',
         targetType: shared.WATCH_TARGET_TYPE.PR,
-        condition: shared.WATCH_CONDITION.MERGED,
-        stopAfter: 0,   // run forever
+        condition: shared.WATCH_CONDITION.NEW_COMMENTS,
+        stopAfter: 0,   // run forever (non-absolute conditions)
         owner: 'dallas',
         interval: 60000,
       });
-      const state = { pullRequests: [{ prNumber: 600, status: 'merged' }], workItems: [] };
-      // Trigger multiple times by resetting last_checked between checks
-      testWatches.checkWatches({}, state);
-      // Force last_checked back so interval doesn't block next check
-      const watchesData = testWatches.getWatches();
-      const found = watchesData.find(x => x.id === w.id);
-      assert.strictEqual(found.triggerCount, 1);
-      assert.strictEqual(found.status, shared.WATCH_STATUS.ACTIVE, 'stopAfter=0 should keep watch active after trigger');
-      // Manually reset last_checked to force another check
-      testWatches.updateWatch(w.id, {}); // no-op but resets nothing — we need to use mutateJsonFileLocked
-      shared.mutateJsonFileLocked(path.join(process.env.MINIONS_TEST_DIR, 'engine', 'watches.json'), (data) => {
+      const watchesJsonPath = path.join(process.env.MINIONS_TEST_DIR, 'engine', 'watches.json');
+      const resetLastChecked = () => shared.mutateJsonFileLocked(watchesJsonPath, (data) => {
         const ww = data.find(x => x.id === w.id);
-        if (ww) ww.last_checked = '2020-01-01T00:00:00.000Z'; // force old timestamp
+        if (ww) ww.last_checked = '2020-01-01T00:00:00.000Z';
         return data;
       }, { defaultValue: [] });
-      testWatches.checkWatches({}, state);
+
+      // Check 1 — initializes baseline _lastState (lastCommentDate = '2026-01-01'), no trigger
+      const state1 = { pullRequests: [{ prNumber: 600, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-01' } }], workItems: [] };
+      testWatches.checkWatches({}, state1);
+      assert.strictEqual(testWatches.getWatches().find(x => x.id === w.id).triggerCount, 0, 'First check initializes baseline, no trigger');
+
+      // Check 2 — comment date changed → triggers (triggerCount = 1)
+      resetLastChecked();
+      const state2 = { pullRequests: [{ prNumber: 600, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-02' } }], workItems: [] };
+      testWatches.checkWatches({}, state2);
+      const after1 = testWatches.getWatches().find(x => x.id === w.id);
+      assert.strictEqual(after1.triggerCount, 1);
+      assert.strictEqual(after1.status, shared.WATCH_STATUS.ACTIVE, 'stopAfter=0 should keep watch active after trigger');
+
+      // Check 3 — another comment date change → triggers again (triggerCount = 2)
+      resetLastChecked();
+      const state3 = { pullRequests: [{ prNumber: 600, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-03' } }], workItems: [] };
+      testWatches.checkWatches({}, state3);
       const after2 = testWatches.getWatches().find(x => x.id === w.id);
-      assert.strictEqual(after2.triggerCount, 2, 'Should trigger again — stopAfter=0 runs forever');
+      assert.strictEqual(after2.triggerCount, 2, 'Should trigger again — stopAfter=0 runs forever for non-absolute conditions');
       assert.strictEqual(after2.status, shared.WATCH_STATUS.ACTIVE, 'Still active after multiple triggers');
     } finally { restore(); }
   });
@@ -19815,6 +19826,8 @@ async function testWatchesModule() {
   });
 
   await test('unique notification keys per trigger — two triggers produce different inbox files', () => {
+    // Use non-absolute condition (new-comments) so stopAfter: 0 means "run forever"
+    // First check initializes baseline; checks 2 and 3 trigger (new comment dates)
     const restore = createTestMinionsDir();
     try {
       delete require.cache[require.resolve('../engine/watches')];
@@ -19822,25 +19835,35 @@ async function testWatchesModule() {
       const w = testWatches.createWatch({
         target: '900',
         targetType: shared.WATCH_TARGET_TYPE.PR,
-        condition: shared.WATCH_CONDITION.MERGED,
+        condition: shared.WATCH_CONDITION.NEW_COMMENTS,
         stopAfter: 0,
         owner: 'dallas',
         interval: 60000,
+        notify: 'inbox',
       });
-      const state = { pullRequests: [{ prNumber: 900, status: 'merged' }], workItems: [] };
-      // First trigger — key is `watch-${watch.id}-1`, so inbox file starts with `dallas-watch-${watch.id}-1-`
-      testWatches.checkWatches({}, state);
-      const inboxDir = path.join(process.env.MINIONS_TEST_DIR, 'notes', 'inbox');
-      const filesAfterFirst = fs.readdirSync(inboxDir).filter(f => f.includes(w.id));
-      assert.strictEqual(filesAfterFirst.length, 1, 'First trigger should create exactly one inbox file');
-      // Force last_checked back for second trigger
-      shared.mutateJsonFileLocked(path.join(process.env.MINIONS_TEST_DIR, 'engine', 'watches.json'), (data) => {
+      const watchesJsonPath = path.join(process.env.MINIONS_TEST_DIR, 'engine', 'watches.json');
+      const resetLastChecked = () => shared.mutateJsonFileLocked(watchesJsonPath, (data) => {
         const ww = data.find(x => x.id === w.id);
         if (ww) ww.last_checked = '2020-01-01T00:00:00.000Z';
         return data;
       }, { defaultValue: [] });
-      // Second trigger — key is `watch-${watch.id}-2`, different from first
-      testWatches.checkWatches({}, state);
+      const inboxDir = path.join(process.env.MINIONS_TEST_DIR, 'notes', 'inbox');
+
+      // Check 1 — baseline initialization, no trigger, no inbox file
+      const state1 = { pullRequests: [{ prNumber: 900, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-01' } }], workItems: [] };
+      testWatches.checkWatches({}, state1);
+
+      // Check 2 — first trigger (comment date changed)
+      resetLastChecked();
+      const state2 = { pullRequests: [{ prNumber: 900, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-02' } }], workItems: [] };
+      testWatches.checkWatches({}, state2);
+      const filesAfterFirst = fs.readdirSync(inboxDir).filter(f => f.includes(w.id));
+      assert.strictEqual(filesAfterFirst.length, 1, 'First trigger should create exactly one inbox file');
+
+      // Check 3 — second trigger (another comment date change)
+      resetLastChecked();
+      const state3 = { pullRequests: [{ prNumber: 900, status: 'active', humanFeedback: { lastProcessedCommentDate: '2026-01-03' } }], workItems: [] };
+      testWatches.checkWatches({}, state3);
       const filesAfterSecond = fs.readdirSync(inboxDir).filter(f => f.includes(w.id));
       assert.strictEqual(filesAfterSecond.length, 2,
         'Second trigger should create a SECOND inbox file (unique key per trigger count), not overwrite the first. Got ' +

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19338,6 +19338,62 @@ async function testWatchesModule() {
     assert.ok(result.message.includes('not found'));
   });
 
+  // evaluateWatch — new-comments condition
+  await test('evaluateWatch: PR new-comments triggers when comment date changes', () => {
+    const watch = { target: '400', targetType: 'pr', condition: 'new-comments',
+      _lastState: { lastCommentDate: '2026-04-01T00:00:00Z' } };
+    const state = { pullRequests: [{ prNumber: 400, status: 'active',
+      humanFeedback: { lastProcessedCommentDate: '2026-04-02T00:00:00Z' } }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, true);
+    assert.ok(result.message.includes('new comment'));
+  });
+
+  await test('evaluateWatch: PR new-comments does not trigger when date unchanged', () => {
+    const watch = { target: '400', targetType: 'pr', condition: 'new-comments',
+      _lastState: { lastCommentDate: '2026-04-01T00:00:00Z' } };
+    const state = { pullRequests: [{ prNumber: 400, status: 'active',
+      humanFeedback: { lastProcessedCommentDate: '2026-04-01T00:00:00Z' } }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, false);
+  });
+
+  await test('evaluateWatch: PR new-comments triggers on first comment (no prior state)', () => {
+    const watch = { target: '400', targetType: 'pr', condition: 'new-comments',
+      _lastState: { lastCommentDate: null } };
+    const state = { pullRequests: [{ prNumber: 400, status: 'active',
+      humanFeedback: { lastProcessedCommentDate: '2026-04-02T00:00:00Z' } }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, true);
+  });
+
+  // evaluateWatch — vote-change condition
+  await test('evaluateWatch: PR vote-change triggers when reviewStatus changes', () => {
+    const watch = { target: '500', targetType: 'pr', condition: 'vote-change',
+      _lastState: { reviewStatus: 'pending' } };
+    const state = { pullRequests: [{ prNumber: 500, status: 'active', reviewStatus: 'approved' }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, true);
+    assert.ok(result.message.includes('pending'));
+    assert.ok(result.message.includes('approved'));
+  });
+
+  await test('evaluateWatch: PR vote-change does not trigger when unchanged', () => {
+    const watch = { target: '500', targetType: 'pr', condition: 'vote-change',
+      _lastState: { reviewStatus: 'pending' } };
+    const state = { pullRequests: [{ prNumber: 500, status: 'active', reviewStatus: 'pending' }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, false);
+  });
+
+  await test('evaluateWatch: PR vote-change does not trigger without prior state', () => {
+    const watch = { target: '500', targetType: 'pr', condition: 'vote-change',
+      _lastState: {} };
+    const state = { pullRequests: [{ prNumber: 500, status: 'active', reviewStatus: 'approved' }] };
+    const result = watches.evaluateWatch(watch, state);
+    assert.strictEqual(result.triggered, false);
+  });
+
   // evaluateWatch — Work Item conditions
   await test('evaluateWatch: WI completed triggers when done', () => {
     const watch = { target: 'W-abc', targetType: 'work-item', condition: 'completed', _lastState: {} };
@@ -19467,6 +19523,21 @@ async function testWatchesModule() {
     assert.strictEqual(captured.status, 'active');
     assert.strictEqual(captured.buildStatus, 'passing');
     assert.strictEqual(captured.reviewStatus, 'waiting');
+  });
+
+  await test('_captureState captures PR lastCommentDate from humanFeedback', () => {
+    const watch = { target: '100', targetType: 'pr' };
+    const state = { pullRequests: [{ prNumber: 100, status: 'active', buildStatus: 'passing', reviewStatus: 'waiting',
+      humanFeedback: { lastProcessedCommentDate: '2026-04-10T12:00:00Z' } }] };
+    const captured = watches._captureState(watch, state);
+    assert.strictEqual(captured.lastCommentDate, '2026-04-10T12:00:00Z');
+  });
+
+  await test('_captureState captures null lastCommentDate when no humanFeedback', () => {
+    const watch = { target: '100', targetType: 'pr' };
+    const state = { pullRequests: [{ prNumber: 100, status: 'active' }] };
+    const captured = watches._captureState(watch, state);
+    assert.strictEqual(captured.lastCommentDate, null);
   });
 
   await test('_captureState captures WI state', () => {
@@ -19914,6 +19985,74 @@ async function testWatchesDashboard() {
       'engine.js must call checkWatches in tick cycle');
     assert.ok(engineSrc.includes("require('./engine/watches')"),
       'engine.js must import watches module');
+  });
+
+  // CC action tests — dashboard.js must support delete/pause/resume watches from CC
+  await test('dashboard.js has delete-watch CC action handler', () => {
+    assert.ok(dashSrc.includes("'delete-watch'") || dashSrc.includes('"delete-watch"'),
+      'dashboard.js must handle delete-watch CC action');
+    assert.ok(dashSrc.includes('deleteWatch'),
+      'delete-watch handler must call watchesMod.deleteWatch');
+  });
+
+  await test('dashboard.js has pause-watch CC action handler', () => {
+    assert.ok(dashSrc.includes("'pause-watch'") || dashSrc.includes('"pause-watch"'),
+      'dashboard.js must handle pause-watch CC action');
+  });
+
+  await test('dashboard.js has resume-watch CC action handler', () => {
+    assert.ok(dashSrc.includes("'resume-watch'") || dashSrc.includes('"resume-watch"'),
+      'dashboard.js must handle resume-watch CC action');
+  });
+
+  // CC preamble tests — watches count should be in the state preamble
+  await test('dashboard.js preamble includes watches count', () => {
+    assert.ok(dashSrc.includes('Watches:') || dashSrc.includes('watches:'),
+      'CC state preamble should include watches count');
+    assert.ok(dashSrc.includes('getWatches'),
+      'Preamble builder should call getWatches for the count');
+  });
+
+  // Condition labels in render-watches.js
+  const renderSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-watches.js'), 'utf8');
+
+  await test('render-watches.js includes new-comments condition label', () => {
+    assert.ok(renderSrc.includes('new-comments'),
+      'render-watches.js must include new-comments condition');
+  });
+
+  await test('render-watches.js includes vote-change condition label', () => {
+    assert.ok(renderSrc.includes('vote-change'),
+      'render-watches.js must include vote-change condition');
+  });
+
+  // CC system prompt tests
+  const ccPromptSrc = fs.readFileSync(path.join(MINIONS_DIR, 'prompts', 'cc-system.md'), 'utf8');
+
+  await test('CC system prompt documents delete-watch action', () => {
+    assert.ok(ccPromptSrc.includes('delete-watch'),
+      'CC system prompt must document delete-watch action');
+  });
+
+  await test('CC system prompt documents pause-watch action', () => {
+    assert.ok(ccPromptSrc.includes('pause-watch'),
+      'CC system prompt must document pause-watch action');
+  });
+
+  await test('CC system prompt documents resume-watch action', () => {
+    assert.ok(ccPromptSrc.includes('resume-watch'),
+      'CC system prompt must document resume-watch action');
+  });
+
+  // shared.js new conditions
+  await test('WATCH_CONDITION includes new-comments', () => {
+    assert.ok(shared.WATCH_CONDITION.NEW_COMMENTS === 'new-comments',
+      'WATCH_CONDITION must have NEW_COMMENTS constant');
+  });
+
+  await test('WATCH_CONDITION includes vote-change', () => {
+    assert.ok(shared.WATCH_CONDITION.VOTE_CHANGE === 'vote-change',
+      'WATCH_CONDITION must have VOTE_CHANGE constant');
   });
 }
 


### PR DESCRIPTION
## Summary

- **Fix critical PROJECTS ReferenceError** in `engine.js` `checkWatches()` — the variable `PROJECTS` was undefined, breaking the entire watches feature at runtime. Replaced with `getProjects(config)` to match the established pattern used throughout the file.
- **Add `new-comments` and `vote-change` watch conditions** — `new-comments` triggers when `humanFeedback.lastProcessedCommentDate` changes on a PR; `vote-change` triggers when `reviewStatus` transitions. Both added to `WATCH_CONDITION` constants, `evaluateWatch()`, `_captureState()`, and the dashboard form/labels.
- **Add CC action handlers** for `delete-watch`, `pause-watch`, and `resume-watch` in `executeCCActions()` — enables the Command Center to manage watches via natural language. Documented in `prompts/cc-system.md`.

## Changes

| File | What |
|------|------|
| `engine/shared.js` | Added `NEW_COMMENTS`, `VOTE_CHANGE` to `WATCH_CONDITION` |
| `engine/watches.js` | New `evaluateWatch` cases + `_captureState` captures `lastCommentDate` |
| `engine.js` | Fixed `PROJECTS` → `getProjects(config)` in `checkWatches` block |
| `dashboard.js` | Added `delete-watch`, `pause-watch`, `resume-watch` CC action handlers |
| `prompts/cc-system.md` | Documented new CC actions with examples |
| `dashboard/js/render-watches.js` | Added condition labels + form dropdown entries |
| `test/unit.test.js` | Tests for new conditions, CC actions, constants |

## Test plan

- [x] All 15 previously failing watches tests now pass
- [x] Full test suite: 1958 passed, 1 failed (pre-existing `SessionStart hook` issue), 2 skipped
- [ ] Verify watches page renders in dashboard
- [ ] Create a watch via dashboard UI and confirm it appears
- [ ] Create/pause/resume/delete watches via CC natural language
- [ ] Confirm engine tick checkWatches no longer throws ReferenceError

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)