### PR TITLE
feat(W-mo0cwcx0uuyy): fix stopAfter=0 watch expiry — run forever for all conditions

### DIFF
--- a/engine/watches.js
+++ b/engine/watches.js
@@ -11,7 +11,7 @@
 const path = require('path');
 const shared = require('./shared');
 const { safeJson, mutateJsonFileLocked, ts, uid, log, writeToInbox,
-  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION, WATCH_ABSOLUTE_CONDITIONS } = shared;
+  WATCH_STATUS, WATCH_TARGET_TYPE, WATCH_CONDITION } = shared;
 
 // Dynamic path — respects MINIONS_TEST_DIR for test isolation
 function _watchesPath() { return path.join(shared.MINIONS_DIR, 'engine', 'watches.json'); }


### PR DESCRIPTION
## Summary

- **Fixed `stopAfter: 0` auto-expire bug** — absolute conditions (merged, build-fail, build-pass, completed, failed) were incorrectly auto-expiring on first trigger when `stopAfter === 0`, contradicting the "run forever" semantics
- **Fixed cascading notification bug** — unique notification keys per trigger now work correctly because watches stay active for subsequent checks
- **Updated misleading comment** in `shared.js` — `WATCH_ABSOLUTE_CONDITIONS` comment now accurately describes it as a classification constant, not an auto-expire trigger

### Root cause
`checkWatches()` had an `else if (isAbsolute && watch.stopAfter === 0)` branch that forced `EXPIRED` status on absolute conditions even when `stopAfter: 0` (run forever). This contradicted the `stopAfter` API contract where `0` means "no limit".

### Fix
Removed the absolute condition auto-expire branch. Now only `stopAfter > 0 && triggerCount >= stopAfter` expires watches. Users who want fire-once semantics should set `stopAfter: 1`.

Closes #1059

## Test plan
- [x] `stopAfter: 0 never expires the watch (runs forever)` — was FAIL, now PASS
- [x] `unique notification keys per trigger — two triggers produce different inbox files` — was FAIL, now PASS
- [x] All 1942 tests pass (1 pre-existing env-specific failure unrelated to this change)
- [x] No regressions in other watch tests (40+ watch tests all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)