### PR TITLE
fix(W-mnzvslqrbfn4): replace undefined PROJECTS with config.projects in checkWatches

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19153,6 +19153,18 @@ async function testWatchesModule() {
     assert.strictEqual(shared.WATCH_CONDITION.ANY, 'any');
   });
 
+  await test('WATCH_ABSOLUTE_CONDITIONS contains fire-once conditions', () => {
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS instanceof Set, 'must be a Set');
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.MERGED));
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.BUILD_FAIL));
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.BUILD_PASS));
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.COMPLETED));
+    assert.ok(shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.FAILED));
+    // Change-detection conditions must NOT be absolute
+    assert.ok(!shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.STATUS_CHANGE));
+    assert.ok(!shared.WATCH_ABSOLUTE_CONDITIONS.has(shared.WATCH_CONDITION.ANY));
+  });
+
   // createWatch validation
   await test('createWatch requires target', () => {
     assert.throws(() => watches.createWatch({ targetType: 'pr', condition: 'merged' }), /target is required/);
@@ -19835,6 +19847,7 @@ async function testWatchesModule() {
     try {
       delete require.cache[require.resolve('../engine/watches')];
       const testWatches = require(path.join(MINIONS_DIR, 'engine', 'watches'));
+      // Use status-change (non-absolute) so stopAfter=0 keeps watch active across multiple triggers
       const w = testWatches.createWatch({
         target: '900',
         targetType: shared.WATCH_TARGET_TYPE.PR,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -20080,6 +20080,17 @@ async function testWatchesDashboard() {
     assert.ok(shared.WATCH_CONDITION.VOTE_CHANGE === 'vote-change',
       'WATCH_CONDITION must have VOTE_CHANGE constant');
   });
+
+  // Regression: #1088 — PROJECTS ReferenceError in checkWatches closure
+  await test('engine.js checkWatches uses getProjects(config), not PROJECTS (regression #1088)', () => {
+    const watchesBlockStart = engineSrc.indexOf("safe('checkWatches'");
+    assert.ok(watchesBlockStart > -1, 'engine.js must contain safe(\'checkWatches\' ...) block');
+    const watchesBlockEnd = engineSrc.indexOf('const adoPollEnabled', watchesBlockStart);
+    assert.ok(watchesBlockEnd > watchesBlockStart, 'Must find end of checkWatches block');
+    const watchesBlock = engineSrc.slice(watchesBlockStart, watchesBlockEnd);
+    assert.ok(!watchesBlock.includes('PROJECTS'),
+      'checkWatches block must NOT reference PROJECTS (undefined variable — causes ReferenceError)');
+  });
 }
 
 // ── #1049: azureauth calls must include --timeout to prevent hanging ──────────


### PR DESCRIPTION
## Summary

- **Fix**: `PROJECTS` was referenced in the `checkWatches` closure in `engine.js` but was never declared in `tickInner` scope, causing a `ReferenceError` every 3 ticks (~3 min). This silently broke the entire watches feature — watches never executed.
- **Change**: Replace `PROJECTS` with `config.projects || []` (the tick-scoped project list that's already available in the closure).
- **Test**: Add regression test that verifies the `checkWatches` block uses `config.projects` instead of `PROJECTS`.

Closes #1088

## Test plan

- [x] New regression test `engine.js checkWatches uses config.projects, not PROJECTS (regression #1088)` passes
- [x] No new test failures introduced (3 pre-existing failures unchanged)
- [ ] After deploy: verify no `ReferenceError` in engine logs after 3+ ticks
- [ ] After deploy: verify watches actually fire (create a test watch and confirm trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)