### PR TITLE
fix(W-mo3zkrqmfat7): pass --add-dir to agents for minions + ~/.claude skills

### DIFF
--- a/engine/spawn-agent.js
+++ b/engine/spawn-agent.js
@@ -7,6 +7,7 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { exec, runFile, cleanChildEnv, killGracefully, killImmediate, ts, safeJson, safeWrite } = require('./shared');
 
@@ -103,16 +104,27 @@ if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
 const debugPath = path.join(tmpDir, 'spawn-debug.log');
 fs.writeFile(debugPath, `spawn-agent.js at ${ts()}\nclaudeBin=${claudeBin || 'not found'}\nnative=${claudeIsNative}\nprompt=${promptFile}\nsysPrompt=${sysPromptFile}\nextraArgs=${extraArgs.join(' ')}\n`, () => {});
 
+// Skill discovery dirs — agents run with CWD set to an external repo worktree,
+// so skills in the minions repo and the user's global ~/.claude dir are otherwise
+// invisible. Pass them via --add-dir on every invocation (resume included, since
+// each resume spawns a fresh CLI process with the same CWD). See issue #1231.
+const minionsDir = path.resolve(__dirname, '..');
+const userClaudeDir = path.join(os.homedir(), '.claude');
+const addDirArgs = ['--add-dir', minionsDir];
+if (fs.existsSync(userClaudeDir) && path.resolve(userClaudeDir) !== path.resolve(minionsDir)) {
+  addDirArgs.push('--add-dir', userClaudeDir);
+}
+
 // When resuming a session, skip system prompt (it's baked into the session)
 const isResume = extraArgs.includes('--resume');
 const sysTmpPath = sysPromptFile + '.tmp';
 let cliArgs;
 if (isResume) {
-  cliArgs = ['-p', ...extraArgs];
+  cliArgs = ['-p', ...addDirArgs, ...extraArgs];
 } else {
   // Pass system prompt via file to avoid ENAMETOOLONG on Windows (32KB arg limit)
   fs.writeFileSync(sysTmpPath, sysPrompt);
-  cliArgs = ['-p', '--system-prompt-file', sysTmpPath, ...extraArgs];
+  cliArgs = ['-p', '--system-prompt-file', sysTmpPath, ...addDirArgs, ...extraArgs];
 }
 
 if (!claudeBin) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -7731,6 +7731,38 @@ async function testSpawnAgentScript() {
     assert.ok(!src.includes('spawnSync') || !src.includes("'--help'"),
       'Should not use spawnSync --help for capability detection (removed as bottleneck)');
   });
+
+  // Issue #1231: skills discovery across external repo worktrees
+  await test('spawn-agent.js passes --add-dir for minions project dir', () => {
+    assert.ok(src.includes("require('os')"),
+      'Should import os module for homedir()');
+    // Minions dir resolves up one from engine/ to repo root
+    assert.ok(src.includes("path.resolve(__dirname, '..')"),
+      'Should resolve minions project dir via path.resolve(__dirname, "..")');
+    assert.ok(src.includes("'--add-dir'"),
+      'Should pass --add-dir flag to claude CLI for skill discovery');
+  });
+
+  await test('spawn-agent.js passes --add-dir for user ~/.claude dir', () => {
+    // Must use os.homedir() per CLAUDE.md cross-platform rule, not $HOME/$USERPROFILE
+    assert.ok(src.includes('os.homedir()'),
+      'Should use os.homedir() (not process.env.HOME) for cross-platform compat');
+    assert.ok(src.includes("'.claude'"),
+      'Should target the .claude subdirectory under home for global skill discovery');
+  });
+
+  await test('spawn-agent.js includes --add-dir on both resume and non-resume paths', () => {
+    // Agents run as fresh processes even on resume — CWD is still the external worktree,
+    // so skill discovery dirs must be passed in both branches of the cliArgs assignment.
+    const resumeIdx = src.indexOf('if (isResume)');
+    assert.ok(resumeIdx !== -1, 'isResume branch must exist');
+    const closeBrace = src.indexOf('\n}\n', resumeIdx);
+    assert.ok(closeBrace !== -1, 'isResume branch should end with closing brace');
+    const branchBlock = src.slice(resumeIdx, closeBrace);
+    const addDirSpreadMatches = branchBlock.match(/\.\.\.addDirArgs/g) || [];
+    assert.ok(addDirSpreadMatches.length >= 2,
+      'Both resume and non-resume cliArgs must spread ...addDirArgs (got ' + addDirSpreadMatches.length + ')');
+  });
 }
 
 // ─── engine.js — Exit Code 78 Handling Tests ────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes yemi33/minions#1231 — user global skills (`~/.claude/skills/`) and minions project skills (`.claude/skills/` in the minions repo) were invisible to agents spawned into external repo worktrees.

## Why

`spawn-agent.js` spawns the Claude CLI with CWD set to the agent's external repo worktree (e.g. `office-bohemia/worktrees/...`). Claude discovers skills relative to its CWD and from `--add-dir` paths. Without any `--add-dir`, agents dispatched to office-bohemia (or any non-minions project) could only see skills inside that external repo — they had no path to `minions/.claude/skills/` or `~/.claude/skills/`.

Concrete symptom: build-fix agents couldn't run the `ado-build-log-fetch-via-timeline` skill even though the playbook referenced it.

## Change

- Add `os` import to `engine/spawn-agent.js`.
- Build an `addDirArgs` array:
  - `--add-dir <minions-repo-root>` (always) — computed as `path.resolve(__dirname, '..')` so it follows this script regardless of where minions is installed.
  - `--add-dir <os.homedir()>/.claude` (when it exists and is distinct from the minions dir) — per CLAUDE.md cross-platform rule, uses `os.homedir()` rather than `$HOME` / `$USERPROFILE`.
- Spread `...addDirArgs` into `cliArgs` on **both** the resume and non-resume branches. Resume spawns a fresh CLI process with the same CWD, so skill discovery still needs the flag.

## Test plan

Three new TDD-first tests in `test/unit.test.js` under `testSpawnAgentScript`:

- [x] `spawn-agent.js passes --add-dir for minions project dir` — verifies `os` import, `path.resolve(__dirname, '..')`, and `'--add-dir'` literal.
- [x] `spawn-agent.js passes --add-dir for user ~/.claude dir` — verifies `os.homedir()` usage (not `process.env.HOME`) and `.claude` subdir target.
- [x] `spawn-agent.js includes --add-dir on both resume and non-resume paths` — verifies `...addDirArgs` is spread in both cliArgs branches.

Full unit suite: **2424 passed** (up from 2421 with the 3 new tests). The single pre-existing failure (`Metrics JSON has valid structure: dallas missing tasksCompleted`) is unrelated — confirmed by re-running against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)