### PR TITLE
feat: SEC-09: redact ADO tokens and JWTs from engine/log.json writes

### DIFF
--- a/engine/shared.js
+++ b/engine/shared.js
@@ -20,6 +20,46 @@ function ts() { return new Date().toISOString(); }
 function logTs() { return new Date().toLocaleTimeString(); }
 function dateStamp() { return new Date().toISOString().slice(0, 10); }
 
+// ── Secret Redaction (SEC-09) ──────────────────────────────────────────────
+// Pure, side-effect-free redactor applied to every entry on the log write path
+// so ADO tokens, JWTs, and azureauth stdout dumps never land in engine/log.json
+// (2500-entry ring buffer readable by any local process).
+//
+// Replacements (order matters — azureauth first, then Bearer, then bare JWT):
+//   1. `"token":"<20+ char base64-ish>"` → `"token":"[REDACTED_AZUREAUTH]"`
+//      Redacts the value only, not the whole line, so surrounding JSON
+//      context (e.g. expiresOn) remains debuggable.
+//   2. `Bearer <20+ char base64-ish>`   → `Bearer [REDACTED]`
+//   3. `ey<b64url>.<b64url>[.<b64url>]` → `[REDACTED_JWT]`
+//      Catches bare JWTs in error messages or stack traces (anything left
+//      after Bearer replacement has consumed its tokens).
+//
+// `redactSecrets` also recurses into objects and arrays — used by `log()` to
+// sanitize both the message and the meta payload before persistence.
+const _BEARER_RE = /Bearer\s+[A-Za-z0-9+/=._\-]{20,}/g;
+const _JWT_RE = /ey[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}(?:\.[A-Za-z0-9_\-]{10,})?/g;
+const _AZUREAUTH_RE = /"token"\s*:\s*"[A-Za-z0-9+/=._\-]{20,}"/g;
+
+function _redactString(s) {
+  if (typeof s !== 'string' || s.length === 0) return s;
+  return s
+    .replace(_AZUREAUTH_RE, '"token":"[REDACTED_AZUREAUTH]"')
+    .replace(_BEARER_RE, 'Bearer [REDACTED]')
+    .replace(_JWT_RE, '[REDACTED_JWT]');
+}
+
+function redactSecrets(value) {
+  if (value == null) return value;
+  if (typeof value === 'string') return _redactString(value);
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (typeof value === 'object') {
+    const out = {};
+    for (const k of Object.keys(value)) out[k] = redactSecrets(value[k]);
+    return out;
+  }
+  return value;
+}
+
 // ── Log Buffering ──────────────────────────────────────────────────────────
 // Buffer log entries in memory and flush to disk periodically to reduce lock
 // contention (~139 calls/tick → 1 lock acquisition per flush).
@@ -27,9 +67,14 @@ const _logBuffer = [];
 let _logFlushTimer = null;
 
 function log(level, msg, meta = {}) {
-  const entry = { timestamp: ts(), level, message: msg, ...meta };
-  // Console output remains immediate
-  console.log(`[${logTs()}] [${level}] ${msg}`);
+  // SEC-09: redact sensitive patterns (ADO tokens, JWTs, azureauth stdout)
+  // before both the in-memory buffer push and the console echo — ensures
+  // nothing sensitive is persisted to engine/log.json or engine stdout logs.
+  const safeMsg = typeof msg === 'string' ? _redactString(msg) : msg;
+  const safeMeta = redactSecrets(meta) || {};
+  const entry = { timestamp: ts(), level, message: safeMsg, ...safeMeta };
+  // Console output remains immediate (also redacted)
+  console.log(`[${logTs()}] [${level}] ${safeMsg}`);
 
   _logBuffer.push(entry);
 
@@ -50,7 +95,9 @@ function log(level, msg, meta = {}) {
 
 function _flushLogBuffer() {
   if (_logBuffer.length === 0) return;
-  const entries = _logBuffer.splice(0);
+  // SEC-09 defense-in-depth: redact again at flush time so any direct
+  // `_logBuffer.push(entry)` callers (tests, future paths) can't leak secrets.
+  const entries = _logBuffer.splice(0).map(redactSecrets);
   try {
     mutateJsonFileLocked(LOG_PATH, (logData) => {
       if (!Array.isArray(logData)) logData = logData?.entries || [];
@@ -1641,6 +1688,7 @@ module.exports = {
   _WIN_RESERVED_NAMES, // exported for testing
   LOCK_STALE_MS,
   flushLogs,
+  redactSecrets,
   slugify,
   safeSlugComponent,
   formatTranscriptEntry,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -3604,6 +3604,216 @@ async function testStateIntegrity() {
     }
   });
 
+  // ─── SEC-09: redactSecrets() — token/JWT/azureauth redaction ──────────────
+  await test('redactSecrets is exported from shared.js', () => {
+    assert.strictEqual(typeof shared.redactSecrets, 'function',
+      'redactSecrets should be exported from engine/shared.js');
+  });
+
+  await test('redactSecrets replaces Bearer tokens with [REDACTED]', () => {
+    const input = 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.payload.sig';
+    const out = shared.redactSecrets(input);
+    assert.ok(out.includes('Bearer [REDACTED]'),
+      `Bearer token should be replaced with "Bearer [REDACTED]", got: ${out}`);
+    assert.ok(!out.includes('eyJ0eXAiOiJKV1Q'),
+      'raw token payload must not survive redaction');
+    // Surrounding context preserved
+    assert.ok(out.startsWith('Authorization: Bearer [REDACTED]'),
+      'surrounding context ("Authorization:") should be preserved');
+  });
+
+  await test('redactSecrets handles lowercase bearer too (boundary case)', () => {
+    // Spec regex is case-sensitive on `Bearer` — documents the contract
+    const input = 'bearer abc';
+    assert.strictEqual(shared.redactSecrets(input), 'bearer abc',
+      'lowercase "bearer" is NOT redacted (regex is case-sensitive, by spec)');
+  });
+
+  await test('redactSecrets does not redact short Bearer values (< 20 chars)', () => {
+    const input = 'Bearer short';
+    assert.strictEqual(shared.redactSecrets(input), 'Bearer short',
+      'short values after Bearer should not match the 20+ char token regex');
+  });
+
+  await test('redactSecrets replaces JWT-shaped strings with [REDACTED_JWT]', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT';
+    const input = `got response token=${jwt} end`;
+    const out = shared.redactSecrets(input);
+    assert.ok(out.includes('[REDACTED_JWT]'),
+      `JWT should be replaced with [REDACTED_JWT], got: ${out}`);
+    assert.ok(!out.includes('SflKxwRJSMeKKF2QT'),
+      'JWT signature segment must not survive redaction');
+    assert.ok(out.startsWith('got response token=') && out.endsWith(' end'),
+      'JWT redaction must preserve surrounding context');
+  });
+
+  await test('redactSecrets handles 2-segment JWT shape', () => {
+    const two = 'eyAAAAAAAAAA.bbbbbbbbbbbbb';
+    const out = shared.redactSecrets(`prefix ${two} suffix`);
+    assert.ok(out.includes('[REDACTED_JWT]'),
+      '2-segment JWT shape (header.payload) should also match');
+    assert.ok(!out.includes('bbbbbbbbbbbbb'), 'JWT payload must not survive');
+  });
+
+  await test('redactSecrets replaces azureauth "token" JSON key output', () => {
+    const input = '{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.aaaaa.bbbbb","expiresOn":"2026-05-01"}';
+    const out = shared.redactSecrets(input);
+    assert.ok(out.includes('[REDACTED_AZUREAUTH]'),
+      `azureauth-shaped "token" JSON field should be replaced, got: ${out}`);
+    assert.ok(!out.includes('eyJ0eXAiOiJKV1Q'),
+      'raw azureauth token value must not survive');
+    // Surrounding context preserved — expiresOn still visible
+    assert.ok(out.includes('"expiresOn":"2026-05-01"'),
+      'non-sensitive surrounding context (expiresOn) should be preserved');
+  });
+
+  await test('redactSecrets is a no-op on clean strings', () => {
+    const clean = 'PR 1234 status: approved — build passing';
+    assert.strictEqual(shared.redactSecrets(clean), clean,
+      'clean string should pass through unchanged');
+  });
+
+  await test('redactSecrets is a no-op on empty / non-string primitives', () => {
+    assert.strictEqual(shared.redactSecrets(''), '', 'empty string passes through');
+    assert.strictEqual(shared.redactSecrets(42), 42, 'numbers pass through');
+    assert.strictEqual(shared.redactSecrets(true), true, 'booleans pass through');
+    assert.strictEqual(shared.redactSecrets(null), null, 'null passes through');
+    assert.strictEqual(shared.redactSecrets(undefined), undefined, 'undefined passes through');
+  });
+
+  await test('redactSecrets recurses into nested objects', () => {
+    const input = {
+      level: 'warn',
+      message: 'auth failed: Bearer eyJlonglongtoken_aaaaaaaaaaaaaaaaaaa',
+      context: {
+        headers: { Authorization: 'Bearer eyJotherlongtoken_bbbbbbbbbbbbbbb' },
+        raw: '{"token":"eyJstdoutdumpAAAAAAAAAAAAAAAA.payload.sig"}',
+      },
+      safe: 42,
+    };
+    const out = shared.redactSecrets(input);
+    assert.ok(out.message.includes('Bearer [REDACTED]'), 'top-level string redacted');
+    assert.ok(out.context.headers.Authorization.includes('Bearer [REDACTED]'),
+      'nested object string redacted');
+    assert.ok(out.context.raw.includes('[REDACTED_AZUREAUTH]'),
+      'deeply nested azureauth payload redacted');
+    assert.strictEqual(out.safe, 42, 'non-string primitives preserved');
+    assert.strictEqual(out.level, 'warn', 'clean strings preserved verbatim');
+    // Original object NOT mutated
+    assert.ok(input.message.includes('eyJlonglongtoken'),
+      'redactSecrets must not mutate the input object');
+  });
+
+  await test('redactSecrets recurses into arrays', () => {
+    const input = ['Bearer eyJonelongtoken_aaaaaaaaaaaaaaaa', 'clean', { t: 'Bearer eyJtwolongtoken_bbbbbbbbbbb' }];
+    const out = shared.redactSecrets(input);
+    assert.ok(Array.isArray(out), 'array stays an array');
+    assert.ok(out[0].includes('Bearer [REDACTED]'), 'array[0] redacted');
+    assert.strictEqual(out[1], 'clean', 'clean array element untouched');
+    assert.ok(out[2].t.includes('Bearer [REDACTED]'), 'object inside array redacted');
+  });
+
+  await test('redactSecrets handles multiple occurrences in one string', () => {
+    const input = 'req1: Bearer eyJfirsttoken_aaaaaaaaaaaaaa / req2: Bearer eyJsecondtoken_bbbbbbbbbbbbbb';
+    const out = shared.redactSecrets(input);
+    const matches = out.match(/Bearer \[REDACTED\]/g) || [];
+    assert.strictEqual(matches.length, 2, 'both Bearer tokens should be redacted');
+    assert.ok(!/eyJfirst|eyJsecond/.test(out), 'no raw token substrings remain');
+  });
+
+  await test('redactSecrets prefers Bearer replacement over JWT when both match', () => {
+    // A JWT after Bearer should yield "Bearer [REDACTED]", not "Bearer [REDACTED_JWT]"
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signatureAAA';
+    const out = shared.redactSecrets(`Bearer ${jwt}`);
+    assert.strictEqual(out, 'Bearer [REDACTED]',
+      'Bearer + JWT should produce a single "Bearer [REDACTED]", not a double-redacted form');
+  });
+
+  await test('log.json writes are redacted end-to-end', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const s = require('../engine/shared');
+      const testDir = process.env.MINIONS_TEST_DIR;
+      const logPath = path.join(testDir, 'engine', 'log.json');
+
+      s._logBuffer.length = 0;
+      s.log('warn', 'Live review check failed: Error: Command failed: curl -H "Authorization: Bearer eyJ0eXAiOiJKV1QLongTokenAAAAAAAAAA.payload.signature"');
+      s.log('info', 'fetched azureauth stdout: {"token":"eyJfreshLongTokenBBBBBBBBBB.payload.sig","expiresOn":"2026-05-01"}');
+      s.log('info', 'normal message without secrets');
+      s.flushLogs();
+
+      const logData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      const messages = logData.map(e => e.message).join('\n');
+
+      assert.ok(messages.includes('Bearer [REDACTED]'),
+        'log.json should contain Bearer [REDACTED] sentinel');
+      assert.ok(messages.includes('[REDACTED_AZUREAUTH]'),
+        'log.json should contain [REDACTED_AZUREAUTH] sentinel');
+      assert.ok(!messages.includes('eyJ0eXAiOiJKV1QLongToken'),
+        'raw Bearer token must not appear in log.json');
+      assert.ok(!messages.includes('eyJfreshLongToken'),
+        'raw azureauth token must not appear in log.json');
+      assert.ok(messages.includes('normal message without secrets'),
+        'clean messages should pass through unchanged');
+    } finally {
+      restore();
+    }
+  });
+
+  await test('log.json redacts string fields in meta payload', () => {
+    const restore = createTestMinionsDir();
+    try {
+      const s = require('../engine/shared');
+      const testDir = process.env.MINIONS_TEST_DIR;
+      const logPath = path.join(testDir, 'engine', 'log.json');
+
+      s._logBuffer.length = 0;
+      s.log('debug', 'request failed', {
+        url: 'https://dev.azure.com/org/project',
+        header: 'Bearer eyJlongmetatoken_cccccccccccccc',
+        code: 401,
+      });
+      s.flushLogs();
+
+      const logData = JSON.parse(fs.readFileSync(logPath, 'utf8'));
+      const entry = logData.find(e => e.message === 'request failed');
+      assert.ok(entry, 'the logged entry should be persisted');
+      assert.strictEqual(entry.code, 401, 'non-string meta fields preserved');
+      assert.strictEqual(entry.url, 'https://dev.azure.com/org/project', 'clean URL preserved');
+      assert.ok(entry.header && entry.header.includes('Bearer [REDACTED]'),
+        'sensitive meta string redacted');
+      assert.ok(!entry.header || !entry.header.includes('eyJlongmetatoken'),
+        'raw token must not survive in meta field');
+    } finally {
+      restore();
+    }
+  });
+
+  await test('engine/ado.js has no raw console.log/console.error token leaks', () => {
+    // SEC-09: acceptance criterion — grep verifies no raw token-logging console calls
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    // Strip line comments so documentation references don't trip the guard
+    const stripped = src.split('\n').map(l => l.replace(/\/\/.*$/, '')).join('\n');
+    // Match console.log / console.error / console.warn / console.info with token-ish content
+    const leakPattern = /console\.(log|error|warn|info)\s*\([^)]*(Bearer|token|azureauth|Authorization)/i;
+    assert.ok(!leakPattern.test(stripped),
+      'engine/ado.js must not call console.* with raw token/Bearer/azureauth/Authorization strings — use the log() helper so redaction applies');
+  });
+
+  await test('_flushLogBuffer wires redactSecrets before persistence', () => {
+    // Source-level guardrail: ensures future refactors don't bypass redaction at the write site
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'shared.js'), 'utf8');
+    assert.ok(src.includes('redactSecrets'),
+      'engine/shared.js must reference redactSecrets');
+    // The flush path must invoke redaction (either via map() at flush or via log() at push)
+    const flushBlock = src.slice(src.indexOf('function _flushLogBuffer'),
+      src.indexOf('function flushLogs'));
+    const logBlock = src.slice(src.indexOf('function log('),
+      src.indexOf('function _flushLogBuffer'));
+    assert.ok(flushBlock.includes('redactSecrets') || logBlock.includes('redactSecrets'),
+      'redactSecrets must be invoked either in log() push-time or _flushLogBuffer() flush-time');
+  });
+
   await test('Dashboard uses lock-backed dispatch mutations for API writes', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
     assert.ok(src.includes('mutateJsonFileLocked'),


### PR DESCRIPTION
## Summary

Adds `redactSecrets(value)` — a pure, recursive redactor — to `engine/shared.js` and wires it into the log write path so ADO bearer tokens, JWTs, and azureauth stdout dumps never persist to `engine/log.json` (2500-entry ring buffer readable by any local process).

Plan item: **P-c9d3e5b1** (plan `minions-2026-04-17.json`, complexity: small)

## What changed

**`engine/shared.js`**
- New `redactSecrets(value)` — recurses into objects/arrays; strings pass through three regex replacements (order matters):
  1. `"token":"<20+ char base64-ish>"` → `"token":"[REDACTED_AZUREAUTH]"` (value-only — preserves surrounding JSON context like `expiresOn`)
  2. `Bearer\s+[A-Za-z0-9+/=._\-]{20,}` → `Bearer [REDACTED]`
  3. `ey[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}(?:\.[A-Za-z0-9_\-]{10,})?` → `[REDACTED_JWT]` (catches bare JWTs left after Bearer consumption)
- Wired at two sites (defense in depth):
  - `log()` redacts `msg` + `meta` **before** the `console.log` echo and before the in-memory `_logBuffer.push`
  - `_flushLogBuffer()` re-runs `redactSecrets` over every buffered entry before `mutateJsonFileLocked(LOG_PATH, ...)` — guards against any direct `_logBuffer.push` caller

**`engine/ado.js`** — no changes needed. Audit confirmed zero `console.log`/`console.error`/`console.warn`/`console.info` calls; all logging flows through `log()`. Added grep-guard test to prevent regressions.

**`test/unit.test.js`** — 17 new tests (source: `test/unit.test.js:3607-3816`):
- `redactSecrets` unit tests: Bearer, JWT (2 & 3 segments), azureauth, clean strings, empty/non-string primitives, nested objects (incl. immutability), arrays, multiple occurrences, Bearer-vs-JWT precedence, lowercase-bearer boundary, short-bearer boundary
- End-to-end: log.json message + meta redaction via `log()` → `flushLogs()`
- Source guards: `engine/ado.js` has no raw console.* token leaks, `_flushLogBuffer` references `redactSecrets`

## Acceptance criteria

- [x] `redactSecrets(str)` exported from `engine/shared.js` and covered by unit tests
- [x] Every `log.json` write passes the entry through redaction before persistence (applied at both `log()` and `_flushLogBuffer()`)
- [x] No existing `console.log`/`console.error` in `engine/ado.js` emits a raw bearer token (verified by grep + test)
- [x] Redaction preserves surrounding context (e.g. `Bearer [REDACTED]` and `"token":"[REDACTED_AZUREAUTH]"` — not whole-line wipes)
- [x] Unit tests cover: bearer patterns, JWT patterns, azureauth output, clean strings, nested object redaction

## Design decisions

- **azureauth replacement is value-only**, not whole-line — contradicts a literal reading of the spec but honors the "Redaction preserves surrounding context ... so logs remain debuggable" acceptance criterion. The `[REDACTED_AZUREAUTH]` sentinel still appears for grep-ability.
- **Bearer regex runs before JWT regex** so `Bearer <JWT>` produces `Bearer [REDACTED]` (single sentinel) rather than `Bearer [REDACTED_JWT]` (double-redacted). Verified by test.
- **Case-sensitive `Bearer` match** — real HTTP `Authorization` headers are always capitalized `Bearer`; avoiding `/i` prevents false positives on prose. Boundary case documented with a test.

## Test plan

- [x] `npm test` — **2463 passed / 1 failed / 3 skipped**
- [x] All 17 new tests pass
- [x] Pre-existing failure (`Metrics JSON has valid structure: dallas missing tasksCompleted`) confirmed present on `origin/master` — unrelated to SEC-09 (live `metrics.json` has `dallas: { prsApproved: 1 }` with no `tasksCompleted` field)
- [ ] Reviewer verify: no regressions in log-buffering, log-flushing, or dashboard-displayed log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)