### PR TITLE
fix(W-mo3zuc6usdut): scheduler substitutes {{date}} in title and description

### DIFF
--- a/engine/scheduler.js
+++ b/engine/scheduler.js
@@ -24,9 +24,28 @@
 const fs = require('fs');
 const path = require('path');
 const shared = require('./shared');
-const { safeJson, safeWrite, mutateJsonFileLocked, ts, WI_STATUS } = shared;
+const { safeJson, safeWrite, mutateJsonFileLocked, ts, dateStamp, WI_STATUS } = shared;
 
 const SCHEDULE_RUNS_PATH = path.join(__dirname, 'schedule-runs.json');
+
+/**
+ * Substitute schedule-time template variables in a string.
+ * Currently supports:
+ *   {{date}} — today's date as YYYY-MM-DD (UTC, via dateStamp())
+ *
+ * Downstream playbook rendering (engine/playbook.js) is a single-pass replace,
+ * so any {{date}} embedded in a schedule's title/description would survive
+ * substitution of {{task_description}} and surface as an "unresolved template
+ * variables: date" warning plus a literal "{{date}}" in agent filenames.
+ * Resolve these fields at schedule time so the work item carries a concrete
+ * date string from the moment it's created.
+ *
+ * Safe on undefined/null/empty/non-string inputs — returns the input unchanged.
+ */
+function resolveScheduleTemplateVars(str) {
+  if (typeof str !== 'string' || str.length === 0) return str;
+  return str.replace(/\{\{date\}\}/g, dateStamp());
+}
 
 // Parse a single cron field into a matcher function.
 // field: e.g., "*", "5", "1,3,5", "*/15"
@@ -121,12 +140,15 @@ function discoverScheduledWork(config) {
       const lastRun = typeof runEntry === 'string' ? runEntry : (runEntry?.lastRun || null);
       if (!shouldRunNow(sched, lastRun)) continue;
 
+      // Substitute schedule-time template vars (e.g. {{date}}) before the work
+      // item is written — single-pass playbook rendering can't reach placeholders
+      // embedded inside task_description, so they must be resolved up front.
       work.push({
         id: `sched-${sched.id}-${Date.now()}`,
-        title: sched.title,
+        title: resolveScheduleTemplateVars(sched.title),
         type: sched.type || 'implement',
         priority: sched.priority || 'medium',
-        description: sched.description || sched.title,
+        description: resolveScheduleTemplateVars(sched.description || sched.title),
         status: WI_STATUS.PENDING,
         created: ts(),
         createdBy: 'scheduler',
@@ -144,4 +166,4 @@ function discoverScheduledWork(config) {
   return work;
 }
 
-module.exports = { parseCronExpr, parseCronField, shouldRunNow, discoverScheduledWork, SCHEDULE_RUNS_PATH };
+module.exports = { parseCronExpr, parseCronField, shouldRunNow, discoverScheduledWork, resolveScheduleTemplateVars, SCHEDULE_RUNS_PATH };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10887,6 +10887,97 @@ async function testSchedulerCronParsing() {
     assert.strictEqual(matcher(3), true);
     assert.strictEqual(matcher(2), false);
   });
+
+  // W-mo3zuc6usdut: scheduler must substitute {{date}} in title/description
+  // so downstream playbooks don't receive literal {{date}} strings that break
+  // single-pass template substitution in renderPlaybook.
+  console.log('\n── scheduler.js — Template Variable Substitution ──');
+
+  await test('resolveScheduleTemplateVars substitutes {{date}} with today YYYY-MM-DD', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    assert.strictEqual(
+      scheduler.resolveScheduleTemplateVars('Test health report {{date}}'),
+      `Test health report ${today}`
+    );
+  });
+
+  await test('resolveScheduleTemplateVars substitutes all occurrences of {{date}}', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    assert.strictEqual(
+      scheduler.resolveScheduleTemplateVars('{{date}}: build report for {{date}}'),
+      `${today}: build report for ${today}`
+    );
+  });
+
+  await test('resolveScheduleTemplateVars passes through strings without {{date}}', () => {
+    assert.strictEqual(scheduler.resolveScheduleTemplateVars('nothing to substitute'), 'nothing to substitute');
+  });
+
+  await test('resolveScheduleTemplateVars handles undefined/null/empty without throwing', () => {
+    assert.strictEqual(scheduler.resolveScheduleTemplateVars(undefined), undefined);
+    assert.strictEqual(scheduler.resolveScheduleTemplateVars(null), null);
+    assert.strictEqual(scheduler.resolveScheduleTemplateVars(''), '');
+  });
+
+  await test('discoverScheduledWork substitutes {{date}} in title and description', () => {
+    // Preserve + restore real schedule-runs.json so the test doesn't leak state
+    const runsSnapshot = _captureFileState(scheduler.SCHEDULE_RUNS_PATH);
+    try {
+      // Wipe any prior run record for our test IDs so the cron fires now
+      let runs = {};
+      try { runs = JSON.parse(fs.readFileSync(scheduler.SCHEDULE_RUNS_PATH, 'utf8') || '{}'); } catch {}
+      delete runs['test-date-sub'];
+      fs.writeFileSync(scheduler.SCHEDULE_RUNS_PATH, JSON.stringify(runs));
+
+      const today = new Date().toISOString().slice(0, 10);
+      const config = {
+        schedules: [{
+          id: 'test-date-sub',
+          cron: '* * *', // matches every minute
+          type: 'explore',
+          title: 'health check {{date}}',
+          description: 'explore test-health-{{date}}.md',
+          project: 'minions',
+          enabled: true,
+        }],
+      };
+      const work = scheduler.discoverScheduledWork(config);
+      const item = work.find(w => w._scheduleId === 'test-date-sub');
+      assert.ok(item, 'discoverScheduledWork should emit a work item for the enabled schedule');
+      assert.strictEqual(item.title, `health check ${today}`, 'title must have {{date}} substituted');
+      assert.strictEqual(item.description, `explore test-health-${today}.md`, 'description must have {{date}} substituted');
+    } finally {
+      _restoreFileState(runsSnapshot);
+    }
+  });
+
+  await test('discoverScheduledWork falls back to substituted title when description is absent', () => {
+    const runsSnapshot = _captureFileState(scheduler.SCHEDULE_RUNS_PATH);
+    try {
+      let runs = {};
+      try { runs = JSON.parse(fs.readFileSync(scheduler.SCHEDULE_RUNS_PATH, 'utf8') || '{}'); } catch {}
+      delete runs['test-date-title-fallback'];
+      fs.writeFileSync(scheduler.SCHEDULE_RUNS_PATH, JSON.stringify(runs));
+
+      const today = new Date().toISOString().slice(0, 10);
+      const config = {
+        schedules: [{
+          id: 'test-date-title-fallback',
+          cron: '* * *',
+          type: 'explore',
+          title: 'daily probe {{date}}',
+          enabled: true,
+        }],
+      };
+      const work = scheduler.discoverScheduledWork(config);
+      const item = work.find(w => w._scheduleId === 'test-date-title-fallback');
+      assert.ok(item, 'should emit a work item');
+      assert.strictEqual(item.description, `daily probe ${today}`,
+        'description should fall back to title with {{date}} substituted');
+    } finally {
+      _restoreFileState(runsSnapshot);
+    }
+  });
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `engine/scheduler.js::discoverScheduledWork` now substitutes `{{date}}` in the schedule's title and description before emitting the work item, using `shared.dateStamp()` (UTC YYYY-MM-DD).
- Fixes the `Playbook "explore": unresolved template variables: date` warning on scheduled explore dispatches and removes literal `{{date}}` strings from agent-written filenames like `test-health-2026-04-18.md`.
- Title is substituted too because `task_description = title + '\n\n' + description` in `engine.js:2405` — fixing description alone would still leak via the title path.

## Root cause

`engine/playbook.js::renderPlaybook` does a single-pass `Object.entries(allVars)` replace. When `task_description` is substituted, any `{{date}}` embedded in that string (having come in from the schedule's description) is no longer reachable by the `date` key's iteration. Resolving schedule-time vars at work-item creation is the cleanest surgical fix — a multi-pass render would risk mangling agent-authored literal `{{...}}` in code samples and quoted KB content.

## Changes

- `engine/scheduler.js`
  - Added `resolveScheduleTemplateVars(str)` (handles `{{date}}`, safe on null/undefined/empty/non-string).
  - Applied to `sched.title` and `sched.description || sched.title` inside `discoverScheduledWork`.
  - Exported the helper.
- `test/unit.test.js`
  - 4 source-level tests for the helper (happy, multi-occurrence, no-op, defensive inputs).
  - 2 behavioral tests via `discoverScheduledWork` that snapshot/restore real `SCHEDULE_RUNS_PATH` (scheduler hard-codes `__dirname`, not redirected by `MINIONS_TEST_DIR`).

## Test plan
- [x] `npm test` → 2428 passed, 0 failed, 3 skipped
- [x] Pre-fix probe confirmed `resolveScheduleTemplateVars` undefined and work item emitted literal `{{date}}`
- [x] Post-fix probe confirmed `resolveScheduleTemplateVars` substitutes to `YYYY-MM-DD` and work item fields contain concrete date
- [x] No leaked `test-date-*` entries in `engine/schedule-runs.json` after suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)