### PR TITLE
fix(W-mo369rxu6ayf): cap temp-agent creation at maxConcurrent per tick

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -122,7 +122,7 @@ const { getConfig, getControl, getDispatch, getNotes,
 
 const { getRouting, parseRoutingTable, getRoutingTableCached, getMonthlySpend,
   getAgentErrorRate, isAgentIdle, resolveAgent, resetClaimedAgents,
-  tempAgents } = require('./engine/routing');
+  setTempBudget, tempAgents } = require('./engine/routing');
 
 // ─── Playbook, system prompt, agent context (extracted to engine/playbook.js) ─
 
@@ -3434,6 +3434,18 @@ async function tickInner() {
   }
 
   // 3. Discover new work from sources
+  // Cap temp-agent creation at (maxConcurrent - activeCount) for this tick so
+  // temps count against maxConcurrent like named agents. Without this, a mass
+  // discovery pass (e.g. 20 PR build failures) would stamp a fresh temp agent
+  // onto every pending item regardless of concurrency cap, and those temps
+  // would spawn over subsequent ticks — overwhelming the OS and mass-orphaning
+  // the dispatches (#1209).
+  {
+    const dispatchPre = getDispatch();
+    const activeCountPre = (dispatchPre.active || []).length;
+    const maxC = config.engine?.maxConcurrent ?? ENGINE_DEFAULTS.maxConcurrent;
+    setTempBudget(Math.max(0, maxC - activeCountPre));
+  }
   let discoveryOk = true;
   try { await discoverWork(config); } catch (e) { log('warn', 'discoverWork: ' + e.message); discoveryOk = false; }
 

--- a/engine/routing.js
+++ b/engine/routing.js
@@ -102,6 +102,20 @@ function isAgentIdle(agentId) {
 const _claimedAgents = new Set();
 function resetClaimedAgents() { _claimedAgents.clear(); }
 
+// Per-tick temp-agent creation budget. Defaults to Infinity (unbounded) so
+// routing.js in isolation keeps previous behaviour. The engine calls
+// setTempBudget() once per tick with `maxConcurrent - activeCount` to ensure
+// temp agents count against maxConcurrent exactly like named agents.
+// Without this, a batch discovery (e.g. PR-poll sweep over many failing PRs)
+// would register one temp agent per pending item, overwhelming the OS and
+// causing mass orphans when the dispatch loop spawns them on later ticks.
+// Closes #1209.
+let _tempBudget = Infinity;
+function setTempBudget(n) {
+  _tempBudget = (typeof n === 'number' && n >= 0 && Number.isFinite(n)) ? n : Infinity;
+}
+function getTempBudget() { return _tempBudget; }
+
 function resolveAgent(workType, config, authorAgent = null) {
   const routes = getRoutingTableCached();
   const route = routes[workType] || routes['implement'];
@@ -144,6 +158,16 @@ function resolveAgent(workType, config, authorAgent = null) {
 
   // No idle configured agent — try temp agent if enabled
   if (config.engine?.allowTempAgents) {
+    // Enforce per-tick temp-agent budget so temps count against maxConcurrent.
+    // Without this guard, a mass-discovery pass (e.g. 20 PR build failures) would
+    // register one temp agent per pending item regardless of concurrency cap,
+    // leaking orphan temp IDs into tempAgents/dispatch and, over subsequent ticks,
+    // spawning far more processes than maxConcurrent allows (#1209).
+    if (_tempBudget <= 0) {
+      log('info', `Temp agent refused for ${workType} — per-tick budget exhausted (maxConcurrent reached)`);
+      return null;
+    }
+    _tempBudget--;
     const tempId = `temp-${shared.uid()}`;
     _claimedAgents.add(tempId);
     tempAgents.set(tempId, { name: `Temp-${tempId.slice(5, 9)}`, role: 'Temporary Agent', createdAt: ts() });
@@ -166,4 +190,6 @@ module.exports = {
   _claimedAgents,
   resetClaimedAgents,
   resolveAgent,
+  setTempBudget,
+  getTempBudget,
 };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4716,6 +4716,188 @@ async function testResolveAgent() {
   });
 }
 
+// ─── W-mo369rxu6ayf / #1209: Temp-agent concurrency budget ─────────────────
+
+async function testTempAgentBudget() {
+  console.log('\n── engine/routing.js — Temp-agent budget (#1209) ──');
+
+  const routingSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'routing.js'), 'utf8');
+  const engineSrc = fs.readFileSync(path.join(MINIONS_DIR, 'engine.js'), 'utf8');
+
+  // ── Source-level guards ──
+
+  await test('routing.js exports setTempBudget / getTempBudget', () => {
+    assert.ok(routingSrc.includes('setTempBudget'),
+      'routing.js must export setTempBudget so the engine can cap per-tick temp creation');
+    assert.ok(routingSrc.includes('getTempBudget'),
+      'routing.js must export getTempBudget for tests and observability');
+  });
+
+  await test('resolveAgent guards temp creation on _tempBudget', () => {
+    assert.ok(routingSrc.includes('_tempBudget <= 0'),
+      'resolveAgent must short-circuit temp creation when _tempBudget <= 0');
+    assert.ok(routingSrc.includes('_tempBudget--'),
+      'resolveAgent must decrement _tempBudget when it creates a temp agent');
+  });
+
+  await test('engine.js calls setTempBudget(maxConcurrent - activeCount) before discoverWork', () => {
+    assert.ok(engineSrc.includes('setTempBudget('),
+      'engine.js must call setTempBudget() each tick so temps count against maxConcurrent');
+    // Verify the budget is computed from activeCount and maxConcurrent (not a literal)
+    assert.ok(engineSrc.match(/setTempBudget\(Math\.max\(0,\s*maxC\s*-\s*activeCountPre\)/)
+      || engineSrc.match(/setTempBudget\(Math\.max\(0,\s*maxConcurrent\s*-\s*activeCount/),
+      'setTempBudget argument must derive from maxConcurrent - activeCount');
+  });
+
+  // ── Behavioral guards (actually exercise routing.resolveAgent) ──
+
+  // Isolate routing module state per test — tests run serially, but fresh
+  // require + resetClaimedAgents() still protects against stale _claimedAgents
+  // or _tempBudget leaking from an earlier test.
+  function loadFreshRouting() {
+    const restore = createTestMinionsDir();
+    for (const m of ['../engine/shared', '../engine/queries', '../engine/routing']) {
+      try { delete require.cache[require.resolve(m)]; } catch {}
+    }
+    const routing = require(path.join(MINIONS_DIR, 'engine', 'routing'));
+    routing.resetClaimedAgents();
+    return { routing, restore };
+  }
+
+  await test('resolveAgent caps temp creation at tempBudget (maxConcurrent=2, 5 pending) — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      const config = { agents: {}, engine: { allowTempAgents: true, maxConcurrent: 2 } };
+      // Simulate engine tick: maxConcurrent - activeCount = 2 - 0 = 2
+      routing.setTempBudget(2);
+
+      const results = [];
+      for (let i = 0; i < 5; i++) results.push(routing.resolveAgent('implement', config));
+
+      const tempCount = results.filter(a => a && a.startsWith('temp-')).length;
+      const refusedCount = results.filter(a => a === null).length;
+      assert.strictEqual(tempCount, 2,
+        `With maxConcurrent=2, at most 2 temp agents per tick (got ${tempCount}: ${JSON.stringify(results)})`);
+      assert.strictEqual(refusedCount, 3,
+        `Remaining 3 calls must return null (refused), got ${refusedCount}`);
+    } finally { restore(); }
+  });
+
+  await test('resolveAgent with tempBudget=0 refuses all temp creation — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      const config = { agents: {}, engine: { allowTempAgents: true, maxConcurrent: 5 } };
+      // All slots consumed by permanent agents already in dispatch.active:
+      // setTempBudget(maxConcurrent - activeCount) = 0
+      routing.setTempBudget(0);
+
+      for (let i = 0; i < 3; i++) {
+        assert.strictEqual(routing.resolveAgent('implement', config), null,
+          `Call ${i}: must refuse temp creation when budget is 0`);
+      }
+    } finally { restore(); }
+  });
+
+  await test('tempBudget resets between ticks via setTempBudget — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      const config = { agents: {}, engine: { allowTempAgents: true, maxConcurrent: 2 } };
+
+      // Tick 1
+      routing.setTempBudget(2);
+      assert.ok(routing.resolveAgent('implement', config)?.startsWith('temp-'));
+      assert.ok(routing.resolveAgent('implement', config)?.startsWith('temp-'));
+      assert.strictEqual(routing.resolveAgent('implement', config), null,
+        'Tick 1: third call refused after budget=2 exhausted');
+
+      // Tick 2: engine resets per-tick state
+      routing.resetClaimedAgents();
+      routing.setTempBudget(1);
+      assert.ok(routing.resolveAgent('implement', config)?.startsWith('temp-'),
+        'Tick 2: fresh budget allows creation');
+      assert.strictEqual(routing.resolveAgent('implement', config), null,
+        'Tick 2: second call refused after budget=1 exhausted');
+    } finally { restore(); }
+  });
+
+  await test('resolveAgent prefers idle named agents without consuming temp budget — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      // Override routing.md cache by providing custom agents matching the routing table.
+      // "implement" routes to dallas → ralph per routing.md.
+      const config = {
+        agents: {
+          dallas: { name: 'Dallas', role: 'Engineer' },
+          ralph: { name: 'Ralph', role: 'Engineer' },
+        },
+        engine: { allowTempAgents: true, maxConcurrent: 5 },
+      };
+      routing.setTempBudget(3);
+
+      // First two calls claim the two idle named agents. Temp budget untouched.
+      const first = routing.resolveAgent('implement', config);
+      const second = routing.resolveAgent('implement', config);
+      assert.ok(!first?.startsWith('temp-'), `First resolution should be named, got ${first}`);
+      assert.ok(!second?.startsWith('temp-'), `Second resolution should be named, got ${second}`);
+      assert.strictEqual(routing.getTempBudget(), 3,
+        'Named-agent claims must NOT decrement temp budget');
+
+      // Third call: all named claimed → falls back to temp, decrements budget.
+      const third = routing.resolveAgent('implement', config);
+      assert.ok(third?.startsWith('temp-'), `Third resolution should be temp, got ${third}`);
+      assert.strictEqual(routing.getTempBudget(), 2,
+        'Temp creation decrements budget by exactly 1');
+    } finally { restore(); }
+  });
+
+  await test('resetClaimedAgents does NOT clobber tempBudget (engine sets it after reset) — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      // Engine contract: setTempBudget is called after resetClaimedAgents in the tick.
+      // Verify reset leaves budget alone so engine.js's explicit setTempBudget() wins.
+      // If reset clobbered budget, the engine's pre-computed value would be lost inside
+      // discoverWork (which calls resetClaimedAgents at its entry), reopening #1209.
+      routing.setTempBudget(4);
+      assert.strictEqual(routing.getTempBudget(), 4);
+      routing.resetClaimedAgents();
+      // After reset, budget persists — engine explicitly re-sets it each tick anyway,
+      // but leaving it alone avoids a subtle tick-ordering bug.
+      assert.strictEqual(routing.getTempBudget(), 4,
+        'resetClaimedAgents must not clobber _tempBudget');
+    } finally { restore(); }
+  });
+
+  await test('setTempBudget with invalid input falls back to Infinity — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      routing.setTempBudget(null);
+      assert.strictEqual(routing.getTempBudget(), Infinity,
+        'null input should reset budget to Infinity (unbounded)');
+      routing.setTempBudget(-1);
+      assert.strictEqual(routing.getTempBudget(), Infinity,
+        'negative input should fall back to Infinity');
+      routing.setTempBudget('nope');
+      assert.strictEqual(routing.getTempBudget(), Infinity,
+        'non-number input should fall back to Infinity');
+    } finally { restore(); }
+  });
+
+  await test('resolveAgent with allowTempAgents=false never creates temps regardless of budget — behavioral', () => {
+    const { routing, restore } = loadFreshRouting();
+    try {
+      const config = { agents: {}, engine: { allowTempAgents: false, maxConcurrent: 5 } };
+      routing.setTempBudget(5);
+
+      for (let i = 0; i < 3; i++) {
+        assert.strictEqual(routing.resolveAgent('implement', config), null,
+          `Must return null (no temp) when allowTempAgents=false — call ${i}`);
+      }
+      assert.strictEqual(routing.getTempBudget(), 5,
+        'Budget must not be consumed when allowTempAgents=false (check runs after)');
+    } finally { restore(); }
+  });
+}
+
 // ─── engine.js — renderPlaybook Tests ───────────────────────────────────────
 
 async function testRenderPlaybook() {
@@ -10430,6 +10612,7 @@ async function main() {
     await testCooldownSystem();
     await testDispatchPromptSidecar();
     await testResolveAgent();
+    await testTempAgentBudget();
     await testRenderPlaybook();
     await testValidatePlaybookVars();
     await testResolvePlaybookPath();


### PR DESCRIPTION
## Summary

Closes #1209.

`resolveAgent()` in `engine/routing.js` had zero concurrency awareness: when `allowTempAgents: true` and every permanent agent was busy, it stamped a brand-new `temp-<uid>` onto every caller. A mass-discovery pass — e.g. an ADO poll sweep detecting build failures across 20 PRs — registered 20 temp IDs into `tempAgents` / `dispatch.pending` in a single tick. Over the next ticks those pending items spawned as slots freed, overwhelming the OS / Claude session system and orphaning 13 of 19 agents in the reported incident.

This PR adds a **per-tick temp-agent budget** to `engine/routing.js`. `resolveAgent` refuses temp creation once the budget is exhausted. The engine sets `setTempBudget(maxConcurrent - activeCount)` before every `discoverWork` pass so temps count against `maxConcurrent` exactly like named agents.

## Changes

- `engine/routing.js` — `_tempBudget` (default `Infinity` for backward compat), `setTempBudget(n)` / `getTempBudget()` exports, guard+decrement in the temp-creation branch of `resolveAgent`.
- `engine.js` — imports `setTempBudget`; calls it with `max(0, maxConcurrent - activeCount)` immediately before `discoverWork(config)` at tick start.
- `test/unit.test.js` — new `testTempAgentBudget()` suite (8 assertions, source + behavioural).

## Why this shape

- **`allowTempAgents` is checked in exactly one place** — inside `resolveAgent` (verified by grep across all `.js` files; other hits are dashboard settings UI and config defaults, not spawn paths). A guard at the creation site covers every discovery path plus the selection-loop reassignment call at `engine.js:3495`.
- **`resetClaimedAgents()` is deliberately untouched.** It's called at the top of `discoverWork`; if it cleared `_tempBudget`, the engine's pre-`discoverWork` `setTempBudget()` would be wiped inside discovery. A regression test pins this invariant.
- **Budget ignores named-agent claims.** The guard only fires in the `allowTempAgents` branch — reached only after all permanents are exhausted. Named-agent routing is unchanged.

## Test plan

- [x] `npm test` — 2333 passed, 0 failed, 3 skipped (pre-existing, unrelated)
- [x] New `testTempAgentBudget` suite verifies:
  - `maxConcurrent=2` + 5 pending items → exactly 2 temp agents created, 3 refused (`null`)
  - `budget=0` → all temp creation refused
  - Budget resets between ticks via `setTempBudget`
  - Named idle agents are preferred and do NOT consume temp budget
  - `resetClaimedAgents` does NOT clobber `_tempBudget`
  - Invalid input (`null`, negative, string) falls back to `Infinity`
  - `allowTempAgents=false` returns `null` without consuming budget
- [x] Grep confirms no secondary `allowTempAgents` spawn path bypasses the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)