### PR TITLE
docs(skill): add substitute-scheduler-template-vars (SK001)

### DIFF
--- a/.claude/skills/substitute-scheduler-template-vars/SKILL.md
+++ b/.claude/skills/substitute-scheduler-template-vars/SKILL.md
@@ -1,0 +1,26 @@
+---
+created: 2026-04-18
+author: Ralph
+name: substitute-scheduler-template-vars
+description: When adding a new schedule-time template variable (like {{date}}) that must land in the work item before dispatch, extend resolveScheduleTemplateVars in engine/scheduler.js rather than relying on renderPlaybook — playbook render is single-pass and can't reach vars embedded inside task_description.
+allowed-tools: Bash, Read, Edit, Grep
+trigger: adding schedule-time template vars to engine/scheduler.js
+scope: project
+project: minions
+---
+
+# Scheduler Template Variable Substitution
+
+## Why
+`engine/playbook.js::renderPlaybook` is single-pass. When `task_description` is built from `item.title + '\n\n' + item.description` (source: `engine.js:2405`), any `{{var}}` embedded in the schedule's title/description survives substitution and surfaces as "unresolved template variables" warnings plus literal `{{var}}` strings in agent filenames.
+
+## Steps
+1. Add/extend `resolveScheduleTemplateVars(str)` in `engine/scheduler.js`. Currently handles `{{date}}`; pattern: `str.replace(/\{\{var\}\}/g, valueProducer())`. Guard non-string inputs with `if (typeof str !== 'string' || str.length === 0) return str;`.
+2. Apply it to **both** `sched.title` and `sched.description || sched.title` in the work item emit block — task_description concatenates both, so missing either leaks.
+3. Export the helper from `module.exports`.
+4. Prefer `shared.dateStamp()` over inline `new Date().toISOString().slice(0,10)` — same output, consistent with `renderPlaybook`'s `{{date}}` source.
+5. Add source-level tests for the helper (happy, multi-occurrence, no-op, undefined/null/empty) AND a behavioral test via `discoverScheduledWork`. The behavioral test MUST snapshot/restore `SCHEDULE_RUNS_PATH` with `_captureFileState`/`_restoreFileState` because the scheduler writes through `__dirname`, not `MINIONS_TEST_DIR`.
+
+## Notes
+- Don't fix this with multi-pass substitution in `renderPlaybook` — it'll resolve literal `{{...}}` inside agent-authored text (code samples in acceptance criteria, quoted playbook snippets in KB entries).
+- Only vars known at schedule time belong here. `{{agent_id}}`, `{{project_name}}`, etc. aren't known yet and must stay in `renderPlaybook`.


### PR DESCRIPTION
## Summary

Adds a project-level skill at `.claude/skills/substitute-scheduler-template-vars/SKILL.md` that guides future agents on the right extension point when adding schedule-time template variables (like `{{date}}`) to the scheduler.

## Why this skill exists

`engine/playbook.js::renderPlaybook` is **single-pass**: it iterates `allVars` and runs `content.replace(new RegExp('\{\{<key>\}\}', 'g'), val)` once per var (playbook.js:411–412). When a scheduled work item's `task_description` is built as `item.title + '\n\n' + item.description` (engine.js:2405), any `{{var}}` literally embedded in the schedule's title/description survives substitution — it arrives at the playbook renderer inside an already-substituted `task_description`, so there's no second pass to catch it. Symptoms: "unresolved template variables" warnings plus literal `{{var}}` strings leaking into agent filenames.

The skill codifies the fix pattern (also shipped via PR #1275 for `{{date}}`):

1. Extend `resolveScheduleTemplateVars(str)` in `engine/scheduler.js` — guard non-strings, use `shared.dateStamp()` over inline ISO slicing for consistency with `renderPlaybook`'s `{{date}}` source.
2. Apply to **both** `sched.title` and `sched.description || sched.title` — task_description concatenates both, so missing either leaks.
3. Export via `module.exports`.
4. Pair source-level tests (happy, multi-occurrence, no-op, undefined/null/empty) with a behavioral test through `discoverScheduledWork` that snapshots `SCHEDULE_RUNS_PATH` via `_captureFileState`/`_restoreFileState` — the scheduler writes through `__dirname`, not `MINIONS_TEST_DIR`.

It also warns against the tempting wrong fix: making `renderPlaybook` multi-pass. That would resolve literal `{{...}}` inside agent-authored text (code samples in acceptance criteria, quoted playbook snippets in KB entries).

## Verification of cross-references in the skill

| Reference | Verified |
|---|---|
| `engine.js:2405` — `task_description: item.title + (item.description ? '\n\n' + item.description : '')` | ✓ |
| `engine/playbook.js:411–412` — single-pass substitution loop | ✓ |
| `engine/scheduler.js:29` — `SCHEDULE_RUNS_PATH = path.join(__dirname, 'schedule-runs.json')` | ✓ |
| `engine/shared.js:21` — `dateStamp()` exported at shared.js:1568 | ✓ |
| `test/unit.test.js:34,42` — `_captureFileState` / `_restoreFileState` helpers | ✓ |

## Test plan

- [x] Unit test suite: `node test/unit.test.js` — **2422 passed, 0 failed, 3 skipped**
- [x] Skill frontmatter validates — engine's runtime skill scanner already picked it up (visible in available-skills list during this task)
- [x] No code changes; docs-only addition

## Run instructions

No runtime behavior change. Agents will see this skill listed under available skills when working in the minions project and the engine picks it up automatically.