### PR TITLE
feat(P-b8e1f4a2): validate project name and path on POST /api/projects/add (SEC-04, SEC-05)

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -3658,12 +3658,58 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     } catch (e) { return jsonReply(res, 500, { error: e.message }); }
   }
 
+  // ── Non-repo confirmation tokens (SEC-05) ───────────────────────────────
+  // Single-use, short-TTL tokens that the client must obtain from
+  // POST /api/projects/confirm-token before a non-repo path can be added.
+  // This forces an explicit round-trip — a single forged POST to /add
+  // can no longer silently register a non-repo path as a project.
+  const _projectConfirmTokens = new Map(); // token → expiresAt (ms epoch)
+  const PROJECT_CONFIRM_TOKEN_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+  function _sweepProjectConfirmTokens() {
+    const now = Date.now();
+    for (const [t, exp] of _projectConfirmTokens) {
+      if (exp <= now) _projectConfirmTokens.delete(t);
+    }
+  }
+
+  function _consumeProjectConfirmToken(token) {
+    if (typeof token !== 'string' || !token) return false;
+    _sweepProjectConfirmTokens();
+    const exp = _projectConfirmTokens.get(token);
+    if (!exp) return false;
+    _projectConfirmTokens.delete(token); // single-use
+    return exp > Date.now();
+  }
+
+  async function handleProjectsConfirmToken(req, res) {
+    _sweepProjectConfirmTokens();
+    const token = require('crypto').randomUUID();
+    _projectConfirmTokens.set(token, Date.now() + PROJECT_CONFIRM_TOKEN_TTL_MS);
+    return jsonReply(res, 200, { confirmToken: token, ttlMs: PROJECT_CONFIRM_TOKEN_TTL_MS });
+  }
+
   async function handleProjectsAdd(req, res) {
     try {
       const body = await readBody(req);
       if (!body.path) return jsonReply(res, 400, { error: 'path required' });
-      const target = path.resolve(body.path);
-      if (!fs.existsSync(target)) return jsonReply(res, 400, { error: 'Directory not found: ' + target });
+
+      // SEC-05: validate path (must be a git repo, unless caller supplies
+      // allowNonRepo + a valid single-use confirmation token). Runs BEFORE any
+      // mutation of config.json so a rejected path leaves no side effects.
+      let target;
+      try {
+        target = shared.validateProjectPath(body.path, {
+          allowNonRepo: body.allowNonRepo === true,
+          confirmToken: body.confirmToken,
+          isValidToken: _consumeProjectConfirmToken,
+        });
+      } catch (e) {
+        return jsonReply(res, e.statusCode || 400, {
+          error: e.message,
+          ...(e.needsConfirmation ? { needsConfirmation: true } : {}),
+        });
+      }
 
       const configPath = path.join(MINIONS_DIR, 'config.json');
       const config = safeJsonObj(configPath);
@@ -3711,7 +3757,20 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         }
       } catch { /* optional */ }
 
-      const name = body.name || detected.name;
+      const rawName = body.name || detected.name;
+
+      // SEC-04: validate project name — rejects path traversal, shell
+      // metacharacters, whitespace, overly long names. Runs BEFORE any
+      // mutation of config.json. Auto-detected names (from package.json /
+      // directory basename) also go through this check so a maliciously
+      // named repo on disk can't inject metacharacters either.
+      let name;
+      try {
+        name = shared.validateProjectName(rawName);
+      } catch (e) {
+        return jsonReply(res, e.statusCode || 400, { error: e.message });
+      }
+
       const prUrlBase = detected.repoHost === 'github'
         ? (detected.org && detected.repoName ? `https://github.com/${detected.org}/${detected.repoName}/pull/` : '')
         : (detected.org && detected.project && detected.repoName
@@ -5007,7 +5066,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     // Projects
     { method: 'POST', path: '/api/projects/browse', desc: 'Open folder picker dialog, return selected path', handler: handleProjectsBrowse },
     { method: 'POST', path: '/api/projects/scan', desc: 'Scan a directory for git repos', params: 'path?, depth?', handler: handleProjectsScan },
-    { method: 'POST', path: '/api/projects/add', desc: 'Auto-discover and add a project to config', params: 'path, name?', handler: handleProjectsAdd },
+    { method: 'POST', path: '/api/projects/confirm-token', desc: 'Mint a single-use UUID token required to add a non-repo path (SEC-05)', handler: handleProjectsConfirmToken },
+    { method: 'POST', path: '/api/projects/add', desc: 'Auto-discover and add a project to config (name validated SEC-04; path validated SEC-05)', params: 'path, name?, allowNonRepo?, confirmToken?', handler: handleProjectsAdd },
 
     // Bug Filing
     { method: 'POST', path: '/api/issues/create', desc: 'File a bug on the Minions repo (yemi33/minions)', params: 'title, description?, labels?', handler: handleFileBug },

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -1029,6 +1029,82 @@ function sanitizeBranch(name) {
   return String(name).replace(/[^a-zA-Z0-9._\-\/]/g, '-').slice(0, 200);
 }
 
+// ── Project Name / Path Validation (SEC-04 / SEC-05) ─────────────────────────
+// Enforced at API boundaries (e.g. POST /api/projects/add). Callers that skip
+// these validators leak caller-controlled strings into worktree paths, config
+// keys, and shell invocations — never bypass them for "internal" callers.
+
+const PROJECT_NAME_RE = /^[a-zA-Z0-9_\-]{1,64}$/;
+
+function _httpError(status, message, extra) {
+  const err = new Error(message);
+  err.statusCode = status;
+  if (extra) Object.assign(err, extra);
+  return err;
+}
+
+/**
+ * Validate a project name against a strict allowlist before it ever reaches
+ * filesystem paths, config keys, or shell arguments.
+ *
+ * Allowlist: `/^[a-zA-Z0-9_\-]{1,64}$/` (letters, digits, underscore, hyphen).
+ * Rejects anything else — path separators, dots, whitespace, shell
+ * metacharacters, null bytes. Returns the validated name; throws a 400 Error.
+ */
+function validateProjectName(name) {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw _httpError(400, 'Invalid project name: name is required and must be a string');
+  }
+  if (name.length > 64) {
+    throw _httpError(400, `Invalid project name: "${name}" is ${name.length} characters (max 64)`);
+  }
+  if (!PROJECT_NAME_RE.test(name)) {
+    throw _httpError(400, `Invalid project name: "${name}". Must match /^[a-zA-Z0-9_\\-]{1,64}$/ (letters, digits, underscore, hyphen; no path separators, spaces, or shell metacharacters)`);
+  }
+  return name;
+}
+
+/**
+ * Validate a project path before it is persisted to config.json or used as a
+ * worktree parent.
+ *
+ * Default requires `fs.existsSync(path.join(pathStr, '.git'))` — accepts either
+ * a `.git` directory (normal repo) or a `.git` file (worktree pointer).
+ *
+ * To register a non-repo path, the caller must pass BOTH
+ *   `allowNonRepo: true`
+ *   `confirmToken: <uuid>`
+ * and supply an `isValidToken(token)` callback that consumes/validates the
+ * token against a freshly generated server-side token. This prevents a
+ * single POST from silently creating a broken project entry and forces the
+ * client through an explicit confirmation step (D-5: Rebecca / UUID vote).
+ *
+ * Returns the resolved absolute path; throws a 400 Error (with
+ * `needsConfirmation: true` when the only problem is the missing `.git`).
+ */
+function validateProjectPath(pathStr, options = {}) {
+  if (typeof pathStr !== 'string' || pathStr.length === 0) {
+    throw _httpError(400, 'Invalid project path: path is required and must be a string');
+  }
+  const resolved = path.resolve(pathStr);
+  if (!fs.existsSync(resolved)) {
+    throw _httpError(400, `Invalid project path: directory does not exist: ${resolved}`);
+  }
+  const gitMarker = path.join(resolved, '.git');
+  if (fs.existsSync(gitMarker)) return resolved; // .git dir OR worktree .git file
+
+  // Not a git repo — only accept with explicit confirmation.
+  const { allowNonRepo, confirmToken, isValidToken } = options;
+  if (allowNonRepo === true && typeof confirmToken === 'string' && typeof isValidToken === 'function' && isValidToken(confirmToken)) {
+    return resolved;
+  }
+  throw _httpError(
+    400,
+    `Invalid project path: "${resolved}" is not a git repository (no .git directory or file). Retry with allowNonRepo:true and a confirmToken from POST /api/projects/confirm-token to override.`,
+    { needsConfirmation: true },
+  );
+}
+
 // ── Skill Frontmatter Parser ─────────────────────────────────────────────────
 
 function parseSkillFrontmatter(content, filename) {
@@ -1631,6 +1707,8 @@ module.exports = {
   getAdoOrgBase,
   sanitizePath,
   sanitizeBranch,
+  validateProjectName,
+  validateProjectPath,
   validatePid,
   parseSkillFrontmatter,
   sleepMs,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -435,6 +435,165 @@ async function testValidatePid() {
   });
 }
 
+async function testValidateProjectName() {
+  console.log('\n── shared.js — Project Name Validation (SEC-04) ──');
+
+  await test('validateProjectName accepts valid names', () => {
+    assert.strictEqual(shared.validateProjectName('minions'), 'minions');
+    assert.strictEqual(shared.validateProjectName('my-project'), 'my-project');
+    assert.strictEqual(shared.validateProjectName('my_project'), 'my_project');
+    assert.strictEqual(shared.validateProjectName('Project123'), 'Project123');
+    assert.strictEqual(shared.validateProjectName('a'), 'a');
+    // 64-char max is accepted
+    const max = 'a'.repeat(64);
+    assert.strictEqual(shared.validateProjectName(max), max);
+  });
+
+  await test('validateProjectName rejects empty / non-string', () => {
+    assert.throws(() => shared.validateProjectName(''), /required|Invalid/);
+    assert.throws(() => shared.validateProjectName(null), /required|Invalid/);
+    assert.throws(() => shared.validateProjectName(undefined), /required|Invalid/);
+    assert.throws(() => shared.validateProjectName(123), /required|Invalid/);
+    assert.throws(() => shared.validateProjectName({}), /required|Invalid/);
+  });
+
+  await test('validateProjectName rejects names longer than 64 characters', () => {
+    const tooLong = 'a'.repeat(65);
+    const err = assert.throws(() => shared.validateProjectName(tooLong), /Invalid project name/);
+    // Violating name should appear in the error message
+    try { shared.validateProjectName(tooLong); } catch (e) {
+      assert.ok(e.message.includes(tooLong) || e.message.includes('65'), `expected message to cite violating name; got: ${e.message}`);
+      assert.strictEqual(e.statusCode, 400, 'should carry HTTP 400 statusCode');
+    }
+  });
+
+  await test('validateProjectName rejects path-traversal characters', () => {
+    assert.throws(() => shared.validateProjectName('../etc/passwd'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('..'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo/bar'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo\\bar'), /Invalid project name/);
+  });
+
+  await test('validateProjectName rejects shell metacharacters', () => {
+    assert.throws(() => shared.validateProjectName('foo;rm -rf /'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo$(whoami)'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo`id`'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo|cat'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo&bar'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo bar'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo.bar'), /Invalid project name/);
+    assert.throws(() => shared.validateProjectName('foo\0bar'), /Invalid project name/);
+  });
+
+  await test('validateProjectName error carries statusCode 400 and violating name', () => {
+    try {
+      shared.validateProjectName('bad/name');
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.strictEqual(e.statusCode, 400);
+      assert.ok(e.message.includes('bad/name'), `expected violating name in error; got: ${e.message}`);
+    }
+  });
+}
+
+async function testValidateProjectPath() {
+  console.log('\n── shared.js — Project Path Validation (SEC-05) ──');
+
+  await test('validateProjectPath accepts path containing .git directory', () => {
+    const tmp = createTmpDir();
+    fs.mkdirSync(path.join(tmp, '.git'), { recursive: true });
+    const result = shared.validateProjectPath(tmp);
+    assert.strictEqual(result, path.resolve(tmp));
+  });
+
+  await test('validateProjectPath accepts path containing .git file (worktree)', () => {
+    const tmp = createTmpDir();
+    fs.writeFileSync(path.join(tmp, '.git'), 'gitdir: /some/main/repo/.git/worktrees/wt');
+    const result = shared.validateProjectPath(tmp);
+    assert.strictEqual(result, path.resolve(tmp));
+  });
+
+  await test('validateProjectPath rejects non-existent path', () => {
+    const missing = path.join(os.tmpdir(), 'minions-test-nonexistent-' + Date.now());
+    try {
+      shared.validateProjectPath(missing);
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.strictEqual(e.statusCode, 400);
+      assert.ok(/does not exist|not found/i.test(e.message), `expected not-found message; got: ${e.message}`);
+    }
+  });
+
+  await test('validateProjectPath rejects empty / non-string path', () => {
+    assert.throws(() => shared.validateProjectPath(''), /required|Invalid/);
+    assert.throws(() => shared.validateProjectPath(null), /required|Invalid/);
+    assert.throws(() => shared.validateProjectPath(undefined), /required|Invalid/);
+    assert.throws(() => shared.validateProjectPath(123), /required|Invalid/);
+  });
+
+  await test('validateProjectPath rejects non-repo path without confirmation', () => {
+    const tmp = createTmpDir();
+    try {
+      shared.validateProjectPath(tmp);
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.strictEqual(e.statusCode, 400);
+      assert.ok(/not a git repository|\.git/i.test(e.message), `expected non-repo error; got: ${e.message}`);
+      assert.strictEqual(e.needsConfirmation, true);
+    }
+  });
+
+  await test('validateProjectPath rejects non-repo path when allowNonRepo missing', () => {
+    const tmp = createTmpDir();
+    assert.throws(
+      () => shared.validateProjectPath(tmp, { confirmToken: 'anything', isValidToken: () => true }),
+      /not a git repository/i,
+    );
+  });
+
+  await test('validateProjectPath rejects non-repo path with wrong confirmation token', () => {
+    const tmp = createTmpDir();
+    const validToken = 'deadbeef-dead-beef-dead-beefdeadbeef';
+    assert.throws(
+      () => shared.validateProjectPath(tmp, {
+        allowNonRepo: true,
+        confirmToken: 'wrong-token',
+        isValidToken: t => t === validToken,
+      }),
+      /not a git repository|invalid.*token/i,
+    );
+  });
+
+  await test('validateProjectPath rejects non-repo path with allowNonRepo but no token', () => {
+    const tmp = createTmpDir();
+    assert.throws(
+      () => shared.validateProjectPath(tmp, { allowNonRepo: true, isValidToken: () => true }),
+      /not a git repository|token/i,
+    );
+  });
+
+  await test('validateProjectPath accepts non-repo path with allowNonRepo + valid token', () => {
+    const tmp = createTmpDir();
+    const validToken = 'deadbeef-dead-beef-dead-beefdeadbeef';
+    let consumedToken = null;
+    const result = shared.validateProjectPath(tmp, {
+      allowNonRepo: true,
+      confirmToken: validToken,
+      isValidToken: t => { consumedToken = t; return t === validToken; },
+    });
+    assert.strictEqual(result, path.resolve(tmp));
+    assert.strictEqual(consumedToken, validToken, 'validator should have invoked isValidToken with the supplied token');
+  });
+
+  await test('validateProjectPath ignores allowNonRepo when path IS a git repo', () => {
+    // Defense in depth: if the path is a real git repo, confirmation logic is irrelevant.
+    const tmp = createTmpDir();
+    fs.mkdirSync(path.join(tmp, '.git'), { recursive: true });
+    const result = shared.validateProjectPath(tmp, { allowNonRepo: true, confirmToken: 'whatever', isValidToken: () => false });
+    assert.strictEqual(result, path.resolve(tmp));
+  });
+}
+
 async function testParseStreamJsonOutput() {
   console.log('\n── shared.js — Claude Output Parsing ──');
 
@@ -11070,6 +11229,8 @@ async function main() {
     await testBranchSanitization();
     await testSanitizePath();
     await testValidatePid();
+    await testValidateProjectName();
+    await testValidateProjectPath();
     await testParseStreamJsonOutput();
     await testClassifyInboxItem();
     await testSkillFrontmatter();


### PR DESCRIPTION
## Summary

Hardens `POST /api/projects/add` against the two security gaps called out in P-b8e1f4a2:

- **SEC-04 — project name validation.** `validateProjectName(name)` enforces allowlist `/^[a-zA-Z0-9_\-]{1,64}$/`. Rejects path separators, dots, whitespace, shell metacharacters, null bytes, and names >64 chars. Previously a caller could POST `name: "../foo"` or `name: "x$(id)"` and have it propagate into worktree paths and project state filenames.
- **SEC-05 — project path validation.** `validateProjectPath(pathStr, options)` requires `fs.existsSync(path.join(pathStr, '.git'))` (accepts both `.git` directories and `.git` files for worktrees). Non-repo paths only pass when the caller supplies `allowNonRepo: true` + a single-use UUID confirmation token minted by the new `POST /api/projects/confirm-token` endpoint (5-min TTL, memory-only, single-use). Implements the D-5 team recommendation (Rebecca's UUID vote).

Both validators run **before any config.json mutation** — rejected requests leave no side effects. Auto-detected names (from `package.json` / directory basename) also flow through the name validator, so a hostile repo on disk can't inject metacharacters either.

## Changes

- `engine/shared.js` — adds `validateProjectName` and `validateProjectPath`, exported from the module.exports block. Private `_httpError(status, msg, extra)` helper keeps error shape consistent (`statusCode`, optional `needsConfirmation`).
- `dashboard.js` — adds in-memory token store (`Map<token, expiresAt>` with 5-min TTL), `handleProjectsConfirmToken`, and wires both validators into `handleProjectsAdd` before any disk I/O beyond the validator's own `fs.existsSync`. New route registered in the routes table.
- `test/unit.test.js` — 16 new unit tests for the two validators.

## Build & Test

- `node test/unit.test.js` — **2462 passed / 1 failed / 3 skipped**. The 1 failure (`Metrics JSON has valid structure: dallas missing tasksCompleted`) is pre-existing on master (verified via `git stash` — master also shows 1 failed, same test). Net delta: +16 new tests, all passing.
- `node -c dashboard.js && node -c engine/shared.js` — syntax check clean.

## Test plan

- [ ] `POST /api/projects/add` with a valid existing git repo still succeeds (no regression).
- [ ] `POST /api/projects/add` with `name: "../etc/passwd"` returns 400 with the violating name quoted.
- [ ] `POST /api/projects/add` with a 65-char name returns 400.
- [ ] `POST /api/projects/add` with a non-repo path returns 400 + `needsConfirmation: true`.
- [ ] `POST /api/projects/confirm-token` → use returned `confirmToken` in a second `POST /api/projects/add` with `allowNonRepo: true` → registers the non-repo path.
- [ ] Replaying the same token a second time returns 400 (single-use).
- [ ] `POST /api/projects/add` with a 6-minute-old token returns 400 (TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)