### PR TITLE
feat(P-a5e9c1d7): Split getStatus() into fast/slow state tiers

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -302,10 +302,16 @@ function parsePinnedEntries(content) {
   return entries;
 }
 
+// Two-tier status cache: fast state (10s) for frequently-changing data, slow state (60s) for rarely-changing data.
+// Combined into _statusCache for API/SSE consumers — no API contract change.
+let _fastState = null;
+let _fastStateTs = 0;
+const FAST_STATE_TTL = 10000; // 10s — dispatch, agents, metrics, work items, etc.
+let _slowState = null;
+let _slowStateTs = 0;
+const SLOW_STATE_TTL = 60000; // 60s — skills, PRDs, pinned, version, projects, etc.
 let _statusCache = null;
 let _statusCacheJson = null; // cached JSON.stringify(_statusCache) — avoids double-serialization for SSE
-let _statusCacheTs = 0;
-const STATUS_CACHE_TTL = 10000; // 10s — reduces expensive aggregation frequency; mutations call invalidateStatusCache()
 const _statusStreamClients = new Set();
 let _statusPushTimer = null;
 let _lastStatusHash = '';
@@ -348,6 +354,9 @@ function _mtimesChanged(prev, curr) {
 }
 
 function invalidateStatusCache() {
+  _fastState = null;
+  _fastStateTs = 0;
+  // Slow state continues on its own TTL — not invalidated by mutations
   _statusCache = null;
   _statusCacheJson = null;
   // Push to SSE clients (debounced 500ms to avoid flooding during batch mutations)
@@ -364,89 +373,109 @@ function invalidateStatusCache() {
 
 function getStatus() {
   const now = Date.now();
-  if (_statusCache && (now - _statusCacheTs) < STATUS_CACHE_TTL) {
-    // Within TTL — check mtimes for early return (skip full rebuild if nothing changed)
+
+  // Fast state: 10s TTL with mtime-based validation for early exit
+  let fastStale = !_fastState || (now - _fastStateTs) >= FAST_STATE_TTL;
+  if (!fastStale) {
+    // Within TTL — check mtimes for early return (skip rebuild if no tracked files changed)
     const currMtimes = _getMtimes();
-    if (!_mtimesChanged(_lastMtimes, currMtimes)) return _statusCache;
+    if (_mtimesChanged(_lastMtimes, currMtimes)) fastStale = true;
   }
 
-  // Reload config on each cache miss — picks up external changes (minions init, minions add)
-  reloadConfig();
+  // Slow state: 60s TTL, pure TTL (no mtime check — these files change rarely)
+  const slowStale = !_slowState || (now - _slowStateTs) >= SLOW_STATE_TTL;
 
-  const prdInfo = getPrdInfo();
-  _statusCache = {
-    agents: getAgents(),
-    prdProgress: prdInfo.progress,
-    inbox: getInbox(),
-    notes: getNotesWithMeta(),
-    prd: prdInfo.status,
-    pullRequests: getPullRequests(),
-    verifyGuides: getVerifyGuides(),
-    archivedPrds: getArchivedPrds(),
-    engine: { ...getEngineState(), worktreeCount: _countWorktrees() },
-    adoThrottle: ado.getAdoThrottleState(),
-    ghThrottle: gh.getGhThrottleState(),
-    dispatch: getDispatchQueue(),
-    engineLog: getEngineLog(),
-    metrics: getMetrics(),
-    workItems: getWorkItems(),
-    skills: getSkills(),
-    mcpServers: getMcpServers(),
-    schedules: (() => {
-      const scheds = CONFIG.schedules || [];
-      const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
-      return scheds.map(s => {
-        const runEntry = runs[s.id];
-        // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
-        const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
-        const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
-        return { ...s, _lastRun, ...extra };
-      });
-    })(),
-    watches: watchesMod.getWatches(),
-    meetings: (() => { try { return require('./engine/meeting').getMeetings(); } catch { return []; } })(),
-    pipelines: (() => { try { const pl = require('./engine/pipeline'); return pl.getPipelines().map(p => ({ ...p, runs: (pl.getPipelineRuns()[p.id] || []).slice(-5) })); } catch { return []; } })(),
-    pinned: (() => { try { return parsePinnedEntries(safeRead(path.join(MINIONS_DIR, 'pinned.md'))); } catch { return []; } })(),
-    projects: PROJECTS.map(p => ({ name: p.name, path: p.localPath, description: p.description || '' })),
-    autoMode: {
-      approvePlans: !!CONFIG.engine?.autoApprovePlans,
-      decompose: CONFIG.engine?.autoDecompose !== false,
-      tempAgents: !!CONFIG.engine?.allowTempAgents,
-      inboxThreshold: CONFIG.engine?.inboxConsolidateThreshold || shared.ENGINE_DEFAULTS.inboxConsolidateThreshold,
-      ccModel: CONFIG.engine?.ccModel || shared.ENGINE_DEFAULTS.ccModel,
-      ccEffort: CONFIG.engine?.ccEffort || shared.ENGINE_DEFAULTS.ccEffort,
-    },
-    initialized: !!(CONFIG.agents && Object.keys(CONFIG.agents).length > 0),
-    installId: safeRead(path.join(MINIONS_DIR, '.install-id')).trim() || null,
-    version: (() => {
-      const engine = getEngineState();
-      const { diskVersion, diskCommit, isGitRepo } = getDiskVersion();
-      const engineStale = !!(engine.codeVersion && diskVersion && engine.codeVersion !== diskVersion) ||
-                          !!(engine.codeCommit && diskCommit && engine.codeCommit !== diskCommit);
-      const dashboardStale = !!(diskVersion && _dashboardVersion.codeVersion && diskVersion !== _dashboardVersion.codeVersion) ||
-                             !!(diskCommit && _dashboardVersion.codeCommit && diskCommit !== _dashboardVersion.codeCommit);
-      return {
-        running: engine.codeVersion || null,
-        runningCommit: engine.codeCommit || null,
-        dashboardRunning: _dashboardVersion.codeVersion,
-        dashboardRunningCommit: _dashboardVersion.codeCommit,
-        dashboardStartedAt: _dashboardVersion.startedAt,
-        disk: diskVersion,
-        diskCommit,
-        engineStale,
-        dashboardStale,
-        stale: engineStale || dashboardStale,
-        latest: _npmVersionCache?.latest || null,
-        // Only show "update available" for npm installs (no git repo) — repo users manage their own updates
-        updateAvailable: !isGitRepo && !!(diskVersion && _npmVersionCache?.latest && _npmVersionCache.latest !== diskVersion && _compareVersions(_npmVersionCache.latest, diskVersion) > 0),
-        _npmCheckError: _npmVersionCache?.error || null,
-      };
-    })(),
-    timestamp: new Date().toISOString(),
-  };
-  _statusCacheTs = now;
+  // If nothing stale, return cached merged result
+  if (!fastStale && !slowStale && _statusCache) return _statusCache;
+
+  // Rebuild fast state (frequently-changing data: ~12-15 reads)
+  if (fastStale) {
+    // Reload config on fast-state miss — picks up external changes (minions init, minions add)
+    reloadConfig();
+    _fastState = {
+      agents: getAgents(),
+      inbox: getInbox(),
+      notes: getNotesWithMeta(),
+      pullRequests: getPullRequests(),
+      engine: { ...getEngineState(), worktreeCount: _countWorktrees() },
+      adoThrottle: ado.getAdoThrottleState(),
+      ghThrottle: gh.getGhThrottleState(),
+      dispatch: getDispatchQueue(),
+      engineLog: getEngineLog(),
+      metrics: getMetrics(),
+      workItems: getWorkItems(),
+      watches: watchesMod.getWatches(),
+      meetings: (() => { try { return require('./engine/meeting').getMeetings(); } catch { return []; } })(),
+    };
+    _fastStateTs = now;
+    _lastMtimes = _getMtimes();
+  }
+
+  // Rebuild slow state (rarely-changing data: ~8-15 reads, 60s TTL)
+  if (slowStale) {
+    const prdInfo = getPrdInfo();
+    _slowState = {
+      prdProgress: prdInfo.progress,
+      prd: prdInfo.status,
+      verifyGuides: getVerifyGuides(),
+      archivedPrds: getArchivedPrds(),
+      skills: getSkills(),
+      mcpServers: getMcpServers(),
+      schedules: (() => {
+        const scheds = CONFIG.schedules || [];
+        const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
+        return scheds.map(s => {
+          const runEntry = runs[s.id];
+          // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
+          const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
+          const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
+          return { ...s, _lastRun, ...extra };
+        });
+      })(),
+      pipelines: (() => { try { const pl = require('./engine/pipeline'); return pl.getPipelines().map(p => ({ ...p, runs: (pl.getPipelineRuns()[p.id] || []).slice(-5) })); } catch { return []; } })(),
+      pinned: (() => { try { return parsePinnedEntries(safeRead(path.join(MINIONS_DIR, 'pinned.md'))); } catch { return []; } })(),
+      projects: PROJECTS.map(p => ({ name: p.name, path: p.localPath, description: p.description || '' })),
+      autoMode: {
+        approvePlans: !!CONFIG.engine?.autoApprovePlans,
+        decompose: CONFIG.engine?.autoDecompose !== false,
+        tempAgents: !!CONFIG.engine?.allowTempAgents,
+        inboxThreshold: CONFIG.engine?.inboxConsolidateThreshold || shared.ENGINE_DEFAULTS.inboxConsolidateThreshold,
+        ccModel: CONFIG.engine?.ccModel || shared.ENGINE_DEFAULTS.ccModel,
+        ccEffort: CONFIG.engine?.ccEffort || shared.ENGINE_DEFAULTS.ccEffort,
+      },
+      initialized: !!(CONFIG.agents && Object.keys(CONFIG.agents).length > 0),
+      installId: safeRead(path.join(MINIONS_DIR, '.install-id')).trim() || null,
+      version: (() => {
+        const engine = getEngineState();
+        const { diskVersion, diskCommit, isGitRepo } = getDiskVersion();
+        const engineStale = !!(engine.codeVersion && diskVersion && engine.codeVersion !== diskVersion) ||
+                            !!(engine.codeCommit && diskCommit && engine.codeCommit !== diskCommit);
+        const dashboardStale = !!(diskVersion && _dashboardVersion.codeVersion && diskVersion !== _dashboardVersion.codeVersion) ||
+                               !!(diskCommit && _dashboardVersion.codeCommit && diskCommit !== _dashboardVersion.codeCommit);
+        return {
+          running: engine.codeVersion || null,
+          runningCommit: engine.codeCommit || null,
+          dashboardRunning: _dashboardVersion.codeVersion,
+          dashboardRunningCommit: _dashboardVersion.codeCommit,
+          dashboardStartedAt: _dashboardVersion.startedAt,
+          disk: diskVersion,
+          diskCommit,
+          engineStale,
+          dashboardStale,
+          stale: engineStale || dashboardStale,
+          latest: _npmVersionCache?.latest || null,
+          // Only show "update available" for npm installs (no git repo) — repo users manage their own updates
+          updateAvailable: !isGitRepo && !!(diskVersion && _npmVersionCache?.latest && _npmVersionCache.latest !== diskVersion && _compareVersions(_npmVersionCache.latest, diskVersion) > 0),
+          _npmCheckError: _npmVersionCache?.error || null,
+        };
+      })(),
+    };
+    _slowStateTs = now;
+  }
+
+  // Merge both tiers — no API contract change
+  _statusCache = { ..._fastState, ..._slowState, timestamp: new Date().toISOString() };
   _statusCacheJson = null; // invalidate cached JSON — will be lazily rebuilt by getStatusJson()
-  _lastMtimes = _getMtimes();
   return _statusCache;
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10209,6 +10209,9 @@ async function main() {
     // W-mo1jw71krscj: Pipeline behavioral tests — CRUD, stage execution, run lifecycle
     await testPipelineBehavioral();
 
+    // P-a5e9c1d7: Split getStatus() into fast/slow state tiers
+    await testStatusCacheTiers();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -23299,6 +23302,103 @@ async function testPipelineBehavioral() {
       assert.ok(fn.includes(`STAGE_TYPE.${type}`), `executeStage should handle STAGE_TYPE.${type}`);
     }
     assert.ok(fn.includes('PIPELINE_STATUS.WAITING_HUMAN'), 'WAIT should return WAITING_HUMAN status');
+  });
+}
+
+// ─── P-a5e9c1d7: Split getStatus() into fast/slow state tiers ───────────────
+
+async function testStatusCacheTiers() {
+  console.log('\n── Status Cache Tiers (fast/slow) ──');
+
+  const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  // ── Tier variables and TTLs exist ──
+
+  await test('dashboard.js has _fastState and _slowState cache variables', () => {
+    assert.ok(dashSrc.includes('let _fastState'), '_fastState variable must exist');
+    assert.ok(dashSrc.includes('let _slowState'), '_slowState variable must exist');
+    assert.ok(dashSrc.includes('let _fastStateTs'), '_fastStateTs timestamp must exist');
+    assert.ok(dashSrc.includes('let _slowStateTs'), '_slowStateTs timestamp must exist');
+  });
+
+  await test('FAST_STATE_TTL is 10s and SLOW_STATE_TTL is 60s', () => {
+    assert.ok(dashSrc.includes('FAST_STATE_TTL = 10000'), 'FAST_STATE_TTL must be 10000ms (10s)');
+    assert.ok(dashSrc.includes('SLOW_STATE_TTL = 60000'), 'SLOW_STATE_TTL must be 60000ms (60s)');
+  });
+
+  // ── Fast state contains the right keys ──
+
+  await test('fast state includes frequently-changing data', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // These must appear in the _fastState assignment
+    assert.ok(body.includes('_fastState'), 'getStatus must build _fastState');
+    for (const key of ['agents:', 'inbox:', 'pullRequests:', 'dispatch:', 'metrics:', 'workItems:', 'watches:', 'meetings:', 'adoThrottle:', 'ghThrottle:', 'engineLog:']) {
+      assert.ok(body.includes(key), `fast state must include ${key}`);
+    }
+  });
+
+  // ── Slow state contains the right keys ──
+
+  await test('slow state includes rarely-changing data', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    assert.ok(body.includes('_slowState'), 'getStatus must build _slowState');
+    for (const key of ['skills:', 'prdProgress:', 'mcpServers:', 'pinned:', 'projects:', 'autoMode:', 'version:', 'schedules:']) {
+      assert.ok(body.includes(key), `slow state must include ${key}`);
+    }
+  });
+
+  // ── invalidateStatusCache invalidates fast state only ──
+
+  await test('invalidateStatusCache nullifies _fastState but not _slowState', () => {
+    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+    assert.ok(fn, 'invalidateStatusCache must exist');
+    const body = fn[0];
+    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState');
+    assert.ok(!body.includes('_slowState = null'), 'must NOT nullify _slowState — slow state stays on its own TTL');
+  });
+
+  // ── mtime tracking applies to fast state only ──
+
+  await test('mtime-based validation applies only to fast-state TTL check', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The mtime check should be near _fastState logic, not _slowState
+    const fastIdx = body.indexOf('_fastState');
+    const mtimeIdx = body.indexOf('_mtimesChanged');
+    const slowIdx = body.indexOf('_slowState');
+    assert.ok(fastIdx > 0 && mtimeIdx > 0 && slowIdx > 0, 'all three markers must exist');
+    // mtime check should appear before or near fast state, not after slow state assignment
+    assert.ok(mtimeIdx < slowIdx, 'mtime validation must appear before slow state building (applies to fast tier only)');
+  });
+
+  // ── getStatus merges both tiers ──
+
+  await test('getStatus merges fast and slow state into combined _statusCache', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The final _statusCache should spread both tiers
+    assert.ok(body.includes('..._fastState') && body.includes('..._slowState'),
+      'getStatus must merge _fastState and _slowState via spread into _statusCache');
+    assert.ok(body.includes('timestamp:'), 'merged status must include timestamp');
+  });
+
+  // ── Slow state is NOT rebuilt when only fast state changes ──
+
+  await test('slow state rebuild is gated by SLOW_STATE_TTL only (no mtime check)', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The slowStale check should reference SLOW_STATE_TTL, not _mtimesChanged
+    assert.ok(body.includes('SLOW_STATE_TTL'), 'slow state staleness must be gated by SLOW_STATE_TTL');
+    // Extract the slowStale logic — it should be a simple TTL check
+    const slowStaleMatch = body.match(/slowStale\s*=.*SLOW_STATE_TTL/);
+    assert.ok(slowStaleMatch, 'slowStale must be determined by SLOW_STATE_TTL comparison');
   });
 }
 


### PR DESCRIPTION
## What

Split the monolithic `getStatus()` status cache into two tiers with separate TTLs to reduce unnecessary file reads for rarely-changing data.

### Fast state (10s TTL + mtime validation)
Data that changes every tick: `agents`, `dispatch`, `metrics`, `workItems`, `pullRequests`, `engine` (+ worktreeCount), `adoThrottle`, `ghThrottle`, `engineLog`, `watches`, `meetings`, `inbox`, `notes`.

### Slow state (60s TTL, pure TTL)
Data that changes on agent completion or config edits: `skills`, `prdProgress`, `prd`, `verifyGuides`, `archivedPrds`, `mcpServers`, `schedules`, `pipelines`, `pinned`, `projects`, `autoMode`, `initialized`, `installId`, `version`.

### Key behaviors
- `invalidateStatusCache()` only clears fast state — slow state stays on its own 60s TTL
- Existing mtime-based validation applies only to fast-state tracked files
- Combined status object merges both tiers — **no API contract change**
- Net: ~6x fewer slow-state file reads per minute

## Files changed
- `dashboard.js` — refactored cache variables, `getStatus()`, and `invalidateStatusCache()`
- `test/unit.test.js` — 8 new tests for tier separation, TTL values, invalidation behavior

## Build & test
```bash
npm test   # 2195 passed, 7 failed (all pre-existing doc-chat tests), 3 skipped
```

## Test plan
- [x] All 8 new status-cache-tier tests pass
- [x] All existing `getStatus`-related tests still pass (version, adoThrottle, ghThrottle, watches)
- [x] No new test failures introduced (7 failures are pre-existing doc-chat tests)
- [ ] Manual: verify dashboard loads and SSE streaming works after change
- [ ] Manual: verify invalidateStatusCache() triggers fast-state rebuild on next call

Built by Minions (Lambert — Analyst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)