### PR TITLE
fix(W-mo0cw3ne8l2t): gate review auto-dispatch on adoPollEnabled and evalLoop

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -1898,6 +1898,13 @@ async function discoverFromPrs(config, project) {
 
   const projMeta = { name: project?.name, localPath: project?.localPath };
 
+  // Resolve poll-enabled per project — stale reviewStatus is untrustworthy without poller
+  const isAdoProject = project?.repoHost !== 'github';
+  const pollEnabled = isAdoProject
+    ? (config.engine?.adoPollEnabled ?? DEFAULTS.adoPollEnabled)
+    : (config.engine?.ghPollEnabled ?? DEFAULTS.ghPollEnabled);
+  const evalLoopEnabled = config.engine?.evalLoop !== false;
+
   // Collect active PR dispatches to prevent simultaneous review+fix on same PR
   const dispatch = getDispatch();
   const activePrIds = new Set(
@@ -1946,7 +1953,8 @@ async function discoverFromPrs(config, project) {
     }
 
     // PRs needing review: pending review status and not already reviewed without new commits
-    const autoReview = config.engine?.autoReview !== false;
+    // Gate on pollEnabled — reviewStatus is stale (never updated) when polling is disabled
+    const autoReview = config.engine?.autoReview !== false && pollEnabled;
     const alreadyReviewed = pr.lastReviewedAt && (!pr.lastPushedAt || pr.lastPushedAt <= pr.lastReviewedAt);
     const needsReview = autoReview && reviewStatus === 'pending' && !alreadyReviewed && !evalEscalated;
     if (needsReview) {
@@ -1972,7 +1980,7 @@ async function discoverFromPrs(config, project) {
           } catch {}
           continue;
         }
-      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message}`); }
+      } catch (e) { log('warn', `Pre-dispatch vote check for ${pr.id}: ${e.message} — skipping dispatch`); continue; }
 
       const agentId = resolveAgent('review', config);
       if (!agentId) continue;
@@ -1985,8 +1993,9 @@ async function discoverFromPrs(config, project) {
     }
 
     // PRs with changes requested → route back to author for fix
+    // Gate on evalLoopEnabled — the review→fix cycle is the eval loop
     let fixDispatched = false;
-    if (reviewStatus === 'changes-requested' && !awaitingReReview && !evalEscalated) {
+    if (evalLoopEnabled && reviewStatus === 'changes-requested' && !awaitingReReview && !evalEscalated) {
       const key = `fix-${project?.name || 'default'}-${pr.id}`;
       if (isAlreadyDispatched(key) || isOnCooldown(key, cooldownMs)) continue;
       const agentId = resolveAgent('fix', config, pr.agent);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4646,6 +4646,56 @@ async function testDiscoverFromPrs() {
     assert.ok(src.includes('isOnCooldown') || src.includes('cooldown'),
       'Should check cooldown before creating new PR work');
   });
+
+  // ─── Poll-gated review dispatch (W-mo0cw3ne8l2t) ─────────────────────────
+
+  await test('discoverFromPrs gates autoReview on pollEnabled', () => {
+    // When adoPollEnabled:false (ADO) or ghPollEnabled:false (GitHub), reviewStatus is stale
+    // (never updated because polling is off). autoReview must be gated on pollEnabled.
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(') !== -1
+      ? src.indexOf('\nfunction discoverFromWorkItems(')
+      : src.indexOf('\nasync function discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('pollEnabled'),
+      'discoverFromPrs must resolve pollEnabled per project');
+    assert.ok(fnBody.includes('autoReview') && fnBody.includes('pollEnabled'),
+      'autoReview must be gated on pollEnabled — stale reviewStatus is untrustworthy without poller');
+  });
+
+  await test('discoverFromPrs gates changes-requested fix dispatch on evalLoopEnabled', () => {
+    // evalLoop:false should suppress the review→fix cycle (changes-requested → fix dispatch)
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(') !== -1
+      ? src.indexOf('\nfunction discoverFromWorkItems(')
+      : src.indexOf('\nasync function discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    assert.ok(fnBody.includes('evalLoopEnabled'),
+      'discoverFromPrs must read evalLoop config flag');
+    // The changes-requested fix block should check evalLoopEnabled
+    const changesIdx = fnBody.indexOf("changes-requested");
+    assert.ok(changesIdx !== -1, 'discoverFromPrs should handle changes-requested');
+    const changesBlock = fnBody.slice(Math.max(0, changesIdx - 200), changesIdx + 200);
+    assert.ok(changesBlock.includes('evalLoopEnabled'),
+      'changes-requested fix dispatch must be gated on evalLoopEnabled — evalLoop:false suppresses review→fix cycle');
+  });
+
+  await test('discoverFromPrs pre-dispatch live check catch blocks skip dispatch on error', () => {
+    // When pre-dispatch live ADO/GitHub check fails, must skip dispatch (continue) not fall through
+    const fnStart = src.indexOf('async function discoverFromPrs(');
+    const fnEnd = src.indexOf('\nfunction discoverFromWorkItems(') !== -1
+      ? src.indexOf('\nfunction discoverFromWorkItems(')
+      : src.indexOf('\nasync function discoverFromWorkItems(');
+    const fnBody = src.slice(fnStart, fnEnd);
+    // Pre-dispatch catch blocks should have 'continue' — skipping dispatch on error
+    const skipPattern = /skipping dispatch.*continue/g;
+    const matches = fnBody.match(skipPattern) || [];
+    assert.ok(matches.length >= 1,
+      `Pre-dispatch vote check catch block must skip dispatch (continue) on error (found ${matches.length})`);
+    // Verify the catch block does NOT fall through without continue
+    assert.ok(!fnBody.includes("Pre-dispatch vote check for ${pr.id}: ${e.message}`); }"),
+      'Pre-dispatch catch block should not fall through without continue');
+  });
 }
 
 // ─── Build Fix Retry Cap Tests ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes yemi33/minions#1091

- **Gate `autoReview` on `pollEnabled`**: Resolves `pollEnabled` per project host (ADO vs GitHub) at the top of `discoverFromPrs`. When polling is disabled (`adoPollEnabled: false` / `ghPollEnabled: false`), `autoReview` is false — prevents dispatching reviews based on stale `reviewStatus` that is never updated.
- **Gate `changes-requested` fix dispatch on `evalLoopEnabled`**: Reads `config.engine.evalLoop` and gates the review→fix cycle on it. When `evalLoop: false`, fix agents are not dispatched for `changes-requested` PRs, breaking the eval loop.
- **Pre-dispatch live check: skip dispatch on error**: The `catch` block in the pre-dispatch vote check now has `continue` instead of falling through. When the live ADO/GitHub check fails (e.g., no cached token because polling is off), dispatch is skipped instead of proceeding with stale data.

## Test plan

- [x] 3 new unit tests verify: `pollEnabled` gates `autoReview`, `evalLoopEnabled` gates `changes-requested` fix dispatch, pre-dispatch catch blocks skip dispatch on error
- [x] All 1943 tests pass (3 pre-existing failures in unrelated watches feature)
- [ ] Manual: set `adoPollEnabled: false` and `evalLoop: false` in config — verify no review/fix agents dispatched for ADO PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)