### PR TITLE
feat(W-mo25loq8kjer): seed realActivityMap at spawn time, stamp pid in live-output

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -916,6 +916,23 @@ async function spawnAgent(dispatchItem, config) {
     throw spawnErr;
   }
 
+  // Seed realActivityMap and stamp PID immediately — BEFORE any handlers or timers (#W-mo25loq8kjer).
+  // Why NOW, not later in the function:
+  //  1. Heartbeat clock anchoring. timeout.js uses realActivityMap as the last-activity timestamp for
+  //     tracked processes; when the map has no entry, it falls back to item.started_at (dispatch time,
+  //     which is 20-60s before actual spawn for write tasks doing worktree setup). Read-only tasks
+  //     that produce no stdout for minutes (explore, security audit, large scans) were hitting
+  //     heartbeatTimeout prematurely — clock had already been running since dispatch.
+  //  2. Error-handler race. The `proc.on('error', ...)` handler below calls realActivityMap.delete(id)
+  //     on synchronous spawn failures. Seeding before registering handlers ensures delete sees a value
+  //     to clear rather than leaving an absent-then-absent no-op that downstream code must guard.
+  //  3. Orphan diagnostics. The PID line gives timeout.js a deterministic way to tell "spawn died
+  //     before first write" (stub-only log) from "process started and is hung" (stub + pid line).
+  realActivityMap.set(id, Date.now());
+  try {
+    fs.appendFileSync(liveOutputPath, `[${new Date().toISOString()}] pid: ${proc.pid ?? 'unknown'}\n`);
+  } catch { /* log stamp is best-effort — don't block spawn on fs failure */ }
+
   const MAX_OUTPUT = 1024 * 1024; // 1MB
   let stdout = '';
   let stderr = '';
@@ -1292,9 +1309,11 @@ async function spawnAgent(dispatchItem, config) {
     }
   }, 3000);
 
-  // Track process — even if PID isn't available yet (async on Windows)
+  // Track process — even if PID isn't available yet (async on Windows).
+  // realActivityMap was already seeded immediately after runFile() returned (#W-mo25loq8kjer);
+  // don't re-seed here — the stdout/stderr handlers above can already have updated it with
+  // a fresher timestamp, and overwriting would clobber the real "last activity" signal.
   activeProcesses.set(id, { proc, agentId, startedAt, sessionId: cachedSessionId });
-  realActivityMap.set(id, Date.now()); // Initialize real activity at spawn time
 
   updateAgentStatus(id, AGENT_STATUS.RUNNING, `Process spawned for ${agentId}`);
 

--- a/engine/timeout.js
+++ b/engine/timeout.js
@@ -308,15 +308,33 @@ function checkTimeouts(config) {
     const procInfo = activeProcesses.get(item.id);
     if (procInfo?._steeringAt && Date.now() - procInfo._steeringAt < 60000) continue;
 
-    // Capture live-output.log file state for orphan/hung diagnostics (#W-mo248lkjwgsu).
-    // Three distinguishable failure modes:
-    //   logExists=false           → spawn call itself threw, no log ever written
-    //   logExists=true, size~stub → process died at startup (stub-only content)
-    //   logExists=true, size>stub → genuine hang (process alive, wrote output, then stopped)
-    let _logState = 'logExists=false logSize=0';
+    // Capture live-output.log file state for orphan/hung diagnostics
+    // (#W-mo248lkjwgsu original, #W-mo25loq8kjer pid annotation).
+    // Four distinguishable failure modes:
+    //   logExists=false                         → spawn call itself threw, no log ever written
+    //   logExists=true pidPresent=false         → engine stub written but spawn died before emitting pid line
+    //   logExists=true pidPresent=true silent   → process spawned (pid recorded) but never produced stdout
+    //   logExists=true pidPresent=true size>pid → genuine hang (process wrote output then stopped)
+    //
+    // The pid line `[<iso>] pid: <N>` is stamped by engine.js immediately after runFile() returns.
+    // Its presence → the child process was actually spawned; absence → spawn itself failed or the
+    // appendFileSync on the pid line threw (rare).
+    let _logState = 'logExists=false logSize=0 pidPresent=false';
     try {
       const lst = fs.statSync(liveLogPath);
-      _logState = `logExists=true logSize=${lst.size}`;
+      // Read only the head (4KB) — pid line is written right after the stub, always near the top.
+      // Avoids loading the full log just for a diagnostic annotation.
+      let pidPresent = false;
+      try {
+        const fd = fs.openSync(liveLogPath, 'r');
+        const headSize = Math.min(lst.size, 4096);
+        const headBuf = Buffer.alloc(headSize);
+        fs.readSync(fd, headBuf, 0, headSize, 0);
+        fs.closeSync(fd);
+        // Match `] pid: <digits>` — agnostic to ISO timestamp format at the start.
+        pidPresent = /\]\s+pid:\s+\d+/.test(headBuf.toString('utf8'));
+      } catch { /* read failure — pidPresent stays false */ }
+      _logState = `logExists=true logSize=${lst.size} pidPresent=${pidPresent}`;
     } catch { /* ENOENT — keep default */ }
 
     if (!hasProcess && silentMs > effectiveTimeout && (Date.now() > engineRestartGraceUntil || engineRestartGraceExempt?.has(item.id))) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -18408,6 +18408,58 @@ async function testIssue716HeartbeatFeedbackLoop() {
         'Heartbeat timer should NOT update realActivityMap — only real stdout/stderr should');
     }
   });
+
+  // 9. #W-mo25loq8kjer — realActivityMap seeded BEFORE stdout/stderr handlers, immediately after runFile() returns.
+  // Premise: for read-only tasks (explore, security audit) the agent may be silent for minutes.
+  // If realActivityMap has no entry, timeout.js falls back to item.started_at (dispatch time)
+  // which eats part of the heartbeatTimeout window on worktree setup / branch fetch.
+  await test('engine.js seeds realActivityMap immediately after runFile() returns, before stdout handler (#W-mo25loq8kjer)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    // Locate the spawn try/catch block — runFile invocation is unique to spawnAgent
+    const runFileIdx = src.indexOf('proc = runFile(process.execPath, spawnArgs');
+    assert.ok(runFileIdx > 0, 'spawnAgent should call runFile on process.execPath');
+    const stdoutHandlerIdx = src.indexOf('proc.stdout.on', runFileIdx);
+    assert.ok(stdoutHandlerIdx > runFileIdx, 'stdout handler should be registered after runFile');
+    // Window between runFile and the stdout handler — seeding must happen in this window.
+    const postSpawnWindow = src.slice(runFileIdx, stdoutHandlerIdx);
+    assert.ok(postSpawnWindow.includes('realActivityMap.set(id, Date.now())'),
+      'realActivityMap should be seeded after runFile() returns, before stdout handler is registered');
+  });
+
+  await test('engine.js appends pid line to live-output.log right after spawn (#W-mo25loq8kjer)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    const runFileIdx = src.indexOf('proc = runFile(process.execPath, spawnArgs');
+    assert.ok(runFileIdx > 0, 'spawnAgent should call runFile on process.execPath');
+    const stdoutHandlerIdx = src.indexOf('proc.stdout.on', runFileIdx);
+    const postSpawnWindow = src.slice(runFileIdx, stdoutHandlerIdx);
+    // Must log the pid to live-output.log in a format the orphan detector can grep:
+    // `[<iso>] pid: <N>\n` — disambiguates stub-only (spawn died) from pid-present (process started).
+    assert.ok(/fs\.appendFileSync\([^)]*liveOutputPath[^)]*pid:/s.test(postSpawnWindow)
+      || /appendFileSync[\s\S]{0,120}pid:\s*\$\{/.test(postSpawnWindow),
+      'live-output.log should receive a "pid: <N>" line right after runFile() returns');
+  });
+
+  await test('engine.js has exactly one spawn-time realActivityMap seed (no duplicate late init) (#W-mo25loq8kjer)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+    // Count `realActivityMap.set(id, Date.now())` occurrences — should be:
+    //   1. post-spawn seed (new location)
+    //   2. stdout handler
+    //   3. stderr handler
+    //   4. resume stdout handler (steering)
+    //   5. resume stderr handler (steering)
+    // 5 total. The old late-init seed at "Initialize real activity at spawn time" must be gone.
+    assert.ok(!src.includes('// Initialize real activity at spawn time'),
+      'Old late-init realActivityMap seed comment should be removed (moved to post-spawn)');
+  });
+
+  await test('timeout.js orphan diagnostic distinguishes stub-only from pid-present log content (#W-mo25loq8kjer)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'timeout.js'), 'utf8');
+    // The orphan log annotation should expose whether the log contains a pid line —
+    // this is the signal that differentiates "spawn died before first write" (stub only)
+    // from "process started and is genuinely hung" (pid present, no later output).
+    assert.ok(src.includes('pidPresent') || src.includes('pid='),
+      'timeout.js _logState should surface whether a pid line is present in the live-output log');
+  });
 }
 
 // ─── PR Review→Fix, Poll→Fix, Merge Conflict, Auto-Complete Flows ──────────


### PR DESCRIPTION
## Summary

- Seed `realActivityMap` and stamp a `pid` line to `live-output.log` **immediately after `runFile()` returns** in `spawnAgent()`, before any handlers or timers register.
- Remove the duplicate late-init seed 380 lines below — it could clobber real stdout timestamps that arrived during the synchronous setup window.
- Update `engine/timeout.js` orphan diagnostic (`_logState`) to surface `pidPresent=true|false`, reading only the first 4KB of the log.

## Why

`timeout.js` uses `realActivityMap.get(item.id)` as last-activity for tracked processes and falls back to `item.started_at` (dispatch time) when the map is empty.

For write tasks, dispatch → spawn can span 20-60s of worktree setup and dependency branch merging. For read-only tasks (explore, security audit, large scans) the process may then produce no stdout for several minutes. Combined, the heartbeat clock was eating a big chunk of `heartbeatTimeout` *before the process had emitted a single byte* — causing premature hung-agent kills on legitimate long-running agents.

Seeding at actual spawn time anchors the clock correctly. The pid line gives orphan detection a deterministic signal to tell "spawn died before first write" (stub only) from "process started and is hung" (stub + pid line).

## Subtleties

- **Seed BEFORE registering handlers.** `proc.on('error', ...)` calls `realActivityMap.delete(id)` on synchronous spawn failures. Seeding first makes the set→delete sequence symmetric — otherwise an immediate spawn error (fires via `process.nextTick`) could delete a not-yet-set entry.
- **Why the old late-init was wrong.** stdout/stderr handlers were registered in the window between spawn and the old re-seed. Although JS single-threading prevents stdout from firing during synchronous code, keeping the old `realActivityMap.set` at line 1297 would unconditionally overwrite the real-activity timestamp with a later `Date.now()` — a lie if real output had already arrived during the synchronous setup.
- **`proc.pid ?? 'unknown'`.** Defensive fallback for the rare case where pid isn't yet assigned.

## Test plan

- [x] TDD: wrote 4 failing tests first, then implemented (under `testIssue716HeartbeatFeedbackLoop`)
  - Seed happens between `runFile(process.execPath, spawnArgs` and `proc.stdout.on` in source order
  - `fs.appendFileSync(liveOutputPath, ...pid:...)` appears in the same post-spawn window
  - No duplicate `Initialize real activity at spawn time` comment survives (guards against silent revert)
  - `timeout.js` `_logState` includes `pidPresent` annotation
- [x] Full unit suite: **2320 passed, 0 failed, 3 skipped**
- [ ] Verify in live engine: read-only explore task survives past old premature-kill window

## Files changed

| File | Delta |
|------|-------|
| `engine.js` | +23 / -2 — post-spawn seed + pid line, removed duplicate late-init |
| `engine/timeout.js` | +25 / -7 — `pidPresent` annotation, 4KB head read |
| `test/unit.test.js` | +52 — 4 new tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)