### PR TITLE
feat(W-mo0kr8tuldlr): Intercept /loop skill invocations in CC and convert to watches

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -607,6 +607,65 @@ function parseCCActions(text) {
   return { text: displayText, actions };
 }
 
+// ── /loop → create-watch safety net ──────────────────────────────────────────
+// CC sometimes invokes the /loop skill instead of emitting a create-watch action.
+// This pure function detects /loop invocation in CC response text and synthesizes
+// a create-watch action as a fallback. Returns null if no conversion needed.
+
+function _detectLoopInvocation(text, actions) {
+  if (!text) return null;
+  // If a create-watch action was already emitted, no fallback needed
+  if (actions && actions.some(a => a.type === 'create-watch')) return null;
+
+  // Check for /loop invocation patterns in CC response
+  const loopPatterns = [
+    /\/loop\b/i,
+    /\bloop skill\b/i,
+    /\bSkill.*\bloop\b/i,
+    /\bstarted.*\bloop\b/i,
+    /\bmonitoring.*\bloop\b/i,
+    /\binvok(?:e|ed|ing).*\bloop\b/i,
+  ];
+  if (!loopPatterns.some(p => p.test(text))) return null;
+
+  // Extract target — PR number or work item ID
+  const prMatch = text.match(/\bPR[- #]?(\d+)\b/i) || text.match(/\bpull[- ]request[- #]?(\d+)/i);
+  const wiMatch = text.match(/\bW-([a-z0-9]+)\b/);
+
+  let target = null, targetType = 'pr';
+  if (prMatch) {
+    target = prMatch[1];
+    targetType = 'pr';
+  } else if (wiMatch) {
+    target = 'W-' + wiMatch[1];
+    targetType = 'work-item';
+  }
+  if (!target) return null; // Can't synthesize without a target
+
+  // Extract interval (e.g. "every 15 minutes", "every 5m")
+  const intervalMatch = text.match(/every\s+(\d+)\s*(s|sec|seconds?|m|min|minutes?|h|hr|hours?)\b/i);
+  let interval = '5m';
+  if (intervalMatch) interval = intervalMatch[1] + intervalMatch[2][0];
+
+  // Infer condition from keywords
+  let condition = 'any';
+  if (/\bbuild\b/i.test(text) && /\b(?:pass(?:es|ing|ed)?|green|succeed(?:s|ed)?|success)\b/i.test(text)) condition = 'build-pass';
+  else if (/\bbuild\b/i.test(text) && /\b(?:fail(?:s|ing|ed)?|red|broken|broke)\b/i.test(text)) condition = 'build-fail';
+  else if (/\bmerge[d]?\b/i.test(text)) condition = 'merged';
+  else if (/\bcomplete[d]?\b/i.test(text)) condition = 'completed';
+
+  return {
+    type: 'create-watch',
+    target,
+    targetType,
+    condition,
+    interval,
+    owner: 'human',
+    description: 'Auto-converted from /loop invocation',
+    stopAfter: condition === 'any' ? 0 : 1,
+  };
+}
+
 // ── Server-side CC action execution ──────────────────────────────────────────
 // Actions are executed server-side so all clients (frontend, curl, Teams) get the same behavior.
 // The frontend still shows status toasts but no longer needs to fire the API calls.
@@ -3523,6 +3582,13 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         }
 
         const parsed = parseCCActions(result.text);
+        // Safety net: detect /loop invocation and convert to create-watch
+        const _loopWatch = _detectLoopInvocation(parsed.text, parsed.actions);
+        if (_loopWatch) {
+          parsed.actions.push(_loopWatch);
+          console.warn('[CC] /loop invocation detected — converted to create-watch');
+          try { shared.log('warn', '/loop invocation detected in CC response — auto-converted to create-watch'); } catch {}
+        }
         if (parsed.actions.length > 0) {
           parsed.actionResults = await executeCCActions(parsed.actions);
         }
@@ -3685,6 +3751,13 @@ What would you like to discuss or change? When you're happy, say "approve" and I
 
         // Send final result with actions — execute server-side first
         const { text: displayText, actions } = parseCCActions(result.text);
+        // Safety net: detect /loop invocation and convert to create-watch
+        const _loopWatch = _detectLoopInvocation(displayText, actions);
+        if (_loopWatch) {
+          actions.push(_loopWatch);
+          console.warn('[CC] /loop invocation detected — converted to create-watch');
+          try { shared.log('warn', '/loop invocation detected in CC response — auto-converted to create-watch'); } catch {}
+        }
         let actionResults;
         if (actions.length > 0) {
           actionResults = await executeCCActions(actions);

--- a/prompts/cc-system.md
+++ b/prompts/cc-system.md
@@ -94,8 +94,11 @@ Additional actions (all take `id` or `file` as primary key):
 - Work item ops: delete-work-item (id, source), archive-work-item (id), work-item-feedback (id, rating: up/down, comment), reopen-work-item (id, project[, description] — reopen a done/failed item back to pending)
 - PRD ops: edit-prd-item, remove-prd-item, reopen-prd-item (id, file — re-dispatches on existing branch)
 - **create-watch**: target, targetType (pr/work-item), condition (merged/build-fail/build-pass/completed/failed/status-change/any/new-comments/vote-change), interval ("15m", "1h", "30s" — default "5m"), owner (agent id or "human"), description, project, stopAfter (0=run forever, 1=expire on first match, N=expire after N matches), onNotMet (null=do nothing, "notify"=write to inbox each poll while condition not met)
+  **NEVER use the /loop skill for monitoring tasks.** Always use the `create-watch` action — it persists across engine restarts and appears in the Watches page. /loop runs ephemerally in the session and leaves no trace.
+  Trigger phrases: user says "keep an eye on X", "watch X every N min", "monitor X", "check X periodically", "ping me when X" → always emit `create-watch`.
   Example: user says "check PR 1065 build every 15 min until green" → `{"type":"create-watch","target":"1065","targetType":"pr","condition":"build-pass","interval":"15m","stopAfter":1,"description":"Watch PR 1065 build until green"}`
   Example: user says "ping me every 15 min while build is still failing" → `{"type":"create-watch","target":"1065","targetType":"pr","condition":"build-pass","interval":"15m","stopAfter":1,"onNotMet":"notify","description":"Watch PR 1065 build — notify each poll"}`
+  Example: user says "keep an eye on PR 200 every 5 min" → `{"type":"create-watch","target":"200","targetType":"pr","condition":"any","interval":"5m","stopAfter":0,"description":"Monitor PR 200"}`
 - **delete-watch**: id — remove a watch permanently
   Example: user says "stop watching PR 1065" → `{"type":"delete-watch","id":"watch-abc123"}`
 - **pause-watch**: id — pause a watch without deleting it (can be resumed later)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9647,6 +9647,9 @@ async function main() {
     await testWatchesModule();
     await testWatchesDashboard();
 
+    // W-mo0kr8tuldlr: /loop → create-watch interception
+    await testLoopToWatchInterception();
+
     // #1049: azureauth --timeout enforcement
     await testAzureauthTimeout();
 
@@ -20283,6 +20286,218 @@ async function testWatchesDashboard() {
     const watchesBlock = engineSrc.slice(watchesBlockStart, watchesBlockEnd);
     assert.ok(!watchesBlock.includes('PROJECTS'),
       'checkWatches block must NOT reference PROJECTS (undefined variable — causes ReferenceError)');
+  });
+}
+
+// ── W-mo0kr8tuldlr: /loop → create-watch interception ────────────────────────
+async function testLoopToWatchInterception() {
+  console.log('\n── /loop → create-watch interception ──');
+
+  const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  // Extract _detectLoopInvocation for behavioral testing
+  const fnBody = dashSrc.match(/function _detectLoopInvocation[\s\S]*?^}/m)[0];
+  const detectLoopInvocation = new Function(fnBody + '\nreturn _detectLoopInvocation;')();
+
+  // ── Behavioral tests — detection ──
+
+  await test('_detectLoopInvocation returns null for normal text', () => {
+    assert.strictEqual(detectLoopInvocation('I created a watch for PR 1065.', []), null);
+  });
+
+  await test('_detectLoopInvocation returns null when text is empty', () => {
+    assert.strictEqual(detectLoopInvocation('', []), null);
+    assert.strictEqual(detectLoopInvocation(null, []), null);
+  });
+
+  await test('_detectLoopInvocation returns null when create-watch already emitted', () => {
+    const text = 'I started a /loop to monitor PR 1065.';
+    const actions = [{ type: 'create-watch', target: '1065' }];
+    assert.strictEqual(detectLoopInvocation(text, actions), null,
+      'should skip when create-watch already in actions');
+  });
+
+  await test('_detectLoopInvocation detects /loop mention with PR target', () => {
+    const result = detectLoopInvocation('I\'ll start /loop to monitor PR 1065 build.', []);
+    assert.ok(result, 'should detect /loop invocation');
+    assert.strictEqual(result.type, 'create-watch');
+    assert.strictEqual(result.target, '1065');
+    assert.strictEqual(result.targetType, 'pr');
+  });
+
+  await test('_detectLoopInvocation detects "loop skill" phrasing', () => {
+    const result = detectLoopInvocation('Using the loop skill to watch PR-200 every 15m.', []);
+    assert.ok(result, 'should detect loop skill mention');
+    assert.strictEqual(result.target, '200');
+    assert.strictEqual(result.targetType, 'pr');
+  });
+
+  await test('_detectLoopInvocation detects "Skill.*loop" pattern', () => {
+    const result = detectLoopInvocation('I invoked Skill: loop to monitor PR-42.', []);
+    assert.ok(result, 'should detect Skill...loop mention');
+    assert.strictEqual(result.target, '42');
+  });
+
+  await test('_detectLoopInvocation detects "started.*loop" pattern', () => {
+    const result = detectLoopInvocation('I started a loop to keep an eye on PR 999.', []);
+    assert.ok(result, 'should detect started...loop');
+    assert.strictEqual(result.target, '999');
+  });
+
+  await test('_detectLoopInvocation detects "monitoring.*loop" pattern', () => {
+    const result = detectLoopInvocation('Monitoring via loop — PR 50 build status.', []);
+    assert.ok(result, 'should detect monitoring...loop');
+    assert.strictEqual(result.target, '50');
+  });
+
+  await test('_detectLoopInvocation detects "invoked.*loop" pattern', () => {
+    const result = detectLoopInvocation('I invoked the loop to watch PR 123.', []);
+    assert.ok(result, 'should detect invoked...loop');
+    assert.strictEqual(result.target, '123');
+  });
+
+  await test('_detectLoopInvocation returns null when no target found', () => {
+    const result = detectLoopInvocation('I started a /loop to monitor things.', []);
+    assert.strictEqual(result, null, 'should return null when no PR or WI target');
+  });
+
+  // ── Target extraction ──
+
+  await test('_detectLoopInvocation extracts work item ID target', () => {
+    const result = detectLoopInvocation('/loop checking on W-abc123def status.', []);
+    assert.ok(result, 'should detect /loop with work item target');
+    assert.strictEqual(result.target, 'W-abc123def');
+    assert.strictEqual(result.targetType, 'work-item');
+  });
+
+  await test('_detectLoopInvocation prefers PR target over work item', () => {
+    const result = detectLoopInvocation('/loop monitoring PR 500 and W-xyz123.', []);
+    assert.ok(result);
+    assert.strictEqual(result.target, '500', 'PR target should take precedence');
+    assert.strictEqual(result.targetType, 'pr');
+  });
+
+  await test('_detectLoopInvocation extracts PR from "pull request 42" format', () => {
+    const result = detectLoopInvocation('/loop watching pull request 42.', []);
+    assert.ok(result);
+    assert.strictEqual(result.target, '42');
+    assert.strictEqual(result.targetType, 'pr');
+  });
+
+  // ── Interval extraction ──
+
+  await test('_detectLoopInvocation extracts interval from "every N min"', () => {
+    const result = detectLoopInvocation('/loop checking PR 100 every 15 minutes.', []);
+    assert.ok(result);
+    assert.strictEqual(result.interval, '15m');
+  });
+
+  await test('_detectLoopInvocation extracts interval from "every N h"', () => {
+    const result = detectLoopInvocation('/loop monitoring PR 100 every 2 hours.', []);
+    assert.ok(result);
+    assert.strictEqual(result.interval, '2h');
+  });
+
+  await test('_detectLoopInvocation defaults interval to 5m', () => {
+    const result = detectLoopInvocation('/loop watching PR 100.', []);
+    assert.ok(result);
+    assert.strictEqual(result.interval, '5m');
+  });
+
+  // ── Condition inference ──
+
+  await test('_detectLoopInvocation infers build-pass condition', () => {
+    const result = detectLoopInvocation('/loop checking PR 100 build until green.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'build-pass');
+  });
+
+  await test('_detectLoopInvocation infers build-fail condition', () => {
+    const result = detectLoopInvocation('/loop monitoring PR 100 when build is failing.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'build-fail');
+  });
+
+  await test('_detectLoopInvocation infers merged condition', () => {
+    const result = detectLoopInvocation('/loop watching PR 100 until merged.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'merged');
+  });
+
+  await test('_detectLoopInvocation infers completed condition', () => {
+    const result = detectLoopInvocation('/loop monitoring W-abc123 until completed.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'completed');
+  });
+
+  await test('_detectLoopInvocation defaults condition to any', () => {
+    const result = detectLoopInvocation('/loop watching PR 100 status.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'any');
+  });
+
+  // ── Synthesized action shape ──
+
+  await test('_detectLoopInvocation synthesizes correct action shape', () => {
+    const result = detectLoopInvocation('/loop checking PR 200 build every 10 minutes until passing.', []);
+    assert.ok(result);
+    assert.strictEqual(result.type, 'create-watch');
+    assert.strictEqual(result.target, '200');
+    assert.strictEqual(result.targetType, 'pr');
+    assert.strictEqual(result.condition, 'build-pass');
+    assert.strictEqual(result.interval, '10m');
+    assert.strictEqual(result.owner, 'human');
+    assert.strictEqual(result.stopAfter, 1, 'non-any conditions should set stopAfter=1');
+    assert.ok(result.description.includes('/loop'), 'description should mention /loop conversion');
+  });
+
+  await test('_detectLoopInvocation sets stopAfter=0 for any condition', () => {
+    const result = detectLoopInvocation('/loop watching PR 300 status.', []);
+    assert.ok(result);
+    assert.strictEqual(result.condition, 'any');
+    assert.strictEqual(result.stopAfter, 0, 'any condition should run forever');
+  });
+
+  // ── Integration: source-level checks ──
+
+  await test('dashboard.js non-streaming path calls _detectLoopInvocation after parseCCActions', () => {
+    // handleCommandCenter should call _detectLoopInvocation after parsing actions
+    const handleCC = dashSrc.match(/async function handleCommandCenter[\s\S]*?^}/m);
+    assert.ok(handleCC, 'handleCommandCenter must exist');
+    const fnText = handleCC[0];
+    assert.ok(fnText.includes('_detectLoopInvocation'), 'non-streaming path must call _detectLoopInvocation');
+    // Ensure it's called after parseCCActions
+    const parseIdx = fnText.indexOf('parseCCActions');
+    const detectIdx = fnText.indexOf('_detectLoopInvocation');
+    assert.ok(parseIdx > -1 && detectIdx > parseIdx,
+      '_detectLoopInvocation must be called after parseCCActions in non-streaming path');
+  });
+
+  await test('dashboard.js streaming path calls _detectLoopInvocation after parseCCActions', () => {
+    const handleStream = dashSrc.match(/async function handleCommandCenterStream[\s\S]*?^}/m);
+    assert.ok(handleStream, 'handleCommandCenterStream must exist');
+    const fnText = handleStream[0];
+    assert.ok(fnText.includes('_detectLoopInvocation'), 'streaming path must call _detectLoopInvocation');
+    const parseIdx = fnText.indexOf('parseCCActions');
+    const detectIdx = fnText.indexOf('_detectLoopInvocation');
+    assert.ok(parseIdx > -1 && detectIdx > parseIdx,
+      '_detectLoopInvocation must be called after parseCCActions in streaming path');
+  });
+
+  await test('CC system prompt warns against /loop for monitoring', () => {
+    const prompt = fs.readFileSync(path.join(MINIONS_DIR, 'prompts', 'cc-system.md'), 'utf8');
+    assert.ok(prompt.includes('NEVER use the /loop skill'),
+      'CC prompt must warn against using /loop');
+    assert.ok(prompt.includes('create-watch'),
+      'CC prompt must redirect to create-watch');
+  });
+
+  await test('CC system prompt has trigger phrase examples for create-watch', () => {
+    const prompt = fs.readFileSync(path.join(MINIONS_DIR, 'prompts', 'cc-system.md'), 'utf8');
+    assert.ok(prompt.includes('keep an eye on'),
+      'CC prompt should include "keep an eye on" trigger phrase');
+    assert.ok(prompt.includes('monitor'),
+      'CC prompt should include "monitor" trigger phrase');
   });
 }
 


### PR DESCRIPTION
## Summary
- **CC system prompt**: Added explicit directive to NEVER use `/loop` for monitoring tasks, with trigger phrase examples directing CC to emit `create-watch` actions instead
- **Safety net in dashboard.js**: Added `_detectLoopInvocation()` that scans CC responses for /loop patterns and auto-synthesizes a `create-watch` action when no watch was already emitted — integrated in both streaming and non-streaming CC response paths
- **27 new tests**: Behavioral tests covering detection patterns, target extraction (PR numbers, work item IDs), interval parsing, condition inference (build-pass/build-fail/merged/completed/any), action shape validation, and integration point verification

## Test plan
- [x] All 27 new tests pass (`testLoopToWatchInterception`)
- [x] No regressions — baseline 2003 → 2030 passed, 1 pre-existing failure unchanged
- [ ] Manual: send CC a message like "keep an eye on PR 200 every 5 min" and verify a watch is created (not a /loop)
- [ ] Manual: verify if CC somehow emits /loop text, the safety net converts it to a watch entry in watches.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)