### PR TITLE
fix: sidecar oversized dispatch prompts to prevent dashboard OOM (#1167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ engine/kb-swept.json
 engine/watches.json
 # All transient temp files (prompts, pids, logs) go in engine/tmp/
 engine/tmp/
+# Large-prompt sidecar files referenced by dispatch.json entries (#1167)
+engine/contexts/
 # Backup/lock files from safeWrite atomic writes
 engine/*.bak
 engine/*.backup

--- a/dashboard.js
+++ b/dashboard.js
@@ -32,6 +32,24 @@ const { getAgents, getAgentDetail, getPrdInfo, getWorkItems, getDispatchQueue,
   getEngineLog, getMetrics, getKnowledgeBaseEntries, timeSince,
   MINIONS_DIR, AGENTS_DIR, ENGINE_DIR, INBOX_DIR, DISPATCH_PATH, PRD_DIR } = queries;
 
+// Startup size guard (#1167): fail fast with a clear error when dispatch.json /
+// cooldowns.json have ballooned past ENGINE_DEFAULTS.maxStateFileBytes. Without
+// this, V8 silently OOMs on JSON.parse(~1 GB) and the operator has no hint as to
+// which file is bloated. The thrown error names the file and directs to
+// engine/contexts/ where sidecars live.
+(() => {
+  const stateFiles = [
+    DISPATCH_PATH,
+    path.join(ENGINE_DIR, 'cooldowns.json'),
+  ];
+  for (const fp of stateFiles) {
+    try { shared.assertStateFileSize(fp); } catch (e) {
+      console.error('\n[dashboard] STARTUP ABORTED — ' + e.message + '\n');
+      process.exit(78); // 78 = configuration error; consistent with spawn-agent.js
+    }
+  }
+})();
+
 const PORT = parseInt(process.env.PORT || process.argv[2]) || 7331;
 let CONFIG = queries.getConfig();
 let PROJECTS = _getProjects(CONFIG);

--- a/engine.js
+++ b/engine.js
@@ -355,7 +355,11 @@ async function recoverPartialWorktree(rootDir, worktreePath, branchName, gitOpts
 }
 
 async function spawnAgent(dispatchItem, config) {
-  const { id, agent: agentId, prompt: taskPrompt, type, meta } = dispatchItem;
+  const { id, agent: agentId, type, meta } = dispatchItem;
+  // Resolve prompt — prefers sidecar file when dispatchItem._promptFile is set
+  // (large prompts are written to engine/contexts/<id>.md to keep dispatch.json
+  // small — see shared.sidecarDispatchPrompt / #1167).
+  const taskPrompt = shared.resolveDispatchPrompt(dispatchItem);
   const claudeConfig = config.claude || {};
   const engineConfig = config.engine || {};
   const startedAt = ts();

--- a/engine/cli.js
+++ b/engine/cli.js
@@ -51,6 +51,18 @@ function handleCommand(cmd, args) {
 
 const commands = {
   start() {
+    // Startup state-file size guard (#1167): dispatch.json / cooldowns.json
+    // bloated past 100 MB silently OOMed V8 on JSON.parse at startup. Fail fast
+    // with an actionable message instead.
+    try {
+      for (const fp of [DISPATCH_PATH, path.join(ENGINE_DIR, 'cooldowns.json')]) {
+        shared.assertStateFileSize(fp);
+      }
+    } catch (stateErr) {
+      console.error('\n[engine] STARTUP ABORTED — ' + stateErr.message + '\n');
+      process.exit(78); // 78 = configuration error
+    }
+
     // Run preflight checks (warn but don't block — engine may still be useful)
     try {
       const { runPreflight, printPreflight } = require('./preflight');

--- a/engine/cooldown.js
+++ b/engine/cooldown.js
@@ -10,6 +10,31 @@ const queries = require('./queries');
 const { safeJson, safeWrite, log, ENGINE_DEFAULTS } = shared;
 const { ENGINE_DIR } = queries;
 
+/**
+ * Truncate any string fields on a pendingContexts entry so a single huge PR
+ * comment / build log cannot bloat cooldowns.json to hundreds of MB (#1167).
+ * Returns a new entry object (does not mutate the caller's copy).
+ */
+function _truncateContextEntry(entry, maxBytes) {
+  if (entry == null) return entry;
+  const limit = Number(maxBytes) > 0 ? Number(maxBytes) : ENGINE_DEFAULTS.maxPendingContextEntryBytes;
+  if (typeof entry === 'string') {
+    return Buffer.byteLength(entry, 'utf8') > limit
+      ? entry.slice(0, limit) + `\n\n... [truncated: context exceeded ${Math.round(limit / 1024)} KB]`
+      : entry;
+  }
+  if (typeof entry !== 'object') return entry;
+  const out = Array.isArray(entry) ? [] : {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (typeof v === 'string' && Buffer.byteLength(v, 'utf8') > limit) {
+      out[k] = v.slice(0, limit) + `\n\n... [truncated: ${k} exceeded ${Math.round(limit / 1024)} KB]`;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
 const COOLDOWN_PATH = path.join(ENGINE_DIR, 'cooldowns.json');
 const dispatchCooldowns = new Map(); // key → { timestamp, failures }
 
@@ -39,9 +64,15 @@ function saveCooldowns() {
     }
     // Trim pendingContexts arrays before writing to prevent bloat
     const cap = ENGINE_DEFAULTS.maxPendingContexts;
+    const entryLimit = ENGINE_DEFAULTS.maxPendingContextEntryBytes;
     for (const [, v] of dispatchCooldowns) {
-      if (Array.isArray(v.pendingContexts) && v.pendingContexts.length > cap) {
-        v.pendingContexts = v.pendingContexts.slice(-cap);
+      if (Array.isArray(v.pendingContexts)) {
+        if (v.pendingContexts.length > cap) {
+          v.pendingContexts = v.pendingContexts.slice(-cap);
+        }
+        // Also truncate oversized individual entries — #1167 showed
+        // 20 entries × 25 MB each still produced a 500 MB cooldowns.json.
+        v.pendingContexts = v.pendingContexts.map(e => _truncateContextEntry(e, entryLimit));
       }
     }
     const obj = Object.fromEntries(dispatchCooldowns);
@@ -69,7 +100,12 @@ function setCooldown(key) {
 function setCooldownWithContext(key, context) {
   const existing = dispatchCooldowns.get(key);
   let pendingContexts = existing?.pendingContexts || [];
-  if (context) pendingContexts.push(context);
+  if (context) {
+    // Truncate oversized string fields per-entry BEFORE storing so a single
+    // huge payload (PR diff, build log, full repo dump) cannot bloat
+    // cooldowns.json regardless of array cap (#1167).
+    pendingContexts.push(_truncateContextEntry(context, ENGINE_DEFAULTS.maxPendingContextEntryBytes));
+  }
   // Cap to last N entries to prevent unbounded growth (cooldowns.json bloat)
   const cap = ENGINE_DEFAULTS.maxPendingContexts;
   if (pendingContexts.length > cap) pendingContexts = pendingContexts.slice(-cap);

--- a/engine/dispatch.js
+++ b/engine/dispatch.js
@@ -11,6 +11,7 @@ const { setCooldownFailure } = require('./cooldown');
 
 const { safeJson, safeWrite, safeReadDir, mutateJsonFileLocked, mutateWorkItems,
   mutatePullRequests, getProjects, projectWorkItemsPath, projectPrPath, log, ts, dateStamp,
+  sidecarDispatchPrompt, deleteDispatchPromptSidecar,
   WI_STATUS, DISPATCH_RESULT, ENGINE_DEFAULTS, AGENT_STATUS, FAILURE_CLASS } = shared;
 const { getConfig, getDispatch, DISPATCH_PATH, INBOX_DIR } = queries;
 
@@ -24,13 +25,34 @@ function recovery() { if (!_recovery) _recovery = require('./recovery'); return 
 
 // ─── Dispatch Mutation ───────────────────────────────────────────────────────
 
+/**
+ * Sweep pending + active dispatch entries and move any oversized prompts to
+ * sidecar files. Keeps dispatch.json from bloating to hundreds of MB when
+ * fix-type prompts inline PR diffs / build logs / coalesced feedback (#1167).
+ * Safe to call on every mutation: small prompts are untouched.
+ */
+function _sidecarOversizedPrompts(dispatch) {
+  const threshold = ENGINE_DEFAULTS.maxDispatchPromptBytes;
+  const lists = [dispatch.pending, dispatch.active];
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const item of list) {
+      if (item && typeof item.prompt === 'string') sidecarDispatchPrompt(item, threshold);
+    }
+  }
+}
+
 function mutateDispatch(mutator) {
   const defaultDispatch = { pending: [], active: [], completed: [] };
   const result = mutateJsonFileLocked(DISPATCH_PATH, (dispatch) => {
     dispatch.pending = Array.isArray(dispatch.pending) ? dispatch.pending : [];
     dispatch.active = Array.isArray(dispatch.active) ? dispatch.active : [];
     dispatch.completed = Array.isArray(dispatch.completed) ? dispatch.completed : [];
-    return mutator(dispatch) ?? dispatch;
+    const next = mutator(dispatch) ?? dispatch;
+    // Prompt-size guard: runs on every write so a single bad item cannot bloat
+    // dispatch.json. Sidecars live in engine/contexts/<id>.md.
+    _sidecarOversizedPrompts(next);
+    return next;
   }, { defaultValue: defaultDispatch });
   // Invalidate the read cache so next getDispatch() sees fresh data
   try { require('./queries').invalidateDispatchCache(); } catch {}
@@ -116,7 +138,12 @@ function completeDispatch(id, result = DISPATCH_RESULT.SUCCESS, reason = '', res
     if (reason) item.reason = reason;
     if (resultSummary) item.resultSummary = resultSummary;
     if (failureClass && result === DISPATCH_RESULT.ERROR) item.failureClass = failureClass;
+    // Drop prompt (and sidecar file, if any) — completed entries don't need
+    // replayable content and it would accumulate forever (#1167).
+    try { deleteDispatchPromptSidecar(item); } catch { /* best-effort */ }
     delete item.prompt;
+    delete item._promptFile;
+    delete item._promptBytes;
     if (dispatch.completed.length >= 100) {
       dispatch.completed = dispatch.completed.slice(-100);
     }

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -162,6 +162,118 @@ function safeUnlink(p) {
   try { fs.unlinkSync(p); } catch { /* cleanup */ }
 }
 
+// ── Dispatch Prompt Sidecar (#1167) ─────────────────────────────────────────
+// Large prompts (PR diffs, build error logs, coalesced human feedback) inlined
+// into dispatch.json caused hundreds-of-MB bloat per entry and eventual V8 OOM
+// at startup. Sidecar files keep dispatch.json small while preserving full
+// content for the agent at spawn time.
+
+// Resolve lazily so MINIONS_TEST_DIR overrides work in tests.
+function _promptContextsDir() {
+  return path.join(MINIONS_DIR, 'engine', 'contexts');
+}
+// Keep the constant for callers that expect a stable export; callers that need
+// the current value (tests) should call _promptContextsDir().
+const PROMPT_CONTEXTS_DIR = _promptContextsDir();
+
+/** Absolute path to the sidecar prompt file for a given dispatch id. */
+function dispatchPromptSidecarPath(dispatchId) {
+  if (!dispatchId) return null;
+  const safeId = String(dispatchId).replace(/[^a-zA-Z0-9._-]/g, '-');
+  return path.join(_promptContextsDir(), `${safeId}.md`);
+}
+
+/**
+ * If the dispatch item's prompt exceeds thresholdBytes, write the full prompt
+ * to engine/contexts/<id>.md and replace `item.prompt` with a short stub
+ * + `_promptFile` reference. Mutates item in place and returns true when
+ * sidecaring happened, false otherwise.
+ */
+function sidecarDispatchPrompt(item, thresholdBytes) {
+  if (!item || typeof item.prompt !== 'string') return false;
+  const threshold = Number(thresholdBytes) > 0
+    ? Number(thresholdBytes)
+    : ENGINE_DEFAULTS.maxDispatchPromptBytes;
+  const byteLen = Buffer.byteLength(item.prompt, 'utf8');
+  if (byteLen <= threshold) return false;
+  if (!item.id) return false; // can't sidecar without a stable id
+  try {
+    const ctxDir = _promptContextsDir();
+    if (!fs.existsSync(ctxDir)) fs.mkdirSync(ctxDir, { recursive: true });
+    const sidecar = dispatchPromptSidecarPath(item.id);
+    safeWrite(sidecar, item.prompt);
+    const relPath = path.relative(MINIONS_DIR, sidecar).replace(/\\/g, '/');
+    item._promptFile = relPath;
+    item._promptBytes = byteLen;
+    item.prompt = `[Prompt sidecarred to ${relPath} — ${Math.round(byteLen / 1024)} KB. The engine reads the sidecar when spawning this agent.]`;
+    try { log('warn', `Sidecarred oversized dispatch prompt: ${item.id} (${Math.round(byteLen / 1024)} KB → ${relPath})`); } catch { /* logger may not be ready */ }
+    return true;
+  } catch (e) {
+    try { log('warn', `sidecarDispatchPrompt failed for ${item.id}: ${e.message}`); } catch { /* cleanup */ }
+    return false;
+  }
+}
+
+/**
+ * Read the effective prompt for a dispatch item. Prefers the sidecar file when
+ * `_promptFile` is set so spawnAgent always sees the full prompt even though
+ * dispatch.json only stores a small stub.
+ */
+function resolveDispatchPrompt(item) {
+  if (!item) return '';
+  if (item._promptFile) {
+    const candidates = [
+      path.isAbsolute(item._promptFile) ? item._promptFile : path.resolve(MINIONS_DIR, item._promptFile),
+      dispatchPromptSidecarPath(item.id),
+    ].filter(Boolean);
+    for (const c of candidates) {
+      try {
+        const content = fs.readFileSync(c, 'utf8');
+        if (content) return content;
+      } catch { /* try next candidate */ }
+    }
+  }
+  return item.prompt || '';
+}
+
+/** Remove the sidecar prompt file for a completed/cancelled dispatch. */
+function deleteDispatchPromptSidecar(item) {
+  if (!item) return;
+  const paths = new Set();
+  if (item._promptFile) {
+    paths.add(path.isAbsolute(item._promptFile) ? item._promptFile : path.resolve(MINIONS_DIR, item._promptFile));
+  }
+  const idPath = dispatchPromptSidecarPath(item.id);
+  if (idPath) paths.add(idPath);
+  for (const p of paths) safeUnlink(p);
+}
+
+/**
+ * Startup guard: throw a clear error when a state file has grown past
+ * maxStateFileBytes. Without this the dashboard silently OOMs on JSON.parse
+ * (seen on a 491 MB dispatch.json + 509 MB cooldowns.json — #1167).
+ * The thrown error points at the bloated file so operators can act instead
+ * of chasing V8 heap traces.
+ */
+function assertStateFileSize(filePath, maxBytes) {
+  const limit = Number(maxBytes) > 0 ? Number(maxBytes) : ENGINE_DEFAULTS.maxStateFileBytes;
+  try {
+    const stat = fs.statSync(filePath);
+    if (stat.size > limit) {
+      throw new Error(
+        `State file too large: ${filePath} is ${Math.round(stat.size / (1024 * 1024))} MB ` +
+        `(limit ${Math.round(limit / (1024 * 1024))} MB). ` +
+        `This usually means dispatch prompts or cooldown contexts were inlined and not sidecarred. ` +
+        `Inspect/trim the file manually, then restart. See engine/contexts/ for sidecar files.`
+      );
+    }
+  } catch (e) {
+    if (e.code === 'ENOENT') return; // file absent is fine
+    if (e.message && e.message.startsWith('State file too large:')) throw e;
+    // Other stat errors (permission etc.) — do not block startup
+  }
+}
+
 function sleepMs(ms) {
   try {
     const ab = new SharedArrayBuffer(4);
@@ -570,6 +682,9 @@ const ENGINE_DEFAULTS = {
   ccEffort: null, // effort level for CC/doc-chat (null, 'low', 'medium', 'high')
   heartbeatTimeouts: {}, // populated after WORK_TYPE is defined (below)
   maxPendingContexts: 20, // cap pendingContexts arrays in cooldowns.json to prevent unbounded growth
+  maxPendingContextEntryBytes: 256 * 1024, // 256 KB — cap each pendingContexts entry to prevent huge PR comments from bloating cooldowns.json
+  maxDispatchPromptBytes: 1024 * 1024, // 1 MB — dispatch items with prompts larger than this sidecar to engine/contexts/ to prevent dispatch.json OOM (#1167)
+  maxStateFileBytes: 100 * 1024 * 1024, // 100 MB — fail startup with a clear error when dispatch.json / cooldowns.json exceed this, rather than silently OOMing on JSON.parse (#1167)
   ccMaxTurns: 50, // max tool-use turns for CC/doc-chat before CLI stops
   // Teams integration — config.teams shape: { enabled, appId, appPassword, certPath, privateKeyPath, tenantId, notifyEvents, ccMirror, inboxPollInterval }
   // Auth modes: (1) appId + appPassword (client secret), or (2) appId + certPath + privateKeyPath + tenantId (certificate)
@@ -1398,6 +1513,12 @@ module.exports = {
   safeJson, safeJsonObj, safeJsonArr,
   safeWrite,
   safeUnlink,
+  PROMPT_CONTEXTS_DIR,
+  dispatchPromptSidecarPath,
+  sidecarDispatchPrompt,
+  resolveDispatchPrompt,
+  deleteDispatchPromptSidecar,
+  assertStateFileSize,
   withFileLock,
   mutateJsonFileLocked,
   mutateWorkItems,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7225,6 +7225,259 @@ async function testWakeupCoalescing() {
     // Cleanup
     cooldown.dispatchCooldowns.delete(testKey);
   });
+
+  // ── Per-entry size cap (#1167) ──
+  // Rationale: count-capping alone (20 entries) is insufficient — a single
+  // huge PR comment blob (50+ MB) would still produce a 1 GB cooldowns.json
+  // at the cap. Each string field must be individually truncated.
+
+  await test('ENGINE_DEFAULTS defines maxPendingContextEntryBytes (#1167)', () => {
+    assert.ok(sharedSrc.includes('maxPendingContextEntryBytes'),
+      'ENGINE_DEFAULTS should define per-entry byte cap for pendingContexts');
+  });
+
+  await test('setCooldownWithContext truncates oversized string fields (#1167)', () => {
+    const cooldown = require(path.join(MINIONS_DIR, 'engine', 'cooldown.js'));
+    const testKey = `__test_entrycap_${Date.now()}`;
+    const huge = 'x'.repeat(1024 * 1024); // 1 MB — above 256 KB default cap
+    cooldown.setCooldownWithContext(testKey, { feedbackContent: huge, timestamp: 'now' });
+    const entry = cooldown.dispatchCooldowns.get(testKey);
+    assert.ok(entry, 'Entry should exist');
+    assert.strictEqual(entry.pendingContexts.length, 1, 'One context should be stored');
+    const stored = entry.pendingContexts[0];
+    // Must be truncated — stored size clearly under the 1 MB input
+    assert.ok(
+      Buffer.byteLength(stored.feedbackContent, 'utf8') < Buffer.byteLength(huge, 'utf8'),
+      'feedbackContent should be truncated from 1 MB to under the cap');
+    assert.ok(stored.feedbackContent.includes('truncated'),
+      'Truncated context should include a marker indicating what happened');
+    assert.strictEqual(stored.timestamp, 'now', 'Non-string fields should be preserved');
+    cooldown.dispatchCooldowns.delete(testKey);
+  });
+}
+
+// ─── Dispatch Prompt Sidecar (#1167) ─────────────────────────────────────────
+// Fix-type prompts inlined hundreds-of-MB PR diffs / build logs into
+// dispatch.json and crashed the dashboard at JSON.parse(~1 GB). The sidecar
+// helpers write oversized prompts to engine/contexts/<id>.md and keep only a
+// short stub + _promptFile ref in dispatch.json. Guards run on every mutation
+// so a single runaway call cannot bloat the queue.
+
+async function testDispatchPromptSidecar() {
+  console.log('\n── dispatch.json prompt sidecar (#1167) ──');
+
+  await test('ENGINE_DEFAULTS defines maxDispatchPromptBytes', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(src.includes('maxDispatchPromptBytes'),
+      'ENGINE_DEFAULTS should define the dispatch prompt size threshold');
+  });
+
+  await test('ENGINE_DEFAULTS defines maxStateFileBytes', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(src.includes('maxStateFileBytes'),
+      'ENGINE_DEFAULTS should define the state-file size ceiling');
+  });
+
+  await test('shared exports sidecar helpers', () => {
+    assert.strictEqual(typeof shared.sidecarDispatchPrompt, 'function',
+      'sidecarDispatchPrompt should be exported');
+    assert.strictEqual(typeof shared.resolveDispatchPrompt, 'function',
+      'resolveDispatchPrompt should be exported');
+    assert.strictEqual(typeof shared.deleteDispatchPromptSidecar, 'function',
+      'deleteDispatchPromptSidecar should be exported');
+    assert.strictEqual(typeof shared.assertStateFileSize, 'function',
+      'assertStateFileSize should be exported');
+  });
+
+  await test('sidecarDispatchPrompt leaves small prompts alone', () => {
+    const restore = createTestMinionsDir();
+    try {
+      // Bust caches so helpers resolve against the test MINIONS_DIR
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const freshShared = require('../engine/shared');
+      const item = { id: 'test-small-1', prompt: 'hello world' };
+      const didSidecar = freshShared.sidecarDispatchPrompt(item, 1024 * 1024);
+      assert.strictEqual(didSidecar, false, 'Small prompt should not be sidecarred');
+      assert.strictEqual(item.prompt, 'hello world', 'Prompt should be untouched');
+      assert.ok(!item._promptFile, 'No _promptFile marker should be added');
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('sidecarDispatchPrompt writes oversized prompt to engine/contexts/<id>.md', () => {
+    const restore = createTestMinionsDir();
+    try {
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const freshShared = require('../engine/shared');
+      const huge = 'A'.repeat(2 * 1024 * 1024); // 2 MB — above 1 MB default threshold
+      const item = { id: 'test-big-1', prompt: huge };
+      const didSidecar = freshShared.sidecarDispatchPrompt(item);
+      assert.strictEqual(didSidecar, true, 'Oversized prompt should be sidecarred');
+      assert.ok(item._promptFile, '_promptFile reference should be set');
+      assert.ok(item.prompt.length < 1000, 'Inlined prompt should be replaced with a short stub');
+      assert.ok(item.prompt.includes(item._promptFile),
+        'Stub prompt should name the sidecar path so humans inspecting dispatch.json see where the content went');
+      // File should exist and match original content
+      const sidecarPath = freshShared.dispatchPromptSidecarPath(item.id);
+      assert.ok(fs.existsSync(sidecarPath), 'Sidecar file should exist on disk');
+      assert.strictEqual(fs.readFileSync(sidecarPath, 'utf8'), huge,
+        'Sidecar must preserve the full original prompt byte-for-byte');
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('resolveDispatchPrompt returns sidecar contents when _promptFile is set', () => {
+    const restore = createTestMinionsDir();
+    try {
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const freshShared = require('../engine/shared');
+      const huge = 'B'.repeat(1.5 * 1024 * 1024);
+      const item = { id: 'test-resolve-1', prompt: huge };
+      freshShared.sidecarDispatchPrompt(item);
+      const resolved = freshShared.resolveDispatchPrompt(item);
+      assert.strictEqual(resolved, huge,
+        'resolveDispatchPrompt must return the full prompt from the sidecar, not the stub');
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('resolveDispatchPrompt returns inline prompt when no sidecar is set', () => {
+    const item = { id: 'inline-1', prompt: 'just a short prompt' };
+    assert.strictEqual(shared.resolveDispatchPrompt(item), 'just a short prompt');
+  });
+
+  await test('deleteDispatchPromptSidecar cleans up the sidecar file', () => {
+    const restore = createTestMinionsDir();
+    try {
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const freshShared = require('../engine/shared');
+      const item = { id: 'test-delete-1', prompt: 'C'.repeat(2 * 1024 * 1024) };
+      freshShared.sidecarDispatchPrompt(item);
+      const sidecarPath = freshShared.dispatchPromptSidecarPath(item.id);
+      assert.ok(fs.existsSync(sidecarPath), 'Sidecar should exist after sidecarDispatchPrompt');
+      freshShared.deleteDispatchPromptSidecar(item);
+      assert.ok(!fs.existsSync(sidecarPath), 'Sidecar should be removed after deleteDispatchPromptSidecar');
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('mutateDispatch sidecars oversized pending prompts automatically', () => {
+    const restore = createTestMinionsDir();
+    try {
+      for (const mod of ['../engine/shared', '../engine/dispatch', '../engine/queries']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const testDispatch = require('../engine/dispatch');
+      const testQueries = require('../engine/queries');
+      const huge = 'D'.repeat(2 * 1024 * 1024);
+      testDispatch.mutateDispatch(dp => {
+        dp.pending.push({ id: 'oversized-1', agent: 'test', type: 'fix', prompt: huge });
+        return dp;
+      });
+      const onDisk = testQueries.getDispatch();
+      const found = onDisk.pending.find(p => p.id === 'oversized-1');
+      assert.ok(found, 'Item should be present in pending');
+      assert.ok(found._promptFile, 'Oversized prompt must be sidecarred automatically');
+      assert.ok(found.prompt.length < 1000,
+        'dispatch.json must not contain the full oversized prompt');
+      // Sanity: dispatch.json size stays reasonable
+      const dispatchBytes = fs.statSync(require('../engine/queries').DISPATCH_PATH).size;
+      assert.ok(dispatchBytes < 100 * 1024,
+        `dispatch.json should stay small after sidecaring (got ${dispatchBytes} bytes)`);
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared', '../engine/dispatch', '../engine/queries']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('completeDispatch deletes the prompt sidecar', () => {
+    const restore = createTestMinionsDir();
+    try {
+      for (const mod of ['../engine/shared', '../engine/dispatch', '../engine/queries', '../engine/lifecycle']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+      const freshShared = require('../engine/shared');
+      const testDispatch = require('../engine/dispatch');
+      const huge = 'E'.repeat(2 * 1024 * 1024);
+      testDispatch.mutateDispatch(dp => {
+        dp.active.push({ id: 'complete-test-1', agent: 'test', type: 'fix', prompt: huge, meta: {} });
+        return dp;
+      });
+      const sidecar = freshShared.dispatchPromptSidecarPath('complete-test-1');
+      assert.ok(fs.existsSync(sidecar), 'Sidecar should exist after mutateDispatch auto-sidecar');
+      testDispatch.completeDispatch('complete-test-1', shared.DISPATCH_RESULT.SUCCESS, '', '', { processWorkItemFailure: false });
+      assert.ok(!fs.existsSync(sidecar),
+        'completeDispatch should delete the sidecar — otherwise engine/contexts/ grows forever');
+    } finally {
+      restore();
+      for (const mod of ['../engine/shared', '../engine/dispatch', '../engine/queries', '../engine/lifecycle']) {
+        try { delete require.cache[require.resolve(mod)]; } catch {}
+      }
+    }
+  });
+
+  await test('assertStateFileSize throws when file exceeds limit', () => {
+    const dir = createTmpDir();
+    const fp = path.join(dir, 'huge.json');
+    // 2 MB file; check with 1 MB limit.
+    fs.writeFileSync(fp, Buffer.alloc(2 * 1024 * 1024, 'x'));
+    assert.throws(() => shared.assertStateFileSize(fp, 1 * 1024 * 1024),
+      /State file too large/,
+      'assertStateFileSize must throw a clear error naming the file');
+    // Under-limit file should not throw
+    const small = path.join(dir, 'small.json');
+    fs.writeFileSync(small, '{}');
+    assert.doesNotThrow(() => shared.assertStateFileSize(small));
+    // Missing file should not throw
+    assert.doesNotThrow(() => shared.assertStateFileSize(path.join(dir, 'missing.json')));
+  });
+
+  await test('dashboard.js guards startup with assertStateFileSize', () => {
+    const dashSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    assert.ok(dashSrc.includes('assertStateFileSize'),
+      'dashboard.js must call assertStateFileSize at startup (#1167)');
+  });
+
+  await test('engine/cli.js start guards with assertStateFileSize', () => {
+    const cliSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'cli.js'), 'utf8');
+    assert.ok(cliSrc.includes('assertStateFileSize'),
+      'engine/cli.js start command must call assertStateFileSize at startup (#1167)');
+  });
+
+  await test('spawnAgent reads prompt via resolveDispatchPrompt (sidecar-aware)', () => {
+    const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    const fnIdx = engineSrc.indexOf('async function spawnAgent(');
+    assert.ok(fnIdx > -1, 'spawnAgent should exist');
+    const fnBody = engineSrc.slice(fnIdx, fnIdx + 2000);
+    assert.ok(fnBody.includes('resolveDispatchPrompt'),
+      'spawnAgent must use resolveDispatchPrompt so oversized prompts are read from sidecar — otherwise agents get only the stub');
+  });
 }
 
 // ─── Budget Enforcement Tests ───────────────────────────────────────────────
@@ -9992,6 +10245,7 @@ async function main() {
     await testIsRetryableFailureReason();
     await testAreDependenciesMet();
     await testCooldownSystem();
+    await testDispatchPromptSidecar();
     await testResolveAgent();
     await testRenderPlaybook();
     await testValidatePlaybookVars();


### PR DESCRIPTION
Closes #1167.

## Problem

Fix-type work items inlined full PR diff / build-log / coalesced-human-feedback contexts directly into the `prompt` field of their dispatch entries. Three pending entries grew to 190 MB + 109 MB + 183 MB, and `cooldowns.json` cached another 505 MB of `pendingContexts`. On dashboard startup, `JSON.parse(~1 GB)` blew past the V8 heap limit and the dashboard would not come up at all.

## Fix

Four independent layers, each of which is sufficient to prevent a recurrence, together making the failure mode impossible:

1. **Sidecar oversized prompts.** `engine/shared.js` now exposes `sidecarDispatchPrompt`, `resolveDispatchPrompt`, `deleteDispatchPromptSidecar`, `dispatchPromptSidecarPath`. Prompts larger than `ENGINE_DEFAULTS.maxDispatchPromptBytes` (1 MB) are written to `engine/contexts/<id>.md`; `dispatch.json` only keeps a short stub naming the sidecar path plus `_promptFile` / `_promptBytes` markers. The contexts dir is gitignored.
2. **Automatic size guard in `mutateDispatch`.** `_sidecarOversizedPrompts` runs on every write, so a single new item cannot bloat the queue even if the discovery path forgets to sidecar. `completeDispatch` deletes the sidecar to keep `engine/contexts/` bounded.
3. **`spawnAgent` reads via `resolveDispatchPrompt`.** Agents still see the full prompt — the sidecar is a storage detail, not an agent-visible one.
4. **Per-entry byte cap on cooldown `pendingContexts`.** Count-capping at 20 entries was insufficient: 20 × 50 MB is still 1 GB. Each string field is individually truncated to `maxPendingContextEntryBytes` (256 KB) with a visible `[truncated: ... exceeded X KB]` marker.
5. **Startup guard.** `assertStateFileSize` is called on `dispatch.json` and `cooldowns.json` from `dashboard.js` and `engine/cli.js start`; when a state file exceeds 100 MB the process exits with code 78 and an actionable message naming the bloated file and pointing at `engine/contexts/`, instead of silently OOMing.

## Tests

11 new tests cover: sidecar small-prompt no-op, sidecar oversized-prompt behavior (file written, stub replaces inline, full content restored via `resolveDispatchPrompt`), sidecar cleanup on `completeDispatch`, `mutateDispatch` auto-sidecar on insert (asserts `dispatch.json` size stays < 100 KB), `assertStateFileSize` throw/no-throw cases, dashboard + engine startup wiring, and cooldown entry truncation. Full suite: **2211 pass / 0 fail / 3 skip**.

## Test plan

- [x] Run `npm test` — all pass.
- [ ] On a machine with a pre-existing bloated `dispatch.json`, `minions start` / `minions dash` now prints a clear abort message instead of OOMing.
- [ ] Dispatch a fix-type task whose review note is large; confirm a file appears under `engine/contexts/`, `dispatch.json` stays small, and the agent still receives the full prompt.