### PR TITLE
fix: auto-fetch PR title on link-pr (closes #1283)

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -4859,7 +4859,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
           mutateJsonFileLocked(prPath, (prs) => {
             const pr = prs.find(p => p.id === prId);
             if (!pr) return prs;
-            if (!title && prData.title) pr.title = prData.title.slice(0, 120);
+            // Remote title always wins — any user-supplied title is a placeholder (closes #1283)
+            if (prData.title) pr.title = prData.title.slice(0, 120);
             if (prData.description) pr.description = prData.description.slice(0, 500);
             if (!pr.branch && prData.branch) pr.branch = prData.branch;
             if (pr.agent === 'human' && prData.author) pr.agent = prData.author;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9011,6 +9011,33 @@ async function testRecentFeatures() {
       'Should support autoObserve (dispatched) vs context-only (polled but no dispatch)');
   });
 
+  await test('PR link enrichment always overrides title from remote (closes #1283)', () => {
+    // Find the link handler — starts at the route path and runs to '{ method:' for next route
+    const start = dashSrc.indexOf("/api/pull-requests/link'");
+    assert.ok(start > 0, 'link handler must exist');
+    // Scan forward until the next route declaration
+    const next = dashSrc.indexOf("{ method: 'POST', path: '/api/pull-requests/delete'", start);
+    assert.ok(next > start, 'delete handler must come after link handler');
+    const linkHandler = dashSrc.slice(start, next);
+
+    // Enrichment must call fetchAdoPrMetadata or gh api to get remote metadata
+    assert.ok(
+      linkHandler.includes('fetchAdoPrMetadata') || linkHandler.includes('gh api'),
+      'link handler must call remote API to fetch PR metadata'
+    );
+    // Title override must NOT be gated on user-supplied title being empty — real title always wins
+    assert.ok(
+      !/if\s*\(\s*!title\s*&&\s*prData\.title\s*\)/.test(linkHandler),
+      'link handler must NOT gate title override on !title — remote title must always win over user placeholder (closes #1283)'
+    );
+    // Title override must still exist, just unconditional on prData.title presence
+    assert.ok(
+      /prData\.title\s*\)\s*pr\.title\s*=/.test(linkHandler)
+        || /pr\.title\s*=\s*prData\.title/.test(linkHandler),
+      'link handler must still assign pr.title from prData.title when remote returns a title'
+    );
+  });
+
   // Plan creation from dashboard
   await test('POST /api/plans/create endpoint exists', () => {
     assert.ok(dashSrc.includes('/api/plans/create'),


### PR DESCRIPTION
Closes yemi33/minions#1283

## What was broken

The `/api/pull-requests/link` handler does async enrichment after the initial write — it calls `gh api` (GitHub) or `ado.fetchAdoPrMetadata` (ADO) and merges the response back into `pull-requests.json`. But the title-update was gated on the user-supplied title being empty:

```js
if (!title && prData.title) pr.title = prData.title.slice(0, 120);
```

Any non-empty placeholder — including CC-supplied values — blocked the real remote title from ever being applied. The form label `"Short description (optional — auto-detected from URL)"` confirms the user-typed title was only ever meant as a provisional placeholder until remote enrichment completed.

## The fix

Drop the `!title &&` guard. One-line change in `dashboard.js:4862`:

```js
// Remote title always wins — any user-supplied title is a placeholder (closes #1283)
if (prData.title) pr.title = prData.title.slice(0, 120);
```

Other enrichment fields (`description`, `branch`, `author`) already had the correct semantics — only `title` had this gating bug.

## Why keep the async pattern

Making the fetch synchronous before the initial write would block the HTTP response on a remote API call (network RTT + ADO token acquisition). The existing pattern writes a placeholder, responds fast, then updates — which is fine once the title-override bug is gone.

## Fallback behavior

If `fetchAdoPrMetadata` returns null (ADO token unavailable) or `gh api` throws, `prData` is falsy and the enrichment IIFE returns early — the user-supplied title (or default `"PR #N (polling...)"`) is preserved.

## Test plan

- [x] Wrote failing regression test first (TDD): `PR link enrichment always overrides title from remote (closes #1283)`. It extracts the link handler between route boundaries, asserts the remote-metadata fetch is still called, and asserts the `if (!title && prData.title)` gating pattern is gone.
- [x] Confirmed test fails against pre-fix source.
- [x] Confirmed test passes after the one-line fix.
- [x] Ran full unit suite: 2448 pass, 1 pre-existing failure ("Metrics JSON has valid structure: dallas missing tasksCompleted") unrelated to this change (verified via `git stash` round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)