### PR TITLE
fix(W-mo1ircuy1r7h): scheduler enabled field falsy check treats undefined as disabled

### DIFF
--- a/engine/scheduler.js
+++ b/engine/scheduler.js
@@ -114,7 +114,7 @@ function discoverScheduledWork(config) {
   mutateJsonFileLocked(SCHEDULE_RUNS_PATH, (runs) => {
     for (const sched of schedules) {
       if (!sched.id || !sched.cron || !sched.title) continue;
-      if (!sched.enabled) continue; // truthy check — matches dashboard UI badge behavior
+      if (sched.enabled === false) continue; // strict false check — undefined/null default to enabled per schema
 
       // Backward compat: runs[sched.id] can be a string (old format) or object (new format)
       const runEntry = runs[sched.id] || null;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -11510,23 +11510,23 @@ async function testAuxModuleBugFixes() {
   });
 
   // Bug #35: scheduler treats undefined/null enabled as disabled
-  await test('scheduler.js: falsy enabled skips schedule', () => {
+  // Fix: only skip schedules explicitly set to enabled === false
+  // undefined/null should default to enabled (per schema: enabled?: boolean -- default true)
+  await test('scheduler.js: only sched.enabled === false skips schedule', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'scheduler.js'), 'utf8');
-    assert.ok(src.includes('!sched.enabled'), 'Should use truthy check to match dashboard UI behavior');
+    assert.ok(src.includes('sched.enabled === false'), 'Should use strict false check so undefined/null default to enabled');
+    assert.ok(!src.includes('!sched.enabled'), 'Should NOT use truthy check — that treats undefined as disabled');
   });
 
-  await test('scheduler discoverScheduledWork skips undefined-enabled schedules', () => {
-    // Functional test: create a schedule with undefined enabled
-    const tmpDir = createTmpDir();
-    const origPath = scheduler.SCHEDULE_RUNS_PATH;
-    // We can't easily override the path, so test the source logic instead
+  await test('scheduler discoverScheduledWork treats omitted enabled as enabled', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'scheduler.js'), 'utf8');
-    // Verify the line that checks enabled
-    assert.ok(src.includes('!sched.enabled'), 'Should use truthy check — matches dashboard UI enabled badge');
-    // A schedule with enabled:undefined should be skipped
-    // A schedule with enabled:null should be skipped
-    // A schedule with enabled:false should be skipped
-    // Only enabled:true should pass
+    // Verify the strict false check
+    assert.ok(src.includes('sched.enabled === false'), 'Should use strict false check — matches schema default true');
+    // With the fix:
+    // A schedule with enabled:undefined should run (default true)
+    // A schedule with enabled:null should run (default true)
+    // A schedule with enabled:true should run
+    // Only enabled:false should be skipped
   });
 
   // Bug #36: spawn-agent registers exit/SIGTERM handler for temp file cleanup
@@ -13271,12 +13271,14 @@ async function testEngineAuditCritical() {
       'resolveWorkItemPath must return null for unrecognized source');
   });
 
-  await test('scheduler enabled check uses truthy, not strict equality', () => {
+  await test('scheduler enabled check uses strict false, not truthy check', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'scheduler.js'), 'utf8');
     assert.ok(!src.includes('sched.enabled !== true'),
       'scheduler must not use strict !== true check — schedules with enabled:undefined would silently never fire');
-    assert.ok(src.includes('!sched.enabled'),
-      'scheduler should use truthy check to match dashboard UI behavior');
+    assert.ok(src.includes('sched.enabled === false'),
+      'scheduler should use strict false check so undefined/null default to enabled per schema');
+    assert.ok(!src.includes('!sched.enabled'),
+      'scheduler must not use truthy check — that treats undefined as disabled, breaking the schema default');
   });
 }
 


### PR DESCRIPTION
## Summary

- **Bug:** `if (!sched.enabled) continue` in `engine/scheduler.js:117` treats `enabled: undefined` (field omitted) as disabled, silently skipping schedules that should run per the schema (`enabled?: boolean -- default true`).
- **Fix:** Changed to `if (sched.enabled === false) continue` — only schedules explicitly set to `false` are skipped; `undefined`/`null` default to enabled.
- **Tests:** Updated 3 source-inspection tests (Bug #35 and a duplicate guard test) to assert the corrected strict-false check instead of the buggy truthy check.

## Test plan
- [x] Updated existing tests to assert correct behavior (TDD: tests failed before fix, pass after)
- [x] Full test suite: 2119 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)