### PR TITLE
fix: Pending dispatch loop: undefined agent causes infinite spawnAgent crash loop

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -3483,6 +3483,35 @@ async function tickInner() {
       log('warn', `Duplicate dispatch ID ${item.id} in pending queue — skipping`);
       continue;
     }
+    // #1206: Guard against undefined/non-string item.agent. A corrupted dispatch
+    // entry (manual edit, serialization round-trip, cleared field) would otherwise
+    // be handed to spawnAgent, which crashes with `TypeError: "path" argument must
+    // be of type string. Received undefined` and re-queues — every tick. Try to
+    // resolve a fallback via routing; if none is available, skip this tick.
+    if (!item.agent || typeof item.agent !== 'string') {
+      const fallback = resolveAgent(item.type || WORK_TYPE.FIX, config);
+      if (!fallback) {
+        log('warn', `Pending dispatch ${item.id} has no agent and routing returned no fallback — skipping`);
+        continue;
+      }
+      log('info', `Pending dispatch ${item.id} missing agent; routed → ${fallback} (#1206 guard)`);
+      item.agent = fallback;
+      item.agentName = config.agents[fallback]?.name || tempAgents.get(fallback)?.name || fallback;
+      item.agentRole = config.agents[fallback]?.role || tempAgents.get(fallback)?.role || 'Agent';
+      // Persist so the fix survives across ticks even if this dispatch is skipped
+      // later in the loop (branch lock, concurrency cap, agent busy, etc.).
+      try {
+        mutateDispatch((dp) => {
+          const p = (dp.pending || []).find(d => d.id === item.id);
+          if (p) {
+            p.agent = item.agent;
+            p.agentName = item.agentName;
+            p.agentRole = item.agentRole;
+          }
+          return dp;
+        });
+      } catch (e) { log('warn', `Persist agent resolution for ${item.id} failed: ${e.message}`); }
+    }
     if (busyAgents.has(item.agent)) {
       // Agent busy reassignment: if item has been waiting on a busy agent past the threshold,
       // try to find an alternative agent via routing. Skip explicitly assigned items.

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10596,6 +10596,9 @@ async function main() {
     // W-mnytn469wx90: Agent busy reassignment
     await testAgentBusyReassignment();
 
+    // #1206: Undefined-agent guard in pending dispatch loop
+    await testUndefinedAgentGuard();
+
     // W-mnyao4dyz8w7: createThrottleTracker factory, adoFetchText throttle, GitHub throttle
     await testCreateThrottleTracker();
     await testAdoFetchTextThrottle();
@@ -20143,6 +20146,108 @@ async function testAgentBusyReassignment() {
     // Must be set when reason === 'agent_busy' and cleared otherwise
     assert.ok(engineSrc.includes("agent_busy") && engineSrc.includes('_agentBusySince'),
       'Both agent_busy and _agentBusySince should be present in the annotation logic');
+  });
+}
+
+// ─── #1206: Undefined-agent guard in pending dispatch loop ─────────────────
+//
+// A pending dispatch item with `item.agent === undefined` must not be handed to
+// spawnAgent — it crashes with `TypeError: The "path" argument must be of type
+// string. Received undefined`, returns null, and the item stays pending, which
+// re-enters the loop on the next tick. Infinite crash loop.
+
+async function testUndefinedAgentGuard() {
+  console.log('\n── #1206: Undefined-agent guard in pending dispatch ──');
+
+  const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+
+  // 1. Source: a truthy guard on item.agent exists in the pending dispatch loop
+  await test('engine.js guards against undefined item.agent before toDispatch.push', () => {
+    // Must contain a check that item.agent is truthy before dispatch
+    // Accept either `if (!item.agent)` style or `typeof item.agent !== 'string'`
+    const hasNullishGuard = /if\s*\(\s*!item\.agent\b/.test(engineSrc)
+      || /typeof\s+item\.agent\s*!==\s*['"]string['"]/.test(engineSrc);
+    assert.ok(hasNullishGuard,
+      'engine.js must include a guard on item.agent being nullish/non-string before spawn');
+  });
+
+  // 2. Source: the guard uses resolveAgent() with the item type as fallback
+  await test('undefined-agent guard uses resolveAgent for fallback resolution', () => {
+    // The guard block should reference resolveAgent with item.type
+    // Look for a `!item.agent` branch that contains `resolveAgent(`
+    const guardBlock = engineSrc.match(/if\s*\(\s*!item\.agent[\s\S]{0,400}?resolveAgent\s*\(/);
+    assert.ok(guardBlock,
+      'Undefined-agent guard must call resolveAgent() to pick a fallback agent');
+  });
+
+  // 3. Behavioral: simulate the dispatch loop — undefined agent gets resolved or skipped
+  await test('undefined item.agent is replaced via routing before push (behavioral)', () => {
+    const pending = [
+      { id: 'u-1', agent: undefined, type: 'fix', meta: { item: {} } },
+    ];
+    const busyAgents = new Set();
+    const toDispatch = [];
+    // Simulate the guard — pick any configured agent as the fallback
+    const cfg = { agents: { dallas: { name: 'Dallas', role: 'Engineer' } } };
+    const resolveAgentStub = (type, config) => Object.keys(config.agents)[0] || null;
+
+    for (const item of pending) {
+      if (!item.agent) {
+        const fallback = resolveAgentStub(item.type || 'fix', cfg);
+        if (!fallback) continue;
+        item.agent = fallback;
+        item.agentName = cfg.agents[fallback]?.name || fallback;
+        item.agentRole = cfg.agents[fallback]?.role || 'Agent';
+      }
+      if (busyAgents.has(item.agent)) continue;
+      toDispatch.push(item);
+      busyAgents.add(item.agent);
+    }
+
+    assert.strictEqual(toDispatch.length, 1, 'Item with resolvable fallback should dispatch');
+    assert.strictEqual(toDispatch[0].agent, 'dallas', 'Should be routed to fallback agent');
+    assert.strictEqual(toDispatch[0].agentName, 'Dallas', 'agentName should be populated from config');
+    assert.strictEqual(toDispatch[0].agentRole, 'Engineer', 'agentRole should be populated from config');
+  });
+
+  // 4. Behavioral: if routing returns null (no agents configured), item is skipped
+  await test('undefined item.agent with no routable fallback is skipped, never pushed (behavioral)', () => {
+    const pending = [
+      { id: 'u-2', agent: undefined, type: 'fix', meta: { item: {} } },
+    ];
+    const toDispatch = [];
+    const resolveAgentStub = () => null; // no agents available
+
+    for (const item of pending) {
+      if (!item.agent) {
+        const fallback = resolveAgentStub();
+        if (!fallback) continue;
+        item.agent = fallback;
+      }
+      toDispatch.push(item);
+    }
+
+    assert.strictEqual(toDispatch.length, 0,
+      'Item must not be pushed to toDispatch when no fallback agent is available');
+    // And spawnAgent must never see an item with undefined agent
+    assert.strictEqual(toDispatch.find(i => !i.agent), undefined,
+      'No item with undefined agent may reach spawn');
+  });
+
+  // 5. Source: the guard block persists the resolved agent back to dispatch.json
+  //    so the fix survives the tick — mirrors the reassignment-path convention.
+  await test('undefined-agent guard persists resolution to dispatch.json (source check)', () => {
+    // Look for a mutateDispatch inside the !item.agent guard block
+    const block = engineSrc.match(/if\s*\(\s*!item\.agent[\s\S]{0,1500}?mutateDispatch/);
+    assert.ok(block,
+      'Undefined-agent guard must call mutateDispatch to persist the resolved agent');
+  });
+
+  // 6. Source: the guard ships with a log line so this case is diagnosable
+  await test('undefined-agent guard emits a log line (source check)', () => {
+    const block = engineSrc.match(/if\s*\(\s*!item\.agent[\s\S]{0,1500}?log\s*\(/);
+    assert.ok(block,
+      'Undefined-agent guard must log when it triggers (for observability)');
   });
 }
 


### PR DESCRIPTION
Closes yemi33/minions#1206

## Problem

A pending dispatch entry whose `agent` field has been lost (manual edit of `dispatch.json`, serialization round-trip, upstream code clearing the field) was handed directly to `spawnAgent`, which crashed with `TypeError: The \"path\" argument must be of type string. Received undefined`. The spawn returned `null`, the item stayed `pending`, and the next tick did the same thing. Infinite crash loop, filling `engine/log.json` and starving every other pending item behind it until someone manually edited `dispatch.json`.

Root cause: the `for (const item of dispatch.pending)` loop at `engine.js:3481` had no guard that `item.agent` was a truthy string before `toDispatch.push(item)`. `busyAgents.has(undefined)` silently returns `false`, so the agent-busy path never tripped either.

## Fix

At the top of the pending-dispatch loop (after the duplicate-ID check, before the busy-agents check) — `engine.js:3486-3514`:

1. If `item.agent` is nullish or non-string, call `resolveAgent(item.type || WORK_TYPE.FIX, config)`.
2. If routing returns `null` → `log('warn', ...)` and `continue`; next tick will retry.
3. If routing returns a fallback → hydrate `item.agent`/`agentName`/`agentRole` from `config.agents[id]` with `tempAgents.get(id)` as secondary source (mirrors the existing reassignment path at `engine.js:3527-3529`), log an info line, and persist via `mutateDispatch` so the fix survives across ticks.

Placing the guard at the top of the loop (rather than immediately before `toDispatch.push`, as the issue suggested) means every downstream check — `busyAgents.has`, branch mutex, `isExplicitAssignment`, post-dispatch `skipReason` annotation — operates on a valid `item.agent`.

## Tests

New `testUndefinedAgentGuard` suite (`test/unit.test.js`, registered ~line 10597) — 6 assertions:

| # | Kind | What it checks |
|---|------|----------------|
| 1 | source | Guard on nullish/non-string `item.agent` exists |
| 2 | source | Guard calls `resolveAgent(...)` for fallback |
| 3 | behavioral | Fallback is assigned, `agentName`/`agentRole` hydrated from `config.agents` |
| 4 | behavioral | If routing returns `null`, item never reaches `toDispatch` |
| 5 | source | Guard block calls `mutateDispatch` (persistence) |
| 6 | source | Guard emits a log line (observability) |

TDD: all 4 source tests failed before the fix, all 6 pass after.

Full suite: **2329 passed, 0 failed, 3 skipped**.

## Why this also helps #1204

Clearing `item.agent` as a workaround for the `#1204` temp-agent pre-assignment stuck-item bug is what surfaced this one. With the guard in place, that manual workaround becomes safe — any item with a cleared `agent` is now transparently re-routed via the normal routing table instead of crashing.