### PR TITLE
fix(W-3pp73vge): scrub stale temp agent IDs from metrics.json

### DIFF
--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -667,6 +667,9 @@ function runCleanup(config, verbose = false) {
     }
   } catch { /* optional — file may not exist */ }
 
+  // 14. Scrub stale temp agent keys from metrics.json
+  try { scrubStaleMetrics(); } catch { /* best-effort cleanup */ }
+
   if (cleaned.ccSessions + cleaned.docSessions + cleaned.cooldowns + cleaned.pidFiles + cleaned.pendingContextsTrimmed > 0) {
     log('info', `Cleanup (resources): ${cleaned.ccSessions} cc-sessions, ${cleaned.docSessions} doc-sessions, ${cleaned.cooldowns} cooldowns, ${cleaned.pendingContextsTrimmed} pendingCtx trimmed, ${cleaned.pidFiles} PID files`);
   }

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -9,7 +9,7 @@ const shared = require('./shared');
 const queries = require('./queries');
 
 const { exec, execSilent, log, ts, ENGINE_DEFAULTS } = shared;
-const { safeJson, safeWrite, safeReadDir, mutateWorkItems, getProjects, projectWorkItemsPath, projectPrPath,
+const { safeJson, safeWrite, safeReadDir, mutateWorkItems, mutateJsonFileLocked, getProjects, projectWorkItemsPath, projectPrPath,
   sanitizeBranch, KB_CATEGORIES } = shared;
 const { getDispatch, getAgentStatus } = queries;
 
@@ -674,9 +674,27 @@ function runCleanup(config, verbose = false) {
   return cleaned;
 }
 
+// ─── Metrics Scrub ──────────────────────────────────────────────────────────
+
+/** Remove stale temp-*, agent1, and _test-* keys from metrics.json.
+ *  Mirrors the guard in lifecycle.js updateMetrics() — cleans up keys
+ *  that were written before that guard existed. */
+function scrubStaleMetrics() {
+  const metricsPath = path.join(ENGINE_DIR, 'metrics.json');
+  if (!fs.existsSync(metricsPath)) return;
+  mutateJsonFileLocked(metricsPath, metrics => {
+    for (const key of Object.keys(metrics)) {
+      if (key.startsWith('temp-') || key === 'agent1' || key.startsWith('_test')) {
+        delete metrics[key];
+      }
+    }
+  });
+}
+
 // ─── Exports ─────────────────────────────────────────────────────────────────
 
 module.exports = {
   runCleanup,
+  scrubStaleMetrics,
   worktreeDirMatchesBranch,  // exported for testing
 };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -16879,6 +16879,45 @@ async function testIsolationVerification() {
     assert.ok(src.includes("temp-") && src.includes("agent1"), 'Should guard test IDs');
   });
 
+  await test('cleanup.js scrubs stale test agent keys from metrics.json', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+    assert.ok(src.includes('metrics.json'), 'cleanup.js should reference metrics.json');
+    assert.ok(src.includes("temp-") || src.includes('temp-'), 'cleanup.js should scrub temp- agent keys');
+  });
+
+  await test('BEHAVIORAL: scrubStaleMetrics removes temp/test keys from metrics.json', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const testShared = require('../engine/shared');
+      const metricsPath = path.join(testShared.MINIONS_DIR, 'engine', 'metrics.json');
+      // Seed metrics with stale temp agent keys + legitimate agent + _engine/_daily
+      const seeded = {
+        'temp-mnyxw3eb0ap5': { tasksCompleted: 1 },
+        'temp-mnyxw31gumvd': { tasksCompleted: 2 },
+        'agent1': { tasksCompleted: 1 },
+        '_test-foo': { tasksCompleted: 1 },
+        'dallas': { tasksCompleted: 10, tasksErrored: 1 },
+        '_engine': { calls: 5 },
+        '_daily': { '2026-04-15': {} },
+      };
+      fs.writeFileSync(metricsPath, JSON.stringify(seeded));
+      const testCleanup = require('../engine/cleanup');
+      testCleanup.scrubStaleMetrics();
+      const after = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
+      // Stale keys removed
+      assert.strictEqual(after['temp-mnyxw3eb0ap5'], undefined, 'temp- key should be removed');
+      assert.strictEqual(after['temp-mnyxw31gumvd'], undefined, 'temp- key should be removed');
+      assert.strictEqual(after['agent1'], undefined, 'agent1 key should be removed');
+      assert.strictEqual(after['_test-foo'], undefined, '_test key should be removed');
+      // Legitimate keys preserved
+      assert.ok(after['dallas'], 'real agent should be preserved');
+      assert.ok(after['_engine'], '_engine should be preserved');
+      assert.ok(after['_daily'], '_daily should be preserved');
+    } finally {
+      restore();
+    }
+  });
+
   await test('shared.js uses MINIONS_TEST_DIR env override', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
     assert.ok(src.includes('MINIONS_TEST_DIR'), 'Should check env var');


### PR DESCRIPTION
## Summary

- Adds `scrubStaleMetrics()` to `engine/cleanup.js` that removes `temp-*`, `agent1`, and `_test-*` keys from `engine/metrics.json`
- Uses `mutateJsonFileLocked` for concurrency-safe read-modify-write
- Mirrors the guard in `lifecycle.js:1333 updateMetrics()` — cleans up keys written before that guard existed

## Investigation

The `updateMetrics` guard (`lifecycle.js:1333`) already blocks test agent IDs from being written:
```js
if (!agentId || agentId.startsWith('temp-') || agentId === 'agent1' || agentId === 'reviewer' || agentId.startsWith('_test')) return;
```
The stale keys (`temp-mnyxw3eb0ap5`, `temp-mnyxw31gumvd`) were written during a test session before this guard existed. `scrubStaleMetrics` provides the cleanup path for any such legacy entries.

## Test plan

- [x] Source check: `cleanup.js` references `metrics.json` and `temp-` — PASS
- [x] Behavioral: `scrubStaleMetrics` removes temp/test keys, preserves `_engine`, `_daily`, real agents — PASS
- [x] Existing `updateMetrics` guard test — PASS
- [x] Full suite: 2000 passed, 2 failed (pre-existing: meeting routing, SessionStart hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)