### PR TITLE
feat(P-a7f2c9d3): SEC-02 — replace curl shell-out in ado.js with adoFetch

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -104,11 +104,12 @@ async function adoFetch(url, token, opts = {}) {
   const _retryCount = typeof opts === 'number' ? opts : (opts._retryCount || 0); // backward compat
   const method = (typeof opts === 'object' && opts.method) || 'GET';
   const body = (typeof opts === 'object' && opts.body) || undefined;
+  const timeout = (typeof opts === 'object' && Number.isFinite(opts.timeout)) ? opts.timeout : 30000;
   const MAX_RETRIES = 1;
   const res = await fetch(url, {
     method,
     headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
-    signal: AbortSignal.timeout(30000),
+    signal: AbortSignal.timeout(timeout),
     body,
   });
   // ── Throttle detection: intercept 429/503 BEFORE generic !res.ok ──
@@ -811,8 +812,11 @@ async function checkLiveReviewStatus(pr, project) {
     const prNum = shared.getPrNumber(pr);
     if (!prNum) return null;
     const url = `${orgBase}/${project.adoProject}/_apis/git/repositories/${project.repositoryId}/pullrequests/${prNum}?api-version=7.1`;
-    const result = await execAsync(`curl -s --max-time 4 -H "Authorization: Bearer ${token}" "${url}"`, { encoding: 'utf-8', timeout: 5000, windowsHide: true });
-    const prData = JSON.parse(result);
+    // SEC-02: use in-process adoFetch rather than a shell-out — keeps the bearer
+    // token out of the process argv list where any local process could read it.
+    // 4s timeout preserves the original request-cancellation semantics via AbortSignal.
+    const prData = await adoFetch(url, token, { timeout: 4000 });
+    if (!prData) return null;
     const votes = (prData.reviewers || []).map(r => r.vote).filter(v => v !== undefined);
     if (votes.length === 0) return 'pending';
     return votesToReviewStatus(votes);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -20063,6 +20063,35 @@ async function testPrReviewFixFlows() {
       'All votes extraction in checkLiveReviewStatus must filter undefined values');
   });
 
+  // ── SEC-02: No curl shell-out in ado.js (token leak via process argv) ──
+
+  await test('ADO checkLiveReviewStatus uses adoFetch, not curl shell-out', () => {
+    const checkFn = adoSrc.slice(adoSrc.indexOf('async function checkLiveReviewStatus('), adoSrc.indexOf('\nasync function fetchAdoPrMetadata'));
+    assert.ok(!/curl\s/.test(checkFn),
+      'checkLiveReviewStatus must not shell out to curl (token would be exposed on argv)');
+    assert.ok(!checkFn.includes('execAsync('),
+      'checkLiveReviewStatus must not use execAsync (token would be exposed on argv)');
+    assert.ok(checkFn.includes('adoFetch('),
+      'checkLiveReviewStatus must use the in-process adoFetch wrapper');
+  });
+
+  await test('ADO ado.js has no curl shell-out in executable code', () => {
+    // Strip only comments (not string literals — curl shell-outs live inside template literals).
+    const stripped = adoSrc
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    assert.ok(!/\bcurl\b/.test(stripped),
+      'engine/ado.js must not reference curl outside comments (SEC-02: ADO bearer token leak via process argv)');
+  });
+
+  await test('adoFetch supports configurable timeout via opts.timeout', () => {
+    const adoFetchFn = adoSrc.slice(adoSrc.indexOf('async function adoFetch('), adoSrc.indexOf('\n/** Fetch raw text from ADO API'));
+    assert.ok(adoFetchFn.includes('opts.timeout') || adoFetchFn.includes('timeout ='),
+      'adoFetch should accept a timeout option so callers can override the 30s default');
+    assert.ok(adoFetchFn.includes('AbortSignal.timeout('),
+      'adoFetch should use AbortSignal.timeout() for request cancellation');
+  });
+
   await test('GitHub checkLiveReviewStatus filters undefined state values from reviews', () => {
     // Review objects from GitHub API may have undefined state — latestByUser.values() must not contain undefined
     const checkFn = ghSrc.slice(ghSrc.indexOf('async function checkLiveReviewStatus('), ghSrc.indexOf('\nmodule.exports'));


### PR DESCRIPTION
## Summary

- Replaces the last `curl` shell-out in `engine/ado.js` (pre-dispatch live review status check) with the in-process `adoFetch` wrapper. The ADO bearer token no longer flows through a child-process argv list where any local process could read it.
- Extends `adoFetch` with an optional `opts.timeout` (falling back to the prior 30s default) so the review-status caller can preserve the original 4s cancellation semantics via `AbortSignal.timeout(4000)`.
- TDD: three tests added before the fix, all passing after.

## Why

Before: `execAsync(\`curl -H "Authorization: Bearer ${token}" "${url}"\`, ...)` at `engine/ado.js:814` exposed the live ADO bearer token on `/proc/<pid>/cmdline` (Linux/macOS) or `Get-Process`/`wmic` output (Windows) for the fetch duration. Exploitable today without CSRF — any local process on the host could harvest the token.

After: token stays in-process, routed through the same `adoFetch` that handles throttle detection, auth refresh, and error normalization for every other ADO call.

## Acceptance Criteria

- [x] `engine/ado.js:814` no longer invokes `curl` via `execAsync` — uses `adoFetch` instead
- [x] ADO bearer token is never passed as a process argument on any code path
- [x] `grep -n curl engine/` returns zero hits in executable code (only doc comments remain: `ado-status.js:6`, `ado.js:845`, `lifecycle.js:2070` — all comments)
- [x] 4s request timeout preserved via `AbortSignal.timeout(4000)` — no indefinite hangs on ADO outage

## Build / Test

- `node test/unit.test.js` — **2449 passed / 1 failed / 3 skipped**
- The 1 failure (`Metrics JSON has valid structure: dallas missing tasksCompleted`) is **pre-existing and unrelated** — it reads runtime `metrics.json` state, not source code
- The 3 new TDD tests pass:
  - `ADO checkLiveReviewStatus uses adoFetch, not curl shell-out`
  - `ADO ado.js has no curl shell-out in executable code`
  - `adoFetch supports configurable timeout via opts.timeout`

## Test plan

- [x] Unit tests pass (2449)
- [x] `grep -n curl engine/` confirms zero executable-code matches
- [ ] Live verification: engine will poll a live PR's review status on next tick — if auth/timeout semantics broke, the log will show `Live review check for ...` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)