### PR TITLE
fix(W-mo248lkjwgsu): stamp live-output.log stub before spawn

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -871,25 +871,16 @@ async function spawnAgent(dispatchItem, config) {
   const spawnScript = path.join(ENGINE_DIR, 'spawn-agent.js');
   const spawnArgs = [spawnScript, promptPath, sysPromptPath, ...args];
 
-  const proc = runFile(process.execPath, spawnArgs, {
-    cwd,
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: childEnv,
-  });
-
-  const MAX_OUTPUT = 1024 * 1024; // 1MB
-  let stdout = '';
-  let stderr = '';
-  let lastOutputAt = Date.now();
-  let heartbeatTimer = null;
-  let _trustCheckDone = false;
-  const _spawnTime = Date.now();
-
-  // Live output file — written as data arrives so dashboard can tail it
+  // Live output file — stamped BEFORE child process is spawned (#W-mo248lkjwgsu).
+  // Writing the stub pre-spawn lets the orphan detector distinguish three failure modes
+  // that otherwise look identical:
+  //   1. No log file          → spawn call itself threw before reaching this line
+  //   2. Log has stub only    → process started but died before its first write
+  //   3. Log has stub + ...   → process alive but hung (the only case that warrants orphan kill+retry)
   const liveOutputPath = path.join(AGENTS_DIR, agentId, 'live-output.log');
 
   // Rotate previous live output to preserve session history (fixes #543: orphan recovery overwrites)
-  // Only rotate if the existing file has meaningful content (beyond just the header)
+  // Only rotate if the existing file has meaningful content (beyond just the header stub)
   const LIVE_OUTPUT_SPARSE_THRESHOLD = 500; // bytes — header + init JSON is typically < 500
   try {
     if (fs.existsSync(liveOutputPath)) {
@@ -901,7 +892,37 @@ async function spawnAgent(dispatchItem, config) {
     }
   } catch { /* rotation is best-effort — overwrite still happens below */ }
 
-  safeWrite(liveOutputPath, `# Live output for ${agentId} — ${id}\n# Started: ${startedAt}\n# Task: ${dispatchItem.task}\n\n`);
+  // Stamp the log synchronously before spawn. If the synchronous write throws,
+  // we still attempt to spawn (log-file stamp failure must not block the agent),
+  // but we note it so the diagnostic trail isn't silent either.
+  try {
+    safeWrite(liveOutputPath, `# Live output for ${agentId} — ${id}\n# Started: ${startedAt}\n# Task: ${dispatchItem.task}\n[${new Date().toISOString()}] spawn: agent=${agentId} item=${id}\n\n`);
+  } catch (stubErr) {
+    log('warn', `Failed to stamp live-output stub for ${agentId} (${id}): ${stubErr.message}`);
+  }
+
+  let proc;
+  try {
+    proc = runFile(process.execPath, spawnArgs, {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: childEnv,
+    });
+  } catch (spawnErr) {
+    // Synchronous spawn failure — record it to the (already-stamped) log so the
+    // orphan detector's "logSize > stub-only" check can tell this apart from a
+    // hung process. Then rethrow so the dispatch loop handles it normally.
+    try { fs.appendFileSync(liveOutputPath, `[${new Date().toISOString()}] spawn-failed: ${spawnErr.message}\n[process-exit] spawn-failed\n`); } catch { /* cleanup-only best effort */ }
+    throw spawnErr;
+  }
+
+  const MAX_OUTPUT = 1024 * 1024; // 1MB
+  let stdout = '';
+  let stderr = '';
+  let lastOutputAt = Date.now();
+  let heartbeatTimer = null;
+  let _trustCheckDone = false;
+  const _spawnTime = Date.now();
 
   // Keep live log active even when the agent produces no stdout/stderr for long stretches.
   // This makes "silent but running" states visible in the dashboard tail view.

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -308,16 +308,27 @@ function checkTimeouts(config) {
     const procInfo = activeProcesses.get(item.id);
     if (procInfo?._steeringAt && Date.now() - procInfo._steeringAt < 60000) continue;
 
+    // Capture live-output.log file state for orphan/hung diagnostics (#W-mo248lkjwgsu).
+    // Three distinguishable failure modes:
+    //   logExists=false           → spawn call itself threw, no log ever written
+    //   logExists=true, size~stub → process died at startup (stub-only content)
+    //   logExists=true, size>stub → genuine hang (process alive, wrote output, then stopped)
+    let _logState = 'logExists=false logSize=0';
+    try {
+      const lst = fs.statSync(liveLogPath);
+      _logState = `logExists=true logSize=${lst.size}`;
+    } catch { /* ENOENT — keep default */ }
+
     if (!hasProcess && silentMs > effectiveTimeout && (Date.now() > engineRestartGraceUntil || engineRestartGraceExempt?.has(item.id))) {
       // No tracked process AND no recent output past effective timeout AND (grace period expired OR confirmed-dead at restart) → orphaned
-      log('warn', `Orphan detected: ${item.agent} (${item.id}) — no process tracked, silent for ${silentSec}s${isBlocking ? ' (blocking timeout exceeded)' : ''}`);
+      log('warn', `Orphan detected: ${item.agent} (${item.id}) — no process tracked, silent for ${silentSec}s${isBlocking ? ' (blocking timeout exceeded)' : ''} [${_logState}]`);
       dispatch().updateAgentStatus(item.id, AGENT_STATUS.TIMED_OUT, `Orphaned — no process, silent for ${silentSec}s`);
       // Clear session so retry starts fresh
       try { shared.safeUnlink(path.join(AGENTS_DIR, item.agent, 'session.json')); } catch {}
       deadItems.push({ item, reason: `Orphaned — no process, silent for ${silentSec}s` });
     } else if (hasProcess && silentMs > effectiveTimeout) {
       // Has process but no output past effective timeout → hung
-      log('warn', `Hung agent: ${item.agent} (${item.id}) — process exists but no output for ${silentSec}s${isBlocking ? ' (blocking timeout exceeded)' : ''}`);
+      log('warn', `Hung agent: ${item.agent} (${item.id}) — process exists but no output for ${silentSec}s${isBlocking ? ' (blocking timeout exceeded)' : ''} [${_logState}]`);
       dispatch().updateAgentStatus(item.id, AGENT_STATUS.TIMED_OUT, `Hung — no output for ${silentSec}s`);
       const procInfo = activeProcesses.get(item.id);
       if (procInfo) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -12010,6 +12010,48 @@ async function testDashboardBugFixes() {
       'Should only rotate when file has meaningful content (above sparse threshold)');
   });
 
+  // W-mo248lkjwgsu: stub live-output.log BEFORE child process spawn so orphan
+  // detector can distinguish "spawn call threw" (no file) from "process crashed
+  // at startup" (stub-only) from "process running but hung" (stub + content).
+  await test('engine.js stamps live-output.log stub BEFORE spawning child process', () => {
+    const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    const spawnFn = engineSrc.slice(
+      engineSrc.indexOf('async function spawnAgent('),
+      engineSrc.indexOf('\nasync function onAgentClose')
+    );
+    assert.ok(spawnFn.length > 0, 'Should find spawnAgent function body');
+
+    // The safeWrite(liveOutputPath, ...) call that creates the header/stub
+    // must precede the runFile(process.execPath, spawnArgs, ...) call.
+    const stubIdx = spawnFn.indexOf('safeWrite(liveOutputPath');
+    const spawnIdx = spawnFn.indexOf('runFile(process.execPath, spawnArgs');
+    assert.ok(stubIdx > 0, 'spawnAgent should call safeWrite(liveOutputPath, ...) to stamp the log');
+    assert.ok(spawnIdx > 0, 'spawnAgent should call runFile(process.execPath, spawnArgs, ...)');
+    assert.ok(stubIdx < spawnIdx,
+      'Log stub must be written BEFORE the child process is spawned so orphan detection can distinguish spawn failure from startup crash');
+
+    // The stub line must record agent + item IDs for the audit trail.
+    assert.ok(/\[.*toISOString.*\] spawn: agent=/.test(spawnFn) || spawnFn.includes('] spawn: agent='),
+      'Stub should include "[<iso>] spawn: agent=..." marker for diagnostics');
+    assert.ok(spawnFn.includes('item=${id}') || spawnFn.includes('item=' + '$' + '{id}'),
+      'Stub should include "item=<dispatch id>" marker');
+  });
+
+  // W-mo248lkjwgsu: orphan detection should capture log-file state so we can
+  // distinguish spawn failure (no file) from early crash (stub-only) from hang.
+  await test('timeout.js orphan detection logs live-output.log file state (exists + size)', () => {
+    const timeoutSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'timeout.js'), 'utf8');
+    // Find the orphan branch: `log('warn', `Orphan detected...`)`
+    const orphanIdx = timeoutSrc.indexOf('Orphan detected:');
+    assert.ok(orphanIdx > 0, 'Should have "Orphan detected:" log line');
+    // Slice a window around the orphan log — must include file state annotation
+    // (logFile=... or live-output.log= reference) before the kill/cleanup.
+    const window = timeoutSrc.slice(Math.max(0, orphanIdx - 800), orphanIdx + 800);
+    assert.ok(
+      window.includes('logFile=') || window.includes('logExists=') || window.includes('logSize='),
+      'Orphan warn should annotate log-file state (logFile=..., logExists=..., or logSize=...)');
+  });
+
   await test('dashboard.js falls back to live-output-prev.log when current is sparse', () => {
     assert.ok(src.includes('live-output-prev.log'),
       'Dashboard should reference live-output-prev.log for fallback');


### PR DESCRIPTION
## Summary

Writes a stub to `live-output.log` **before** `runFile` spawns the child
process so the orphan detector can distinguish three failure modes that
previously looked identical:

| Log-file state at orphan check | Meaning |
|---|---|
| no file | spawn call itself threw before the stub write |
| stub only (~180 B) | process started but died before its first write |
| stub + content (>500 B) | genuine hang — only case that warrants orphan kill+retry |

Orphan/hung warn lines in `engine/timeout.js` now end with
`[logExists=<bool> logSize=<bytes>]` so the audit trail captures which
failure mode occurred.

- `engine.js` — moved the `liveOutputPath` stamp + rotation block to
  before `runFile`; wrapped `runFile` in try/catch so a synchronous
  spawn failure appends `[process-exit] spawn-failed` before rethrowing
  (dispatch loop at `engine.js:3525` already handles `spawnAgent`
  throws).
- `engine/timeout.js` — added `_logState` annotation to both the
  `Orphan detected` and `Hung agent` warn lines.
- `test/unit.test.js` — TDD tests that failed before implementation and
  pass after.

## Test plan

- [x] `node test/unit.test.js` — 2316 passed / 0 failed / 3 skipped
- [x] `node -e "require('./engine.js'); require('./engine/timeout.js')"` — modules load without error
- [x] New tests fail on the pre-change source (confirmed before
  implementation)
- [x] Stub-write error path is guarded (try/catch around `safeWrite`) so
  a failing log stamp cannot block agent spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)