### PR TITLE
[E2E] Dashboard & engine perf: gzip cache, tiered status, lock backoff, polling parallelization

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -302,10 +302,16 @@ function parsePinnedEntries(content) {
   return entries;
 }
 
+// Two-tier status cache: fast state (10s) for frequently-changing data, slow state (60s) for rarely-changing data.
+// Combined into _statusCache for API/SSE consumers — no API contract change.
+let _fastState = null;
+let _fastStateTs = 0;
+const FAST_STATE_TTL = 10000; // 10s — dispatch, agents, metrics, work items, etc.
+let _slowState = null;
+let _slowStateTs = 0;
+const SLOW_STATE_TTL = 60000; // 60s — skills, PRDs, pinned, version, projects, etc.
 let _statusCache = null;
 let _statusCacheJson = null; // cached JSON.stringify(_statusCache) — avoids double-serialization for SSE
-let _statusCacheTs = 0;
-const STATUS_CACHE_TTL = 10000; // 10s — reduces expensive aggregation frequency; mutations call invalidateStatusCache()
 const _statusStreamClients = new Set();
 let _statusPushTimer = null;
 let _lastStatusHash = '';
@@ -348,6 +354,9 @@ function _mtimesChanged(prev, curr) {
 }
 
 function invalidateStatusCache() {
+  _fastState = null;
+  _fastStateTs = 0;
+  // Slow state continues on its own TTL — not invalidated by mutations
   _statusCache = null;
   _statusCacheJson = null;
   // Push to SSE clients (debounced 500ms to avoid flooding during batch mutations)
@@ -364,89 +373,109 @@ function invalidateStatusCache() {
 
 function getStatus() {
   const now = Date.now();
-  if (_statusCache && (now - _statusCacheTs) < STATUS_CACHE_TTL) {
-    // Within TTL — check mtimes for early return (skip full rebuild if nothing changed)
+
+  // Fast state: 10s TTL with mtime-based validation for early exit
+  let fastStale = !_fastState || (now - _fastStateTs) >= FAST_STATE_TTL;
+  if (!fastStale) {
+    // Within TTL — check mtimes for early return (skip rebuild if no tracked files changed)
     const currMtimes = _getMtimes();
-    if (!_mtimesChanged(_lastMtimes, currMtimes)) return _statusCache;
+    if (_mtimesChanged(_lastMtimes, currMtimes)) fastStale = true;
   }
 
-  // Reload config on each cache miss — picks up external changes (minions init, minions add)
-  reloadConfig();
+  // Slow state: 60s TTL, pure TTL (no mtime check — these files change rarely)
+  const slowStale = !_slowState || (now - _slowStateTs) >= SLOW_STATE_TTL;
 
-  const prdInfo = getPrdInfo();
-  _statusCache = {
-    agents: getAgents(),
-    prdProgress: prdInfo.progress,
-    inbox: getInbox(),
-    notes: getNotesWithMeta(),
-    prd: prdInfo.status,
-    pullRequests: getPullRequests(),
-    verifyGuides: getVerifyGuides(),
-    archivedPrds: getArchivedPrds(),
-    engine: { ...getEngineState(), worktreeCount: _countWorktrees() },
-    adoThrottle: ado.getAdoThrottleState(),
-    ghThrottle: gh.getGhThrottleState(),
-    dispatch: getDispatchQueue(),
-    engineLog: getEngineLog(),
-    metrics: getMetrics(),
-    workItems: getWorkItems(),
-    skills: getSkills(),
-    mcpServers: getMcpServers(),
-    schedules: (() => {
-      const scheds = CONFIG.schedules || [];
-      const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
-      return scheds.map(s => {
-        const runEntry = runs[s.id];
-        // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
-        const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
-        const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
-        return { ...s, _lastRun, ...extra };
-      });
-    })(),
-    watches: watchesMod.getWatches(),
-    meetings: (() => { try { return require('./engine/meeting').getMeetings(); } catch { return []; } })(),
-    pipelines: (() => { try { const pl = require('./engine/pipeline'); return pl.getPipelines().map(p => ({ ...p, runs: (pl.getPipelineRuns()[p.id] || []).slice(-5) })); } catch { return []; } })(),
-    pinned: (() => { try { return parsePinnedEntries(safeRead(path.join(MINIONS_DIR, 'pinned.md'))); } catch { return []; } })(),
-    projects: PROJECTS.map(p => ({ name: p.name, path: p.localPath, description: p.description || '' })),
-    autoMode: {
-      approvePlans: !!CONFIG.engine?.autoApprovePlans,
-      decompose: CONFIG.engine?.autoDecompose !== false,
-      tempAgents: !!CONFIG.engine?.allowTempAgents,
-      inboxThreshold: CONFIG.engine?.inboxConsolidateThreshold || shared.ENGINE_DEFAULTS.inboxConsolidateThreshold,
-      ccModel: CONFIG.engine?.ccModel || shared.ENGINE_DEFAULTS.ccModel,
-      ccEffort: CONFIG.engine?.ccEffort || shared.ENGINE_DEFAULTS.ccEffort,
-    },
-    initialized: !!(CONFIG.agents && Object.keys(CONFIG.agents).length > 0),
-    installId: safeRead(path.join(MINIONS_DIR, '.install-id')).trim() || null,
-    version: (() => {
-      const engine = getEngineState();
-      const { diskVersion, diskCommit, isGitRepo } = getDiskVersion();
-      const engineStale = !!(engine.codeVersion && diskVersion && engine.codeVersion !== diskVersion) ||
-                          !!(engine.codeCommit && diskCommit && engine.codeCommit !== diskCommit);
-      const dashboardStale = !!(diskVersion && _dashboardVersion.codeVersion && diskVersion !== _dashboardVersion.codeVersion) ||
-                             !!(diskCommit && _dashboardVersion.codeCommit && diskCommit !== _dashboardVersion.codeCommit);
-      return {
-        running: engine.codeVersion || null,
-        runningCommit: engine.codeCommit || null,
-        dashboardRunning: _dashboardVersion.codeVersion,
-        dashboardRunningCommit: _dashboardVersion.codeCommit,
-        dashboardStartedAt: _dashboardVersion.startedAt,
-        disk: diskVersion,
-        diskCommit,
-        engineStale,
-        dashboardStale,
-        stale: engineStale || dashboardStale,
-        latest: _npmVersionCache?.latest || null,
-        // Only show "update available" for npm installs (no git repo) — repo users manage their own updates
-        updateAvailable: !isGitRepo && !!(diskVersion && _npmVersionCache?.latest && _npmVersionCache.latest !== diskVersion && _compareVersions(_npmVersionCache.latest, diskVersion) > 0),
-        _npmCheckError: _npmVersionCache?.error || null,
-      };
-    })(),
-    timestamp: new Date().toISOString(),
-  };
-  _statusCacheTs = now;
+  // If nothing stale, return cached merged result
+  if (!fastStale && !slowStale && _statusCache) return _statusCache;
+
+  // Rebuild fast state (frequently-changing data: ~12-15 reads)
+  if (fastStale) {
+    // Reload config on fast-state miss — picks up external changes (minions init, minions add)
+    reloadConfig();
+    _fastState = {
+      agents: getAgents(),
+      inbox: getInbox(),
+      notes: getNotesWithMeta(),
+      pullRequests: getPullRequests(),
+      engine: { ...getEngineState(), worktreeCount: _countWorktrees() },
+      adoThrottle: ado.getAdoThrottleState(),
+      ghThrottle: gh.getGhThrottleState(),
+      dispatch: getDispatchQueue(),
+      engineLog: getEngineLog(),
+      metrics: getMetrics(),
+      workItems: getWorkItems(),
+      watches: watchesMod.getWatches(),
+      meetings: (() => { try { return require('./engine/meeting').getMeetings(); } catch { return []; } })(),
+    };
+    _fastStateTs = now;
+    _lastMtimes = _getMtimes();
+  }
+
+  // Rebuild slow state (rarely-changing data: ~8-15 reads, 60s TTL)
+  if (slowStale) {
+    const prdInfo = getPrdInfo();
+    _slowState = {
+      prdProgress: prdInfo.progress,
+      prd: prdInfo.status,
+      verifyGuides: getVerifyGuides(),
+      archivedPrds: getArchivedPrds(),
+      skills: getSkills(),
+      mcpServers: getMcpServers(),
+      schedules: (() => {
+        const scheds = CONFIG.schedules || [];
+        const runs = shared.safeJson(path.join(MINIONS_DIR, 'engine', 'schedule-runs.json')) || {};
+        return scheds.map(s => {
+          const runEntry = runs[s.id];
+          // Backward compat: runEntry can be a string (old format) or object (new format with back-references)
+          const _lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || runEntry?.lastCompletedAt || null);
+          const extra = typeof runEntry === 'object' && runEntry ? { _lastWorkItemId: runEntry.lastWorkItemId, _lastResult: runEntry.lastResult, _lastCompletedAt: runEntry.lastCompletedAt } : {};
+          return { ...s, _lastRun, ...extra };
+        });
+      })(),
+      pipelines: (() => { try { const pl = require('./engine/pipeline'); return pl.getPipelines().map(p => ({ ...p, runs: (pl.getPipelineRuns()[p.id] || []).slice(-5) })); } catch { return []; } })(),
+      pinned: (() => { try { return parsePinnedEntries(safeRead(path.join(MINIONS_DIR, 'pinned.md'))); } catch { return []; } })(),
+      projects: PROJECTS.map(p => ({ name: p.name, path: p.localPath, description: p.description || '' })),
+      autoMode: {
+        approvePlans: !!CONFIG.engine?.autoApprovePlans,
+        decompose: CONFIG.engine?.autoDecompose !== false,
+        tempAgents: !!CONFIG.engine?.allowTempAgents,
+        inboxThreshold: CONFIG.engine?.inboxConsolidateThreshold || shared.ENGINE_DEFAULTS.inboxConsolidateThreshold,
+        ccModel: CONFIG.engine?.ccModel || shared.ENGINE_DEFAULTS.ccModel,
+        ccEffort: CONFIG.engine?.ccEffort || shared.ENGINE_DEFAULTS.ccEffort,
+      },
+      initialized: !!(CONFIG.agents && Object.keys(CONFIG.agents).length > 0),
+      installId: safeRead(path.join(MINIONS_DIR, '.install-id')).trim() || null,
+      version: (() => {
+        const engine = getEngineState();
+        const { diskVersion, diskCommit, isGitRepo } = getDiskVersion();
+        const engineStale = !!(engine.codeVersion && diskVersion && engine.codeVersion !== diskVersion) ||
+                            !!(engine.codeCommit && diskCommit && engine.codeCommit !== diskCommit);
+        const dashboardStale = !!(diskVersion && _dashboardVersion.codeVersion && diskVersion !== _dashboardVersion.codeVersion) ||
+                               !!(diskCommit && _dashboardVersion.codeCommit && diskCommit !== _dashboardVersion.codeCommit);
+        return {
+          running: engine.codeVersion || null,
+          runningCommit: engine.codeCommit || null,
+          dashboardRunning: _dashboardVersion.codeVersion,
+          dashboardRunningCommit: _dashboardVersion.codeCommit,
+          dashboardStartedAt: _dashboardVersion.startedAt,
+          disk: diskVersion,
+          diskCommit,
+          engineStale,
+          dashboardStale,
+          stale: engineStale || dashboardStale,
+          latest: _npmVersionCache?.latest || null,
+          // Only show "update available" for npm installs (no git repo) — repo users manage their own updates
+          updateAvailable: !isGitRepo && !!(diskVersion && _npmVersionCache?.latest && _npmVersionCache.latest !== diskVersion && _compareVersions(_npmVersionCache.latest, diskVersion) > 0),
+          _npmCheckError: _npmVersionCache?.error || null,
+        };
+      })(),
+    };
+    _slowStateTs = now;
+  }
+
+  // Merge both tiers — no API contract change
+  _statusCache = { ..._fastState, ..._slowState, timestamp: new Date().toISOString() };
   _statusCacheJson = null; // invalidate cached JSON — will be lazily rebuilt by getStatusJson()
-  _lastMtimes = _getMtimes();
   return _statusCache;
 }
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -171,7 +171,14 @@ function getVerifyGuides() {
 function getArchivedPrds() { return []; }
 function getEngineState() { return queries.getControl(); }
 
+let _worktreeCountCache = 0;
+let _worktreeCountCacheTs = 0;
+
 function _countWorktrees() {
+  const now = Date.now();
+  if (_worktreeCountCacheTs && (now - _worktreeCountCacheTs) < shared.ENGINE_DEFAULTS.worktreeCountCacheTtl) {
+    return _worktreeCountCache;
+  }
   try {
     const config = queries.getConfig();
     const projects = shared.getProjects(config);
@@ -199,6 +206,8 @@ function _countWorktrees() {
         }
       } catch {}
     }
+    _worktreeCountCache = count;
+    _worktreeCountCacheTs = now;
     return count;
   } catch { return 0; }
 }

--- a/dashboard.js
+++ b/dashboard.js
@@ -304,11 +304,12 @@ function parsePinnedEntries(content) {
 
 let _statusCache = null;
 let _statusCacheJson = null; // cached JSON.stringify(_statusCache) — avoids double-serialization for SSE
+let _statusCacheGzip = null; // pre-computed gzip of _statusCacheJson — avoids per-request gzipSync
 let _statusCacheTs = 0;
 const STATUS_CACHE_TTL = 10000; // 10s — reduces expensive aggregation frequency; mutations call invalidateStatusCache()
 const _statusStreamClients = new Set();
 let _statusPushTimer = null;
-let _lastStatusHash = '';
+let _lastStatusPushRef = null; // last JSON string reference pushed to SSE — O(1) change detection
 
 // mtime-based cache invalidation — skip full rebuild if no tracked files changed
 const _mtimeTrackedFiles = () => {
@@ -350,6 +351,7 @@ function _mtimesChanged(prev, curr) {
 function invalidateStatusCache() {
   _statusCache = null;
   _statusCacheJson = null;
+  _statusCacheGzip = null;
   // Push to SSE clients (debounced 500ms to avoid flooding during batch mutations)
   if (_statusPushTimer) return;
   _statusPushTimer = setTimeout(() => {
@@ -446,6 +448,7 @@ function getStatus() {
   };
   _statusCacheTs = now;
   _statusCacheJson = null; // invalidate cached JSON — will be lazily rebuilt by getStatusJson()
+  _statusCacheGzip = null;
   _lastMtimes = _getMtimes();
   return _statusCache;
 }
@@ -455,6 +458,7 @@ function getStatusJson() {
   getStatus(); // ensure _statusCache is fresh
   if (!_statusCacheJson) {
     _statusCacheJson = JSON.stringify(_statusCache);
+    _statusCacheGzip = zlib.gzipSync(_statusCacheJson); // pre-compute gzip once per cache rebuild
   }
   return _statusCacheJson;
 }
@@ -463,9 +467,8 @@ function getStatusJson() {
 setInterval(() => {
   if (_statusStreamClients.size === 0) return;
   const data = getStatusJson();
-  const hash = require('crypto').createHash('md5').update(data).digest('hex');
-  if (hash === _lastStatusHash) return;
-  _lastStatusHash = hash;
+  if (data === _lastStatusPushRef) return; // O(1) reference comparison — new string ref means content changed
+  _lastStatusPushRef = data;
   for (const res of _statusStreamClients) {
     try { res.write('data: ' + data + '\n\n'); } catch { _statusStreamClients.delete(res); }
   }
@@ -4222,15 +4225,15 @@ What would you like to discuss or change? When you're happy, say "approve" and I
 
   async function handleStatus(req, res) {
     try {
-      // Use pre-serialized JSON to avoid double-stringify in jsonReply
+      // Use pre-serialized JSON and pre-computed gzip buffer — zero per-request compression
       const json = getStatusJson();
       res.setHeader('Content-Type', 'application/json');
       res.setHeader('Access-Control-Allow-Origin', '*');
       res.statusCode = 200;
       const ae = req && req.headers && req.headers['accept-encoding'] || '';
-      if (ae.includes('gzip') && json.length > 1024) {
+      if (ae.includes('gzip') && _statusCacheGzip) {
         res.setHeader('Content-Encoding', 'gzip');
-        res.end(zlib.gzipSync(json));
+        res.end(_statusCacheGzip);
       } else {
         res.end(json);
       }

--- a/engine.js
+++ b/engine.js
@@ -3229,16 +3229,19 @@ async function tickInner() {
   // Awaited so PR state is consistent before discoverWork reads it
   // Also re-polls early if previous tick had ADO auth failures (stale build status recovery)
   if (tickCount % adoPollStatusEvery === 0 || needsAdoPollRetry()) {
+    // Build promise array — enabled+unthrottled polls run concurrently via Promise.allSettled
+    const statusPolls = [];
     if (adoPollEnabled && !isAdoThrottled()) {
-      try { await pollPrStatus(config); } catch (err) { log('warn', `ADO PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
+      statusPolls.push(pollPrStatus(config).catch(err => { log('warn', `ADO PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
     } else if (adoPollEnabled && isAdoThrottled()) {
       log('info', '[ado] PR status poll skipped — throttled');
     }
     if (ghPollEnabled && !isGhThrottled()) {
-      try { await ghPollPrStatus(config); } catch (err) { log('warn', `GitHub PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
+      statusPolls.push(ghPollPrStatus(config).catch(err => { log('warn', `GitHub PR status poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
     } else if (ghPollEnabled && isGhThrottled()) {
       log('info', '[gh] PR status poll skipped — throttled');
     }
+    if (statusPolls.length) await Promise.allSettled(statusPolls);
     try { await processPendingRebases(config); } catch (err) { log('warn', `Pending rebase processing error: ${err?.message || err}`); }
     // Sync PR status back to PRD items (missing → done when active PR exists)
     try { syncPrdFromPrs(config); } catch (err) { log('warn', `PRD sync error: ${err?.message || err}`); }
@@ -3260,19 +3263,25 @@ async function tickInner() {
 
   // 2.7. Poll PR threads for human comments (every adoPollCommentsEvery ticks, default ~12 minutes)
   if (tickCount % adoPollCommentsEvery === 0) {
+    // Build promise array — enabled+unthrottled comment polls run concurrently via Promise.allSettled
+    const commentPolls = [];
     if (adoPollEnabled && !isAdoThrottled()) {
-      try { await pollPrHumanComments(config); } catch (err) { log('warn', `ADO PR comment poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
+      commentPolls.push(pollPrHumanComments(config).catch(err => { log('warn', `ADO PR comment poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
     } else if (adoPollEnabled && isAdoThrottled()) {
       log('info', '[ado] PR comment poll skipped — throttled');
     }
     if (ghPollEnabled && !isGhThrottled()) {
-      try { await ghPollPrHumanComments(config); } catch (err) { log('warn', `GitHub PR comment poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
+      commentPolls.push(ghPollPrHumanComments(config).catch(err => { log('warn', `GitHub PR comment poll error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
     } else if (ghPollEnabled && isGhThrottled()) {
       log('info', '[gh] PR comment poll skipped — throttled');
     }
+    if (commentPolls.length) await Promise.allSettled(commentPolls);
     // Reconciliation runs regardless of poll flags — it's a recovery sweep, not a convenience poll
-    try { await reconcilePrs(config); } catch (err) { log('warn', `ADO PR reconciliation error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
-    try { await ghReconcilePrs(config); } catch (err) { log('warn', `GitHub PR reconciliation error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }
+    // Reconciliation also parallelized — ADO and GitHub reconciliation are independent
+    const reconcilePolls = [];
+    reconcilePolls.push(reconcilePrs(config).catch(err => { log('warn', `ADO PR reconciliation error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
+    reconcilePolls.push(ghReconcilePrs(config).catch(err => { log('warn', `GitHub PR reconciliation error: ${err?.message || err}${err?.stack ? ' | ' + err.stack.split('\n')[1]?.trim() : ''}`); }));
+    await Promise.allSettled(reconcilePolls);
   }
 
   // 2.9. Stalled dispatch detection — auto-retry failed items blocking the graph (every 20 ticks = ~10 min)

--- a/engine/cleanup.js
+++ b/engine/cleanup.js
@@ -442,22 +442,24 @@ function runCleanup(config, verbose = false) {
 
   // 6a. Reconcile failed work items that have an attached PR (#407)
   // If a work item is 'failed' but already has _pr, it should be 'done'.
+  // Uses mutateWorkItems() for locked atomic read-modify-write — prevents
+  // race conditions with concurrent engine/dashboard/lifecycle writers.
   for (const project of projects) {
     try {
       const wiPath = projectWorkItemsPath(project);
-      const items = safeJson(wiPath) || [];
       let reconciled = 0;
-      for (const item of items) {
-        if (item.status === shared.WI_STATUS.FAILED && item._pr) {
-          item.status = shared.WI_STATUS.DONE;
-          if (item.failReason) delete item.failReason;
-          if (item.failedAt) delete item.failedAt;
-          if (!item.completedAt) item.completedAt = shared.ts();
-          reconciled++;
+      mutateWorkItems(wiPath, items => {
+        for (const item of items) {
+          if (item.status === shared.WI_STATUS.FAILED && item._pr) {
+            item.status = shared.WI_STATUS.DONE;
+            if (item.failReason) delete item.failReason;
+            if (item.failedAt) delete item.failedAt;
+            if (!item.completedAt) item.completedAt = shared.ts();
+            reconciled++;
+          }
         }
-      }
+      });
       if (reconciled > 0) {
-        safeWrite(wiPath, items);
         log('info', `Reconciled ${reconciled} failed-with-PR item(s) → done in ${project.name}`);
       }
     } catch (e) { log('warn', 'reconcile failed-with-PR: ' + e.message); }

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -534,6 +534,7 @@ const ENGINE_DEFAULTS = {
   worktreeCreateTimeout: 300000, // 5min for git worktree add on large Windows repos
   worktreeCreateRetries: 1, // retry once on transient timeout/lock races
   worktreeRoot: '../worktrees',
+  worktreeCountCacheTtl: 30000, // 30s — TTL for cached _countWorktrees() result in dashboard
   idleAlertMinutes: 15,
   fanOutTimeout: null, // falls back to agentTimeout
   restartGracePeriod: 1200000, // 20min

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -554,7 +554,7 @@ const ENGINE_DEFAULTS = {
   versionCheckInterval: 3600000, // 1 hour — how often to check npm for updates (ms)
   logFlushInterval: 5000, // 5s — how often to flush buffered log entries to disk
   logBufferSize: 50, // flush immediately when buffer exceeds this many entries
-  lockRetries: 2, // retry lock acquisition this many times after initial timeout (total attempts = 1 + lockRetries)
+  lockRetries: 0, // no retries — single 5s timeout window with 25ms polling (200 attempts) is sufficient; stale lock recovery at 60s handles crashes
   lockRetryBackoffMs: 500, // base backoff between lock retries (doubles each attempt: 500ms, 1s, 2s, ...)
   maxBuildFixAttempts: 3, // max consecutive auto-fix dispatch cycles per PR before escalation to human
   buildFixGracePeriod: 600000, // 10min — wait for CI to run after build fix before re-dispatching

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10209,6 +10209,9 @@ async function main() {
     // W-mo1jw71krscj: Pipeline behavioral tests — CRUD, stage execution, run lifecycle
     await testPipelineBehavioral();
 
+    // P-c7f1a3b8: Pre-cached gzip status buffer
+    await testStatusGzipCache();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -23299,6 +23302,97 @@ async function testPipelineBehavioral() {
       assert.ok(fn.includes(`STAGE_TYPE.${type}`), `executeStage should handle STAGE_TYPE.${type}`);
     }
     assert.ok(fn.includes('PIPELINE_STATUS.WAITING_HUMAN'), 'WAIT should return WAITING_HUMAN status');
+  });
+}
+
+// ─── P-c7f1a3b8: Pre-cached gzip status buffer ────────────────────────────
+
+async function testStatusGzipCache() {
+  console.log('\n── P-c7f1a3b8: Pre-cached gzip status buffer ──');
+
+  const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  await test('_statusCacheGzip variable exists alongside _statusCacheJson', () => {
+    assert.ok(dashSrc.includes('let _statusCacheGzip'),
+      'dashboard.js must declare _statusCacheGzip variable');
+    // Both should be declared near each other
+    const jsonIdx = dashSrc.indexOf('let _statusCacheJson');
+    const gzipIdx = dashSrc.indexOf('let _statusCacheGzip');
+    assert.ok(Math.abs(gzipIdx - jsonIdx) < 200,
+      '_statusCacheGzip must be declared near _statusCacheJson');
+  });
+
+  await test('getStatusJson() pre-computes gzip buffer on cache rebuild', () => {
+    const fn = dashSrc.match(/function getStatusJson\(\)[\s\S]*?^}/m);
+    assert.ok(fn, 'getStatusJson must exist');
+    assert.ok(fn[0].includes('_statusCacheGzip') && fn[0].includes('gzipSync'),
+      'getStatusJson must compute _statusCacheGzip via gzipSync when rebuilding cache');
+  });
+
+  await test('gzipSync called once per cache rebuild, not per request in handleStatus', () => {
+    // handleStatus should NOT call gzipSync — it should serve _statusCacheGzip
+    const handleStatusStart = dashSrc.indexOf('async function handleStatus(');
+    const handleStatusEnd = dashSrc.indexOf('async function', handleStatusStart + 30);
+    const handleStatusFn = dashSrc.slice(handleStatusStart, handleStatusEnd > 0 ? handleStatusEnd : handleStatusStart + 1000);
+    assert.ok(!handleStatusFn.includes('gzipSync'),
+      'handleStatus must NOT call gzipSync — should serve pre-cached _statusCacheGzip');
+    assert.ok(handleStatusFn.includes('_statusCacheGzip'),
+      'handleStatus must serve the pre-cached _statusCacheGzip buffer');
+  });
+
+  await test('handleStatus serves pre-cached gzip when Accept-Encoding includes gzip', () => {
+    const handleStatusStart = dashSrc.indexOf('async function handleStatus(');
+    const handleStatusEnd = dashSrc.indexOf('async function', handleStatusStart + 30);
+    const handleStatusFn = dashSrc.slice(handleStatusStart, handleStatusEnd > 0 ? handleStatusEnd : handleStatusStart + 1000);
+    assert.ok(handleStatusFn.includes('accept-encoding') || handleStatusFn.includes('Accept-Encoding'),
+      'handleStatus must check Accept-Encoding header');
+    assert.ok(handleStatusFn.includes('Content-Encoding') && handleStatusFn.includes('gzip'),
+      'handleStatus must set Content-Encoding: gzip when serving cached buffer');
+  });
+
+  await test('SSE periodic push uses reference comparison instead of MD5 hash', () => {
+    // Find the setInterval for periodic push (the 10000ms one)
+    const intervalMatch = dashSrc.match(/setInterval\(\(\) => \{[\s\S]*?_statusStreamClients[\s\S]*?\}, 10000\)/);
+    assert.ok(intervalMatch, 'SSE periodic push interval must exist');
+    const intervalBody = intervalMatch[0];
+    // Must NOT use MD5 hash
+    assert.ok(!intervalBody.includes('createHash') && !intervalBody.includes('md5'),
+      'SSE periodic push must NOT use MD5 hash — use reference comparison');
+    // Should use reference comparison (checking if data !== _lastXxx or similar)
+    assert.ok(!intervalBody.includes('.digest('),
+      'SSE periodic push must not compute hash digests');
+  });
+
+  await test('_lastStatusHash is removed or replaced with reference-based tracking', () => {
+    // The old _lastStatusHash should be replaced
+    const intervalMatch = dashSrc.match(/setInterval\(\(\) => \{[\s\S]*?_statusStreamClients[\s\S]*?\}, 10000\)/);
+    assert.ok(intervalMatch, 'SSE periodic push interval must exist');
+    const intervalBody = intervalMatch[0];
+    // Should have some form of "last" reference comparison
+    assert.ok(intervalBody.includes('===') || intervalBody.includes('!=='),
+      'SSE periodic push must use reference equality for change detection');
+  });
+
+  await test('invalidateStatusCache clears _statusCacheGzip', () => {
+    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+    assert.ok(fn, 'invalidateStatusCache must exist');
+    assert.ok(fn[0].includes('_statusCacheGzip = null') || fn[0].includes('_statusCacheGzip=null'),
+      'invalidateStatusCache must clear _statusCacheGzip');
+  });
+
+  await test('getStatus cache rebuild invalidates _statusCacheGzip', () => {
+    // When _statusCache is rebuilt in getStatus(), both _statusCacheJson and _statusCacheGzip are invalidated
+    const fn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(fn, 'getStatus must exist');
+    assert.ok(fn[0].includes('_statusCacheGzip = null') || fn[0].includes('_statusCacheGzip=null'),
+      'getStatus must invalidate _statusCacheGzip when rebuilding cache');
+  });
+
+  await test('jsonReply still gzips normally for non-status endpoints', () => {
+    const fn = dashSrc.match(/function jsonReply[\s\S]*?^}/m);
+    assert.ok(fn, 'jsonReply must exist');
+    assert.ok(fn[0].includes('gzipSync'),
+      'jsonReply must still call gzipSync for non-status endpoints');
   });
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10209,6 +10209,9 @@ async function main() {
     // W-mo1jw71krscj: Pipeline behavioral tests — CRUD, stage execution, run lifecycle
     await testPipelineBehavioral();
 
+    // P-e1c8b4a6: Parallelize ADO and GitHub PR polling with Promise.allSettled
+    await testParallelPrPolling();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -23299,6 +23302,122 @@ async function testPipelineBehavioral() {
       assert.ok(fn.includes(`STAGE_TYPE.${type}`), `executeStage should handle STAGE_TYPE.${type}`);
     }
     assert.ok(fn.includes('PIPELINE_STATUS.WAITING_HUMAN'), 'WAIT should return WAITING_HUMAN status');
+  });
+}
+
+// ─── P-e1c8b4a6: Parallelize ADO and GitHub PR polling with Promise.allSettled ──
+
+async function testParallelPrPolling() {
+  console.log('\n── P-e1c8b4a6: Parallel PR polling via Promise.allSettled ──');
+
+  const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+
+  // ── Section 2.6: status polls use Promise.allSettled ──
+
+  await test('section 2.6 uses Promise.allSettled for concurrent status polls', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    assert.ok(section26Idx > -1, 'Section 2.6 comment must exist');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    assert.ok(section26Block.includes('Promise.allSettled'),
+      'Section 2.6 must use Promise.allSettled to run ADO and GitHub status polls concurrently');
+  });
+
+  await test('section 2.6 builds a promise array for conditional poll dispatch', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    // Should push to an array, not await sequentially
+    assert.ok(section26Block.includes('.push('),
+      'Section 2.6 must push poll promises to an array (conditional dispatch pattern)');
+  });
+
+  await test('section 2.6 processPendingRebases runs AFTER Promise.allSettled', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    const allSettledIdx = section26Block.indexOf('Promise.allSettled');
+    const rebaseIdx = section26Block.indexOf('processPendingRebases');
+    assert.ok(allSettledIdx > -1, 'Promise.allSettled must exist in section 2.6');
+    assert.ok(rebaseIdx > -1, 'processPendingRebases must exist in section 2.6');
+    assert.ok(rebaseIdx > allSettledIdx,
+      'processPendingRebases must appear AFTER Promise.allSettled (depends on updated PR state)');
+  });
+
+  await test('section 2.6 syncPrdFromPrs runs AFTER Promise.allSettled', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    const allSettledIdx = section26Block.indexOf('Promise.allSettled');
+    const syncIdx = section26Block.indexOf('syncPrdFromPrs');
+    assert.ok(allSettledIdx > -1, 'Promise.allSettled must exist in section 2.6');
+    assert.ok(syncIdx > -1, 'syncPrdFromPrs must exist in section 2.6');
+    assert.ok(syncIdx > allSettledIdx,
+      'syncPrdFromPrs must appear AFTER Promise.allSettled (depends on updated PR state)');
+  });
+
+  await test('section 2.6 preserves conditional guards for ADO and GitHub polls', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    // ADO guard: adoPollEnabled && !isAdoThrottled()
+    assert.ok(section26Block.includes('adoPollEnabled') && section26Block.includes('isAdoThrottled'),
+      'Section 2.6 must preserve adoPollEnabled and isAdoThrottled guards');
+    // GitHub guard: ghPollEnabled && !isGhThrottled()
+    assert.ok(section26Block.includes('ghPollEnabled') && section26Block.includes('isGhThrottled'),
+      'Section 2.6 must preserve ghPollEnabled and isGhThrottled guards');
+  });
+
+  await test('section 2.6 throttle skip log messages preserved for both ADO and GitHub', () => {
+    const section26Idx = engineSrc.indexOf('2.6');
+    const section27Idx = engineSrc.indexOf('2.7', section26Idx);
+    const section26Block = engineSrc.slice(section26Idx, section27Idx);
+    assert.ok(section26Block.includes('[ado]') && section26Block.includes('throttled'),
+      'Section 2.6 must log [ado] throttled message when ADO poll is skipped');
+    assert.ok(section26Block.includes('[gh]') && section26Block.includes('throttled'),
+      'Section 2.6 must log [gh] throttled message when GitHub poll is skipped');
+  });
+
+  // ── Behavioral test: concurrent execution ──
+
+  await test('Promise.allSettled pattern enables concurrent poll execution', async () => {
+    // Simulate the engine pattern: build promise array conditionally, allSettled them
+    const callOrder = [];
+    const mockAdoPoll = async () => {
+      callOrder.push('ado-start');
+      await new Promise(r => setTimeout(r, 30));
+      callOrder.push('ado-end');
+    };
+    const mockGhPoll = async () => {
+      callOrder.push('gh-start');
+      await new Promise(r => setTimeout(r, 30));
+      callOrder.push('gh-end');
+    };
+
+    // Build promise array (mimics engine conditional push pattern)
+    const polls = [];
+    polls.push(mockAdoPoll().catch(() => {}));
+    polls.push(mockGhPoll().catch(() => {}));
+    await Promise.allSettled(polls);
+
+    // Both should start before either finishes (concurrent execution)
+    assert.ok(callOrder.indexOf('gh-start') < callOrder.indexOf('ado-end'),
+      `Polls must execute concurrently — gh-start should occur before ado-end. Order: ${callOrder.join(', ')}`);
+    assert.strictEqual(callOrder.length, 4, 'All four events (2 starts + 2 ends) must fire');
+  });
+
+  await test('Promise.allSettled isolates errors between polls', async () => {
+    // If ADO fails, GitHub should still complete
+    let ghCompleted = false;
+    const mockAdoPoll = async () => { throw new Error('ADO network error'); };
+    const mockGhPoll = async () => { ghCompleted = true; };
+
+    const polls = [];
+    polls.push(mockAdoPoll().catch(() => {}));
+    polls.push(mockGhPoll().catch(() => {}));
+    await Promise.allSettled(polls);
+
+    assert.ok(ghCompleted, 'GitHub poll must complete even when ADO poll fails');
   });
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3377,6 +3377,22 @@ async function testLegacyStatusMigration() {
       'cleanup should log reconciliation of failed-with-PR items');
   });
 
+  await test('cleanup.js failed-with-PR reconciliation uses locked write via mutateWorkItems (#407)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
+    // Extract the reconciliation section (6a) — between the "Reconcile failed" comment and the next section
+    const sectionStart = src.indexOf('// 6a. Reconcile failed work items');
+    const sectionEnd = src.indexOf('// 6b.');
+    assert.ok(sectionStart > -1 && sectionEnd > sectionStart, 'Section 6a must exist');
+    const section = src.slice(sectionStart, sectionEnd);
+    // Must use mutateWorkItems (locked) — not safeJson+safeWrite (unlocked)
+    assert.ok(section.includes('mutateWorkItems'),
+      'reconciliation must use mutateWorkItems() for locked atomic read-modify-write');
+    assert.ok(!section.includes('safeWrite('),
+      'reconciliation must NOT use unlocked safeWrite() — race condition with concurrent writers');
+    assert.ok(!section.includes('safeJson('),
+      'reconciliation must NOT use safeJson() for read — mutateWorkItems provides the data inside the lock');
+  });
+
   await test('cleanup.js resets orphaned PRD item statuses (#779)', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cleanup.js'), 'utf8');
     assert.ok(src.includes('shared.WI_STATUS.DISPATCHED') && src.includes('!wiIds.has(feat.id)'),

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -23300,6 +23300,47 @@ async function testPipelineBehavioral() {
     }
     assert.ok(fn.includes('PIPELINE_STATUS.WAITING_HUMAN'), 'WAIT should return WAITING_HUMAN status');
   });
+
+  // ── _countWorktrees TTL cache ──
+
+  await test('_countWorktrees uses TTL cache variables', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(dashSrc.includes('_worktreeCountCache'), '_worktreeCountCache variable must exist');
+    assert.ok(dashSrc.includes('_worktreeCountCacheTs'), '_worktreeCountCacheTs timestamp variable must exist');
+  });
+
+  await test('_countWorktrees returns cached value within TTL', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    // The function must check Date.now() against _worktreeCountCacheTs to decide cache hit
+    const fn = dashSrc.slice(dashSrc.indexOf('function _countWorktrees('), dashSrc.indexOf('\n}', dashSrc.indexOf('function _countWorktrees(')) + 2);
+    assert.ok(fn.includes('Date.now()'), '_countWorktrees must check current time for TTL');
+    assert.ok(fn.includes('_worktreeCountCacheTs'), '_countWorktrees must reference cache timestamp');
+    assert.ok(fn.includes('_worktreeCountCache'), '_countWorktrees must reference cached value');
+    // Must have early return for cache hit (return cached value without scanning)
+    assert.ok(fn.includes('return _worktreeCountCache'), '_countWorktrees must return cached value on cache hit');
+  });
+
+  await test('_countWorktrees updates cache after filesystem scan', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const fn = dashSrc.slice(dashSrc.indexOf('function _countWorktrees('), dashSrc.indexOf('\n}', dashSrc.indexOf('function _countWorktrees(')) + 2);
+    // After scanning, must write back to cache
+    assert.ok(fn.includes('_worktreeCountCache = count') || fn.includes('_worktreeCountCache = '),
+      '_countWorktrees must store scanned count in cache');
+    assert.ok(fn.includes('_worktreeCountCacheTs = '),
+      '_countWorktrees must update cache timestamp after scan');
+  });
+
+  await test('_countWorktrees TTL uses ENGINE_DEFAULTS.worktreeCountCacheTtl', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const fn = dashSrc.slice(dashSrc.indexOf('function _countWorktrees('), dashSrc.indexOf('\n}', dashSrc.indexOf('function _countWorktrees(')) + 2);
+    assert.ok(fn.includes('worktreeCountCacheTtl'),
+      '_countWorktrees TTL must reference ENGINE_DEFAULTS.worktreeCountCacheTtl, not a hardcoded number');
+  });
+
+  await test('ENGINE_DEFAULTS includes worktreeCountCacheTtl', () => {
+    assert.strictEqual(shared.ENGINE_DEFAULTS.worktreeCountCacheTtl, 30000,
+      'worktreeCountCacheTtl must be 30000ms (30 seconds)');
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10305,6 +10305,72 @@ async function testSharedJsFixes() {
     try { fs.unlinkSync(lockPath); } catch {}
   });
 
+  await test('ENGINE_DEFAULTS.lockRetries is 0 — single attempt, no exponential backoff', () => {
+    // lockRetries=0 means maxAttempts=1: one 5s timeout window, no backoff sleeps
+    assert.strictEqual(shared.ENGINE_DEFAULTS.lockRetries, 0,
+      'lockRetries should be 0 to eliminate exponential backoff blocking');
+    // lockRetryBackoffMs kept at 500 for callers that explicitly override lockRetries
+    assert.strictEqual(shared.ENGINE_DEFAULTS.lockRetryBackoffMs, 500,
+      'lockRetryBackoffMs should remain at 500 for override callers');
+  });
+
+  await test('withFileLock with retries=0 throws immediately after single timeout — no retry', () => {
+    const dir = createTmpDir();
+    const lockPath = path.join(dir, 'no-retry.lock');
+    // Hold the lock externally
+    fs.writeFileSync(lockPath, 'held');
+
+    const start = Date.now();
+    let threw = false;
+    try {
+      shared.withFileLock(lockPath, () => {}, { timeoutMs: 200, retryDelayMs: 25, retries: 0 });
+    } catch (e) {
+      threw = true;
+      assert.ok(e.message.includes('Lock timeout'), `Expected lock timeout, got: ${e.message}`);
+    }
+    const elapsed = Date.now() - start;
+    assert.ok(threw, 'should throw Lock timeout with retries=0');
+    // With retries=0, should complete in ~200ms (single timeout), not ~600ms+ (which would indicate a retry)
+    assert.ok(elapsed < 400, `Should finish in ~200ms (single attempt), took ${elapsed}ms — indicates retry happened`);
+    try { fs.unlinkSync(lockPath); } catch {}
+  });
+
+  await test('withFileLock callers can override retries via options parameter', () => {
+    const dir = createTmpDir();
+    const lockPath = path.join(dir, 'override-retry.lock');
+    // Hold the lock externally
+    fs.writeFileSync(lockPath, 'held');
+
+    const start = Date.now();
+    let threw = false;
+    try {
+      // Explicitly pass retries=1 — should attempt twice (1 timeout + backoff + 1 timeout)
+      shared.withFileLock(lockPath, () => {}, { timeoutMs: 150, retryDelayMs: 25, retries: 1, retryBackoffMs: 50 });
+    } catch (e) {
+      threw = true;
+      assert.ok(e.message.includes('Lock timeout'), `Expected lock timeout, got: ${e.message}`);
+    }
+    const elapsed = Date.now() - start;
+    assert.ok(threw, 'should throw Lock timeout after exhausting override retries');
+    // With retries=1: 150ms timeout + 50ms backoff + 150ms timeout = ~350ms minimum
+    assert.ok(elapsed >= 300, `With retries=1, should take >=300ms, took ${elapsed}ms — override not working`);
+    try { fs.unlinkSync(lockPath); } catch {}
+  });
+
+  await test('mutateJsonFileLocked uses ENGINE_DEFAULTS.lockRetries=0 by default', () => {
+    // Verify mutateJsonFileLocked reads lockRetries from ENGINE_DEFAULTS
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    const fnStart = src.indexOf('function mutateJsonFileLocked(');
+    assert.ok(fnStart >= 0, 'mutateJsonFileLocked should exist');
+    const fnBody = src.substring(fnStart, fnStart + 500);
+    // Should use ENGINE_DEFAULTS.lockRetries as default
+    assert.ok(fnBody.includes('ENGINE_DEFAULTS.lockRetries'),
+      'mutateJsonFileLocked should default to ENGINE_DEFAULTS.lockRetries');
+    // Should use ENGINE_DEFAULTS.lockRetryBackoffMs as default
+    assert.ok(fnBody.includes('ENGINE_DEFAULTS.lockRetryBackoffMs'),
+      'mutateJsonFileLocked should default to ENGINE_DEFAULTS.lockRetryBackoffMs');
+  });
+
   await test('sanitizePath allows valid subpaths', () => {
     const base = createTmpDir();
     const result = shared.sanitizePath('sub/dir/file.txt', base);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10209,6 +10209,9 @@ async function main() {
     // W-mo1jw71krscj: Pipeline behavioral tests — CRUD, stage execution, run lifecycle
     await testPipelineBehavioral();
 
+    // P-a5e9c1d7: Split getStatus() into fast/slow state tiers
+    await testStatusCacheTiers();
+
     // Test isolation verification (must be LAST — checks no pollution from earlier tests)
     await testIsolationVerification();
   } finally {
@@ -23299,6 +23302,103 @@ async function testPipelineBehavioral() {
       assert.ok(fn.includes(`STAGE_TYPE.${type}`), `executeStage should handle STAGE_TYPE.${type}`);
     }
     assert.ok(fn.includes('PIPELINE_STATUS.WAITING_HUMAN'), 'WAIT should return WAITING_HUMAN status');
+  });
+}
+
+// ─── P-a5e9c1d7: Split getStatus() into fast/slow state tiers ───────────────
+
+async function testStatusCacheTiers() {
+  console.log('\n── Status Cache Tiers (fast/slow) ──');
+
+  const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+
+  // ── Tier variables and TTLs exist ──
+
+  await test('dashboard.js has _fastState and _slowState cache variables', () => {
+    assert.ok(dashSrc.includes('let _fastState'), '_fastState variable must exist');
+    assert.ok(dashSrc.includes('let _slowState'), '_slowState variable must exist');
+    assert.ok(dashSrc.includes('let _fastStateTs'), '_fastStateTs timestamp must exist');
+    assert.ok(dashSrc.includes('let _slowStateTs'), '_slowStateTs timestamp must exist');
+  });
+
+  await test('FAST_STATE_TTL is 10s and SLOW_STATE_TTL is 60s', () => {
+    assert.ok(dashSrc.includes('FAST_STATE_TTL = 10000'), 'FAST_STATE_TTL must be 10000ms (10s)');
+    assert.ok(dashSrc.includes('SLOW_STATE_TTL = 60000'), 'SLOW_STATE_TTL must be 60000ms (60s)');
+  });
+
+  // ── Fast state contains the right keys ──
+
+  await test('fast state includes frequently-changing data', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // These must appear in the _fastState assignment
+    assert.ok(body.includes('_fastState'), 'getStatus must build _fastState');
+    for (const key of ['agents:', 'inbox:', 'pullRequests:', 'dispatch:', 'metrics:', 'workItems:', 'watches:', 'meetings:', 'adoThrottle:', 'ghThrottle:', 'engineLog:']) {
+      assert.ok(body.includes(key), `fast state must include ${key}`);
+    }
+  });
+
+  // ── Slow state contains the right keys ──
+
+  await test('slow state includes rarely-changing data', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    assert.ok(body.includes('_slowState'), 'getStatus must build _slowState');
+    for (const key of ['skills:', 'prdProgress:', 'mcpServers:', 'pinned:', 'projects:', 'autoMode:', 'version:', 'schedules:']) {
+      assert.ok(body.includes(key), `slow state must include ${key}`);
+    }
+  });
+
+  // ── invalidateStatusCache invalidates fast state only ──
+
+  await test('invalidateStatusCache nullifies _fastState but not _slowState', () => {
+    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+    assert.ok(fn, 'invalidateStatusCache must exist');
+    const body = fn[0];
+    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState');
+    assert.ok(!body.includes('_slowState = null'), 'must NOT nullify _slowState — slow state stays on its own TTL');
+  });
+
+  // ── mtime tracking applies to fast state only ──
+
+  await test('mtime-based validation applies only to fast-state TTL check', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The mtime check should be near _fastState logic, not _slowState
+    const fastIdx = body.indexOf('_fastState');
+    const mtimeIdx = body.indexOf('_mtimesChanged');
+    const slowIdx = body.indexOf('_slowState');
+    assert.ok(fastIdx > 0 && mtimeIdx > 0 && slowIdx > 0, 'all three markers must exist');
+    // mtime check should appear before or near fast state, not after slow state assignment
+    assert.ok(mtimeIdx < slowIdx, 'mtime validation must appear before slow state building (applies to fast tier only)');
+  });
+
+  // ── getStatus merges both tiers ──
+
+  await test('getStatus merges fast and slow state into combined _statusCache', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The final _statusCache should spread both tiers
+    assert.ok(body.includes('..._fastState') && body.includes('..._slowState'),
+      'getStatus must merge _fastState and _slowState via spread into _statusCache');
+    assert.ok(body.includes('timestamp:'), 'merged status must include timestamp');
+  });
+
+  // ── Slow state is NOT rebuilt when only fast state changes ──
+
+  await test('slow state rebuild is gated by SLOW_STATE_TTL only (no mtime check)', () => {
+    const statusFn = dashSrc.match(/function getStatus\(\)[\s\S]*?^}/m);
+    assert.ok(statusFn, 'getStatus must exist');
+    const body = statusFn[0];
+    // The slowStale check should reference SLOW_STATE_TTL, not _mtimesChanged
+    assert.ok(body.includes('SLOW_STATE_TTL'), 'slow state staleness must be gated by SLOW_STATE_TTL');
+    // Extract the slowStale logic — it should be a simple TTL check
+    const slowStaleMatch = body.match(/slowStale\s*=.*SLOW_STATE_TTL/);
+    assert.ok(slowStaleMatch, 'slowStale must be determined by SLOW_STATE_TTL comparison');
   });
 }
 


### PR DESCRIPTION
## Summary

Aggregate E2E PR for plan `minions-2026-04-16-2.json` — Dashboard & engine performance optimizations.

Combines 6 individual PRs:
- **#1166** Cache `_countWorktrees()` with 30s TTL (`work/P-b2d4e6f0`)
- **#1168** Reduce `withFileLock` retry backoff to 0 retries (`work/P-f3b7d2a4`)
- **#1169** Fix unlocked `safeWrite` to work-items.json in cleanup.js (`work/P-d9a3f5c2`)
- **#1170** Split `getStatus()` into fast/slow state tiers with separate TTLs (`work/P-a5e9c1d7`)
- **#1171** Pre-cache gzipped status buffer alongside JSON cache (`work/P-c7f1a3b8`)
- **#1172** Parallelize ADO and GitHub PR polling with `Promise.allSettled` (`work/P-e1c8b4a6`)

## Build & Test Results

| Project | Worktree | Build | Tests | Notes |
|---------|----------|-------|-------|-------|
| minions | `D:/worktrees/verify-minions-minions-2026-04-16-2-mo1ll95npv5v` | PASS | 2222 passed, 7 failed, 3 skipped | 7 failures are pre-existing doc-chat tests from parent history (not in any of the 6 PRs); master has 0 failures |

## Acceptance Criteria Verification

All 6 items **PASS** — every acceptance criterion verified against source:

- ✅ **P-b2d4e6f0**: `_worktreeCountCache`/`_worktreeCountCacheTs` with 30s TTL via `ENGINE_DEFAULTS.worktreeCountCacheTtl`
- ✅ **P-f3b7d2a4**: `ENGINE_DEFAULTS.lockRetries` = 0, `lockRetryBackoffMs` remains 500, `withFileLock()` logic untouched
- ✅ **P-d9a3f5c2**: `mutateWorkItems()` replaces `safeJson()+safeWrite()`, callback is sync, count logged after lock release
- ✅ **P-a5e9c1d7**: `_fastState` (10s) + `_slowState` (60s), merged into `_statusCache`, `invalidateStatusCache()` only resets fast state
- ✅ **P-c7f1a3b8**: `_statusCacheGzip` pre-computed once per rebuild, served directly in `handleStatus()`, SSE uses O(1) ref comparison
- ✅ **P-e1c8b4a6**: `Promise.allSettled()` for concurrent polls, conditional guards preserved, post-poll steps run after both complete

## Merge Conflicts Resolved

- `dashboard.js`: Integrated gzip cache variables (`_statusCacheGzip`) with tiered status cache (fast/slow state). Kept gzip var declarations and invalidation alongside the tiered approach.
- `test/unit.test.js`: Included all three new test suites (tiered cache, gzip cache, parallel polling) in the test runner.

## Testing Guide

See `prd/guides/verify-minions-2026-04-16-2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)