### PR TITLE
fix(W-mo3zjdcfev53): preserve VERDICT marker by tail-slicing agent output (#1234)

### DIFF
--- a/engine/llm.js
+++ b/engine/llm.js
@@ -149,7 +149,9 @@ function _createStreamAccumulator({
     if (obj.session_id) sessionId = obj.session_id;
     if (obj.type === 'result') {
       if (typeof obj.result === 'string') {
-        text = maxTextLength ? obj.result.slice(0, maxTextLength) : obj.result;
+        // Tail-slice: VERDICTs, completion blocks, and PR URLs live at the END
+        // of agent output. Head-slicing dropped them (#1234).
+        text = maxTextLength ? obj.result.slice(-maxTextLength) : obj.result;
       }
       if (obj.total_cost_usd || obj.usage) {
         usage = {
@@ -166,7 +168,8 @@ function _createStreamAccumulator({
     if (obj.type === 'assistant' && Array.isArray(obj.message?.content)) {
       for (const block of obj.message.content) {
         if (block?.type === 'text' && block.text) {
-          text = maxTextLength ? block.text.slice(0, maxTextLength) : block.text;
+          // Tail-slice for consistency with the result branch (see #1234).
+          text = maxTextLength ? block.text.slice(-maxTextLength) : block.text;
           if (onChunk && block.text !== lastTextSent) {
             lastTextSent = block.text;
             onChunk(block.text);

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -608,7 +608,11 @@ function parseStreamJsonOutput(raw, { maxTextLength = 0 } = {}) {
 
   function extractResult(obj) {
     if (obj.type !== 'result') return false;
-    if (obj.result) text = maxTextLength ? obj.result.slice(0, maxTextLength) : obj.result;
+    // Slice from the tail, not the head — review VERDICTs, structured completion
+    // blocks, PR URLs, and agent conclusions all appear at the END of the output.
+    // Head-slicing truncated VERDICTs and caused review work items to be
+    // re-dispatched up to maxRetries times despite successful completion (#1234).
+    if (obj.result) text = maxTextLength ? obj.result.slice(-maxTextLength) : obj.result;
     if (obj.session_id) sessionId = obj.session_id;
     if (obj.total_cost_usd || obj.usage) {
       usage = {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -475,6 +475,20 @@ async function testParseStreamJsonOutput() {
     assert.strictEqual(text.length, 50);
   });
 
+  await test('parseStreamJsonOutput keeps tail, not head, when maxTextLength is set (#1234)', () => {
+    // Regression: review agents write long findings with VERDICT markers at the
+    // end; slicing from head dropped the verdict, causing parseReviewVerdict to
+    // return null and the engine to re-dispatch the review up to maxRetries times.
+    const body = 'PREAMBLE_' + 'y'.repeat(2000) + '_VERDICT: APPROVE';
+    const raw = '{"type":"result","result":"' + body + '"}';
+    const { text } = shared.parseStreamJsonOutput(raw, { maxTextLength: 500 });
+    assert.strictEqual(text.length, 500);
+    assert.ok(text.includes('VERDICT: APPROVE'),
+      'tail slice must preserve VERDICT marker at end of output');
+    assert.ok(!text.startsWith('PREAMBLE_'),
+      'tail slice must drop the preamble, not the tail');
+  });
+
   await test('parseStreamJsonOutput finds result scanning from end', () => {
     const lines = [];
     for (let i = 0; i < 100; i++) lines.push(`{"type":"assistant","message":"line ${i}"}`);
@@ -19657,6 +19671,24 @@ async function testPrReviewFixFlows() {
     assert.strictEqual(parseReviewVerdict(null), null);
     assert.strictEqual(parseReviewVerdict(''), null);
     assert.strictEqual(parseReviewVerdict('This is just a comment, no verdict'), null);
+  });
+
+  await test('parseAgentOutput preserves VERDICT from long review output (#1234)', () => {
+    // Regression: review summaries with VERDICT at the end were truncated by
+    // parseAgentOutput's 2000-char slice from head, so parseReviewVerdict(null)
+    // re-queued the WI up to maxRetries times even on successful completion.
+    const { parseAgentOutput, parseReviewVerdict } = require(path.join(MINIONS_DIR, 'engine', 'lifecycle'));
+    const longBody =
+      '# Review of PR #1234\n\n' +
+      'Walked through every changed file and checked the logic.\n'.repeat(80) +
+      'Ran the tests locally: 2201 passing, 0 failing.\n'.repeat(20) +
+      '\n## Summary\n\nLooks good overall.\n\nVERDICT: APPROVE\n';
+    assert.ok(longBody.length > 2000, 'test fixture must exceed the slice window to be meaningful');
+    const raw = JSON.stringify({ type: 'result', result: longBody, session_id: 'abc' });
+    const { resultSummary } = parseAgentOutput(raw);
+    assert.ok(resultSummary.includes('VERDICT: APPROVE'),
+      `resultSummary lost the VERDICT marker (got tail: ...${resultSummary.slice(-80)})`);
+    assert.strictEqual(parseReviewVerdict(resultSummary), 'approved');
   });
 
   await test('updatePrAfterReview falls back to verdict parsing when live check is pending', () => {


### PR DESCRIPTION
## Summary

Fixes #1234. Review work items were re-dispatched up to `maxRetries` times even when the agent successfully completed the review.

## Root cause

`parseStreamJsonOutput(stdout, { maxTextLength: 2000 })` sliced the result text from the **head**: `obj.result.slice(0, maxTextLength)`. Review agents write long findings with the `VERDICT: APPROVE` / `VERDICT: REQUEST_CHANGES` marker at the **end**, so it was truncated away.

Downstream chain:

1. `parseAgentOutput()` in `engine/lifecycle.js:1463` returned `resultSummary` missing the verdict
2. `parseReviewVerdict(resultSummary)` returned `null`
3. `runPostCompletionHooks` set `skipDoneStatus = true` and incremented `_retryCount`
4. Engine reset status to `pending`, re-dispatched up to `maxRetries` times

Confirmed incident: `W-mo3jeqid1l65` — Lambert completed the review; the engine re-dispatched 3 more times.

## Fix

Change the slice direction from **head** to **tail** in two places:

- `engine/shared.js` — `parseStreamJsonOutput.extractResult()` — the main parser used by `lifecycle`, `meeting`, `consolidation`
- `engine/llm.js` — `_createStreamAccumulator.captureResult()` — the streaming accumulator for direct-spawn CC / doc-chat

`obj.result.slice(0, n)` → `obj.result.slice(-n)`

This is the correct semantic for *every* consumer because agent-produced tails contain the pieces we actually need:

- VERDICT markers (review path)
- Structured ` ```completion ` blocks (completion protocol)
- PR URLs produced after `gh pr create`
- Final conclusions in meeting rounds

The length cap still applies — we just keep the last N chars instead of the first N.

## Tests

Two regression tests added, both fail on master and pass on this branch:

- `parseStreamJsonOutput keeps tail, not head, when maxTextLength is set (#1234)` — direct unit test of the slice function
- `parseAgentOutput preserves VERDICT from long review output (#1234)` — end-to-end path through `parseAgentOutput` → `parseReviewVerdict`

Full suite: 2423 passing (2 new), 1 pre-existing failure on master unrelated to this change (`Metrics JSON has valid structure: dallas missing tasksCompleted`).

## Test plan

- [x] `npm test` passes on this branch (save the one pre-existing failure on master)
- [x] New tests fail on master without the fix
- [x] No changes to `parseStreamJsonOutput`'s signature — all existing callers still work
- [x] `meeting.js` (maxTextLength: 50000) and `consolidation.js` (no limit) unaffected on the common path

🤖 Generated with [Claude Code](https://claude.com/claude-code)