### PR TITLE
fix(W-8eobrosn): fix GitHub poller maxBuffer exceeded — PR status polling broken

### DIFF
--- a/engine/github.js
+++ b/engine/github.js
@@ -20,6 +20,11 @@ function engine() {
 let _dispatch = null;
 function dispatchModule() { if (!_dispatch) _dispatch = require('./dispatch'); return _dispatch; }
 
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+// 10 MB — prevents maxBuffer exceeded errors on repos with many open PRs.
+// Node.js default is 1 MB which overflows when GitHub API returns 100+ PR objects.
+const GH_MAX_BUFFER = 10 * 1024 * 1024;
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function isGitHub(project) {
@@ -83,11 +88,16 @@ const isGhThrottled = () => _ghThrottle.isThrottled();
 /** Returns a snapshot of the current GitHub throttle state. */
 const getGhThrottleState = () => _ghThrottle.getState();
 
-/** Run a `gh api` call and parse JSON result. Returns null on failure. */
-async function ghApi(endpoint, slug) {
+/** Run a `gh api` call and parse JSON result. Returns null on failure.
+ * @param {string} endpoint - API endpoint (e.g. '/pulls?state=open')
+ * @param {string} slug - owner/repo slug
+ * @param {object} [opts] - Options: { paginate: boolean, timeout: number }
+ */
+async function ghApi(endpoint, slug, opts = {}) {
   try {
-    const cmd = `gh api "repos/${slug}${endpoint}"`;
-    const result = await execAsync(cmd, { timeout: 30000, encoding: 'utf-8' });
+    const paginateFlag = opts.paginate ? ' --paginate' : '';
+    const cmd = `gh api${paginateFlag} "repos/${slug}${endpoint}"`;
+    const result = await execAsync(cmd, { timeout: opts.timeout || 30000, encoding: 'utf-8', maxBuffer: GH_MAX_BUFFER });
     const parsed = JSON.parse(result);
     _ghThrottle.recordSuccess();
     return parsed;
@@ -152,7 +162,7 @@ async function fetchGhBuildErrorLog(slug, failedRuns) {
       // Always fetch job log — annotations alone often lack test failure details
       try {
         const cmd = `gh api "repos/${slug}/actions/jobs/${run.id}/logs" 2>&1`;
-        const result = await execAsync(cmd, { timeout: 15000, encoding: 'utf-8' });
+        const result = await execAsync(cmd, { timeout: 15000, encoding: 'utf-8', maxBuffer: GH_MAX_BUFFER });
         if (result && !result.includes('Not Found')) {
           logParts.push(`--- ${run.name || 'Check'} (log) ---\n${result}`);
         }
@@ -471,7 +481,7 @@ async function pollPrStatus(config) {
       if (autoComplete) {
         try {
           const mergeMethod = ['squash', 'merge', 'rebase'].includes(config.engine?.prMergeMethod) ? config.engine.prMergeMethod : 'squash';
-          await execAsync(`gh pr merge ${prNum} --${mergeMethod} --repo ${slug} --delete-branch`, { timeout: 30000, encoding: 'utf-8' });
+          await execAsync(`gh pr merge ${prNum} --${mergeMethod} --repo ${slug} --delete-branch`, { timeout: 30000, encoding: 'utf-8', maxBuffer: GH_MAX_BUFFER });
           pr._autoCompleted = true;
           log('info', `Auto-completed PR ${pr.id}: builds green + review approved → merged (${mergeMethod})`);
           updated = true;
@@ -612,8 +622,8 @@ async function reconcilePrs(config) {
       } catch { continue; }
     }
 
-    // Fetch open PRs
-    const prsData = await ghApi('/pulls?state=open&per_page=100', slug);
+    // Fetch open PRs — paginate to handle repos with >100 open PRs
+    const prsData = await ghApi('/pulls?state=open&per_page=100', slug, { paginate: true, timeout: 60000 });
     if (!prsData || !Array.isArray(prsData)) {
       recordSlugFailure(slug);
       continue;
@@ -760,4 +770,5 @@ module.exports = {
   resetSlugBackoff,
   _ghPollBackoff,
   _ghThrottle, // exported for testing
+  GH_MAX_BUFFER, // exported for testing
 };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10203,6 +10203,10 @@ async function main() {
     await testDuplicatePrPrevention();
     await testCancelDispatchesOnPrClose();
 
+    // W-8eobrosn: GitHub poller maxBuffer fix
+    await testGhMaxBuffer();
+
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -21553,6 +21557,7 @@ async function testSyncPrsToolResultInUserMessages() {
     }
   });
 }
+
 // ─── W-mo0kxqenseo9: Cancel Work Item ─────────────────────────────────────
 
 async function testCancelWorkItem() {
@@ -21911,6 +21916,116 @@ async function testCancelDispatchesOnPrClose() {
       assert.strictEqual(dispatch.pending.length, 1, 'Queue unchanged for null/empty input');
     } finally { restore(); }
   });
+}
+
+// ─── W-8eobrosn: GitHub poller maxBuffer fix ──────────────────────────────────
+
+async function testGhMaxBuffer() {
+  console.log('\n── W-8eobrosn: GitHub poller maxBuffer fix ──');
+
+  const ghPath = path.join(MINIONS_DIR, 'engine', 'github.js');
+  const ghSrc = fs.readFileSync(ghPath, 'utf8');
+
+  // ── Source-level verification ──
+
+  await test('github.js defines GH_MAX_BUFFER constant (>= 10MB)', () => {
+    assert.ok(ghSrc.includes('GH_MAX_BUFFER'),
+      'github.js must define a GH_MAX_BUFFER constant');
+    // Must be at least 10 * 1024 * 1024
+    const match = ghSrc.match(/GH_MAX_BUFFER\s*=\s*(\d+)\s*\*\s*(\d+)\s*\*\s*(\d+)/);
+    assert.ok(match, 'GH_MAX_BUFFER must be defined as a product (e.g. 10 * 1024 * 1024)');
+    const value = parseInt(match[1]) * parseInt(match[2]) * parseInt(match[3]);
+    assert.ok(value >= 10 * 1024 * 1024,
+      `GH_MAX_BUFFER must be >= 10MB, got ${value}`);
+  });
+
+  await test('ghApi passes maxBuffer to execAsync', () => {
+    const ghApiFn = ghSrc.match(/async function ghApi[\s\S]*?^}/m);
+    assert.ok(ghApiFn, 'ghApi function must exist');
+    const src = ghApiFn[0];
+    assert.ok(src.includes('maxBuffer') && src.includes('GH_MAX_BUFFER'),
+      'ghApi must pass maxBuffer: GH_MAX_BUFFER to execAsync');
+  });
+
+  await test('fetchGhBuildErrorLog passes maxBuffer to execAsync', () => {
+    const fn = ghSrc.match(/async function fetchGhBuildErrorLog[\s\S]*?^}/m);
+    assert.ok(fn, 'fetchGhBuildErrorLog function must exist');
+    const src = fn[0];
+    assert.ok(src.includes('maxBuffer'),
+      'fetchGhBuildErrorLog must pass maxBuffer to execAsync for log fetch');
+  });
+
+  await test('gh pr merge in pollPrStatus passes maxBuffer to execAsync', () => {
+    // The auto-complete merge call also uses execAsync — ensure maxBuffer is set
+    assert.ok(ghSrc.includes("gh pr merge") && ghSrc.includes('GH_MAX_BUFFER'),
+      'Auto-complete merge call must use GH_MAX_BUFFER');
+  });
+
+  await test('reconcilePrs uses pagination to fetch all open PRs', () => {
+    // reconcilePrs must use --paginate flag on gh api or loop through pages
+    const reconcileFn = ghSrc.slice(ghSrc.indexOf('async function reconcilePrs'));
+    assert.ok(reconcileFn.includes('paginate'),
+      'reconcilePrs must use pagination to handle repos with >100 open PRs');
+  });
+
+  await test('ghApi supports paginate option', () => {
+    // ghApi must accept an opts parameter with paginate support
+    const ghApiFn = ghSrc.match(/async function ghApi[\s\S]*?^}/m);
+    assert.ok(ghApiFn, 'ghApi function must exist');
+    const src = ghApiFn[0];
+    assert.ok(src.includes('paginate'),
+      'ghApi must support a paginate option for endpoints returning arrays');
+  });
+
+  // ── Runtime verification ──
+
+  await test('GH_MAX_BUFFER exported value is at least 10MB', () => {
+    const gh = require(ghPath);
+    assert.ok(typeof gh.GH_MAX_BUFFER === 'number', 'GH_MAX_BUFFER must be exported as a number');
+    assert.ok(gh.GH_MAX_BUFFER >= 10 * 1024 * 1024,
+      `GH_MAX_BUFFER runtime value must be >= 10MB, got ${gh.GH_MAX_BUFFER}`);
+  });
+
+  await test('GH_MAX_BUFFER can hold 250+ PR JSON objects (simulated large response)', () => {
+    // Simulate what gh api --paginate returns for 250 open PRs
+    // Each PR object from GitHub REST API is roughly 3-8KB of JSON
+    const gh = require(ghPath);
+    const fakePr = {
+      number: 1, state: 'open',
+      title: 'feat: implement feature ABCDEF — a reasonably long title for testing',
+      body: 'This is a PR description with some content. '.repeat(20), // ~900 chars
+      head: { ref: 'work/W-abc123def456', sha: 'a'.repeat(40), repo: { full_name: 'org/repo' } },
+      base: { ref: 'master', sha: 'b'.repeat(40), repo: { full_name: 'org/repo' } },
+      user: { login: 'dallas', id: 12345, avatar_url: 'https://example.com/avatar.png' },
+      html_url: 'https://github.com/org/repo/pull/1',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-04-15T00:00:00Z',
+      labels: [{ name: 'enhancement' }, { name: 'agent-generated' }],
+      assignees: [{ login: 'dallas' }],
+      requested_reviewers: [{ login: 'ripley' }],
+      mergeable: true, mergeable_state: 'clean',
+      additions: 150, deletions: 30, changed_files: 5,
+    };
+    // Build an array of 300 PRs (well above the 246 that triggered the bug)
+    const prs = Array.from({ length: 300 }, (_, i) => ({ ...fakePr, number: i + 1 }));
+    const jsonStr = JSON.stringify(prs);
+    const byteSize = Buffer.byteLength(jsonStr, 'utf8');
+    assert.ok(byteSize < gh.GH_MAX_BUFFER,
+      `300 simulated PRs produce ${(byteSize / 1024 / 1024).toFixed(2)}MB — must fit in GH_MAX_BUFFER (${(gh.GH_MAX_BUFFER / 1024 / 1024).toFixed(0)}MB)`);
+  });
+
+  await test('all execAsync calls in github.js include maxBuffer', () => {
+    // Every execAsync call in github.js must pass maxBuffer — none should use Node default
+    const execCalls = ghSrc.match(/execAsync\([^)]*\)/g) || [];
+    assert.ok(execCalls.length >= 3,
+      `Expected at least 3 execAsync calls in github.js, found ${execCalls.length}`);
+    for (const call of execCalls) {
+      assert.ok(call.includes('maxBuffer') || call.includes('GH_MAX_BUFFER'),
+        `execAsync call missing maxBuffer: ${call.slice(0, 80)}...`);
+    }
+  });
+
+  delete require.cache[require.resolve(ghPath)];
 }
 
 main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- **Added `GH_MAX_BUFFER` (10MB) constant** to `engine/github.js` and applied it to all 3 `execAsync` call sites: `ghApi()`, `fetchGhBuildErrorLog()`, and the `gh pr merge` auto-complete path. Node.js default is 1MB which overflows when GitHub returns 100+ PR objects.
- **Added `--paginate` support** to `ghApi()` via a new `opts.paginate` parameter, and enabled it in `reconcilePrs()` to fetch all pages of open PRs (the repo has 246 open PRs across 3+ pages).
- **Added 9 tests** covering: source-level verification of maxBuffer on every execAsync call, runtime constant value check, and a behavioral test simulating 300 PR JSON objects to verify they fit within the buffer.

## Root cause

`engine/github.js` spawned `gh api` commands via `execAsync()` without a `maxBuffer` option, defaulting to Node.js's 1MB limit. With 246 open PRs, the paginated GitHub API response exceeded 1MB, causing `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` and breaking all PR status/build/comment polling (44 failures today).

## Test plan

- [x] All 9 new W-8eobrosn tests pass
- [x] Full test suite: 2007 passed, 2 failed (pre-existing), 0 regressions
- [x] Simulated 300-PR JSON payload verified to fit within 10MB buffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)