### PR TITLE
Implement: SEC-13: Prototype pollution guard in readBody

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1287,7 +1287,20 @@ function readBody(req) {
       reject(new Error('Request body timeout after 30s'));
     }, 30000);
     req.on('data', chunk => { body += chunk; if (body.length > 1e6) { clearTimeout(timeout); reject(new Error('Too large')); } });
-    req.on('end', () => { clearTimeout(timeout); try { resolve(JSON.parse(body)); } catch(e) { reject(e); } });
+    req.on('end', () => {
+      clearTimeout(timeout);
+      let parsed;
+      try { parsed = JSON.parse(body); } catch(e) { reject(e); return; }
+      // Belt-and-braces: reject payloads containing prototype-pollution attack keys
+      // before they reach any downstream Object.assign / spread / deep-merge.
+      if (shared.hasDangerousKey(parsed)) {
+        const err = new Error('Request body contains forbidden key (__proto__, constructor, or prototype)');
+        err.statusCode = 400; // honoured by handler catch blocks so response is 400 regardless of handler
+        reject(err);
+        return;
+      }
+      resolve(parsed);
+    });
     req.on('error', (e) => { clearTimeout(timeout); reject(e); });
   });
 }
@@ -1514,7 +1527,7 @@ const server = http.createServer(async (req, res) => {
         }
       }
       return jsonReply(res, 200, { ok: true, message: 'Completion check ran but no verify task was needed' });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleWorkItemsRetry(req, res) {
@@ -1842,7 +1855,7 @@ const server = http.createServer(async (req, res) => {
         if (content) { try { allArchived.push(...JSON.parse(content).map(i => ({ ...i, _source: project.name }))); } catch {} }
       }
       return jsonReply(res, 200, allArchived);
-    } catch (e) { console.error('Archive fetch error:', e.message); return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { console.error('Archive fetch error:', e.message); return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleWorkItemsReopen(req, res) {
@@ -3467,7 +3480,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       }
       return jsonReply(res, 200, { ok: true, answer: answer + '\n\n(Read-only — changes not saved)', edited: false, actions });
       } finally { _docAbort = null; docChatInFlight.delete(docKey); }
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleInboxPersist(req, res) {
@@ -3655,7 +3668,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       }
       if (!selectedPath) return jsonReply(res, 200, { cancelled: true });
       return jsonReply(res, 200, { path: selectedPath.replace(/\\/g, '/') });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleProjectsAdd(req, res) {
@@ -3793,7 +3806,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       });
 
       return jsonReply(res, 200, { repos: results });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleFileBug(req, res) {
@@ -3928,7 +3941,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       } finally {
         _releaseCCTab(tabId);
       }
-    } catch (e) { _releaseCCTab(tabId); return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { _releaseCCTab(tabId); return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   /** Build a lightweight input object for SSE tool events — keeps only the fields formatToolSummary needs, with truncated string values. */
@@ -4141,8 +4154,16 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     } catch (e) {
       stopCcHeartbeat();
       _releaseCCTab(tabId);
-      writeCcEvent({ type: 'error', error: e.message });
-      _ccStreamEnded = true; try { res.end(); } catch {}
+      // If SSE headers haven't been sent yet (e.g. readBody guard fired), respond with the
+      // intended HTTP status (400 for prototype-pollution rejection) instead of an SSE event.
+      if (!res.headersSent) {
+        res.statusCode = e.statusCode || 500;
+        res.setHeader('Content-Type', 'application/json');
+        try { res.end(JSON.stringify({ error: e.message })); } catch {}
+      } else {
+        writeCcEvent({ type: 'error', error: e.message });
+        _ccStreamEnded = true; try { res.end(); } catch {}
+      }
     }
   }
 
@@ -4296,7 +4317,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
     try {
       const newPid = restartEngine();
       return jsonReply(res, 200, { ok: true, pid: newPid });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleSettingsRead(req, res) {
@@ -4320,7 +4341,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         })),
         routing,
       });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleSettingsUpdate(req, res) {
@@ -4462,7 +4483,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
         ? 'Settings saved. Some values were adjusted: ' + _clamped.join('; ')
         : 'Settings saved. Engine picks up changes on next tick.';
       return jsonReply(res, 200, { ok: true, message: msg, clamped: _clamped });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleSettingsRouting(req, res) {
@@ -4471,7 +4492,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       if (!body.content) return jsonReply(res, 400, { error: 'content required' });
       safeWrite(path.join(MINIONS_DIR, 'routing.md'), body.content);
       return jsonReply(res, 200, { ok: true });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleSettingsReset(req, res) {
@@ -4484,7 +4505,7 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       reloadConfig();
       invalidateStatusCache();
       return jsonReply(res, 200, { ok: true });
-    } catch (e) { return jsonReply(res, 500, { error: e.message }); }
+    } catch (e) { return jsonReply(res, e.statusCode || 500, { error: e.message }); }
   }
 
   async function handleHealth(req, res) {

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -1011,6 +1011,61 @@ function sanitizePath(file, baseDir) {
   return resolved;
 }
 
+// ── Prototype Pollution Guard ────────────────────────────────────────────────
+
+const _DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Detect the presence of prototype-pollution attack keys in a JSON-decoded payload.
+ *
+ * Belt-and-braces defence for endpoints that call `JSON.parse` on untrusted
+ * request bodies and then feed the result into `Object.assign`, spread, or
+ * deep-merge utilities. `JSON.parse` itself is safe — it installs `__proto__`
+ * as a regular own data property and does not mutate the prototype chain —
+ * but downstream code that shallow-merges the payload into a target object
+ * CAN elevate it into a prototype write.
+ *
+ * Contract is **rejection, not sanitization**: we inspect the top level plus
+ * one level deep and return a boolean. Deeper walks are intentionally skipped
+ * to avoid their own DoS pathologies on adversarial inputs.
+ *
+ * - Null / undefined / primitives → false.
+ * - Arrays are transparent: each element is checked at the same depth as the
+ *   array itself (an array does NOT consume a depth level).
+ * - Max object nesting inspected: 1. Dangerous keys at object-depth 2+
+ *   are intentionally NOT flagged.
+ * - Never mutates the input.
+ *
+ * @param {*} obj - any JSON-decoded value
+ * @param {number} [_depth=0] - internal recursion counter; do not pass externally
+ * @returns {boolean} true if any forbidden key is present at object-depth ≤ 1
+ */
+function hasDangerousKey(obj, _depth = 0) {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return false;
+
+  // Arrays are transparent — preserve depth when recursing into elements.
+  if (Array.isArray(obj)) {
+    for (const elt of obj) {
+      if (hasDangerousKey(elt, _depth)) return true;
+    }
+    return false;
+  }
+
+  // Object: check own keys at the current depth.
+  for (const key of Object.keys(obj)) {
+    if (_DANGEROUS_KEYS.has(key)) return true;
+  }
+
+  // Stop after one level of object nesting. Deeper recursion is an explicit
+  // non-goal (see DoS note in the header).
+  if (_depth >= 1) return false;
+
+  for (const v of Object.values(obj)) {
+    if (hasDangerousKey(v, _depth + 1)) return true;
+  }
+  return false;
+}
+
 /**
  * Validate that a PID value is a positive integer. Returns the numeric PID.
  * Throws if the value could be used for command injection.
@@ -1631,6 +1686,7 @@ module.exports = {
   getAdoOrgBase,
   sanitizePath,
   sanitizeBranch,
+  hasDangerousKey,
   validatePid,
   parseSkillFrontmatter,
   sleepMs,

--- a/test/minions-tests.js
+++ b/test/minions-tests.js
@@ -130,6 +130,33 @@ async function testApiEndpoints() {
     const r = await GET('/api/plans/..%2Fconfig.json');
     assert.strictEqual(r.status, 400);
   });
+
+  await test('Prototype pollution guard rejects __proto__ in request body', async () => {
+    // JSON.parse creates __proto__ as an own enumerable data property; JSON.stringify round-trips it.
+    const poisoned = JSON.parse('{"message":"hi","__proto__":{"polluted":true}}');
+    const r = await POST('/api/command-center', poisoned);
+    assert.strictEqual(r.status, 400, `expected 400, got ${r.status} (body: ${r.body})`);
+    assert.ok(r.json && /forbidden key/.test(r.json.error || ''),
+      `expected forbidden-key error, got: ${JSON.stringify(r.json)}`);
+    // Verify the native Object prototype was not mutated as a side effect
+    assert.strictEqual(({}).polluted, undefined, 'Object.prototype was polluted!');
+  });
+
+  await test('Prototype pollution guard rejects constructor in request body', async () => {
+    const r = await POST('/api/command-center', { message: 'hi', constructor: { bad: true } });
+    assert.strictEqual(r.status, 400, `expected 400, got ${r.status}`);
+    assert.ok(r.json && /forbidden key/.test(r.json.error || ''),
+      `expected forbidden-key error, got: ${JSON.stringify(r.json)}`);
+  });
+
+  await test('Prototype pollution guard allows clean request bodies', async () => {
+    // Use a fast endpoint that also goes through readBody — proves the guard doesn't over-trigger.
+    const r = await POST('/api/work-items', { title: 'Pollution guard — clean body', type: 'implement', priority: 'low' });
+    assert.strictEqual(r.status, 200, `expected 200, got ${r.status} (body: ${r.body})`);
+    assert.ok(r.json.id, 'expected an id on successful work-item create');
+    // Clean up so we don't leak test state
+    await POST('/api/work-items/delete', { id: r.json.id, source: 'central' });
+  });
 }
 
 async function testWorkItemCrud() {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -435,6 +435,93 @@ async function testValidatePid() {
   });
 }
 
+async function testHasDangerousKey() {
+  console.log('\n── shared.js — hasDangerousKey (Prototype Pollution Guard) ──');
+
+  await test('hasDangerousKey flags top-level __proto__', () => {
+    // JSON.parse creates __proto__ as own enumerable data property
+    const obj = JSON.parse('{"__proto__":{"x":1}}');
+    assert.strictEqual(shared.hasDangerousKey(obj), true);
+  });
+
+  await test('hasDangerousKey flags top-level constructor', () => {
+    assert.strictEqual(shared.hasDangerousKey({ constructor: 1 }), true);
+  });
+
+  await test('hasDangerousKey flags top-level prototype', () => {
+    assert.strictEqual(shared.hasDangerousKey({ prototype: null }), true);
+  });
+
+  await test('hasDangerousKey flags one-level-deep __proto__', () => {
+    const obj = JSON.parse('{"foo":{"__proto__":1}}');
+    assert.strictEqual(shared.hasDangerousKey(obj), true);
+  });
+
+  await test('hasDangerousKey flags one-level-deep constructor', () => {
+    assert.strictEqual(shared.hasDangerousKey({ foo: { constructor: 1 } }), true);
+  });
+
+  await test('hasDangerousKey flags one-level-deep prototype', () => {
+    assert.strictEqual(shared.hasDangerousKey({ foo: { prototype: {} } }), true);
+  });
+
+  await test('hasDangerousKey does NOT recurse beyond one level by design', () => {
+    // Two levels deep is intentionally ignored — guard is belt-and-braces, not deep sanitizer.
+    const obj = JSON.parse('{"foo":{"bar":{"__proto__":1}}}');
+    assert.strictEqual(shared.hasDangerousKey(obj), false);
+  });
+
+  await test('hasDangerousKey returns false for empty object', () => {
+    assert.strictEqual(shared.hasDangerousKey({}), false);
+  });
+
+  await test('hasDangerousKey returns false for null', () => {
+    assert.strictEqual(shared.hasDangerousKey(null), false);
+  });
+
+  await test('hasDangerousKey returns false for undefined', () => {
+    assert.strictEqual(shared.hasDangerousKey(undefined), false);
+  });
+
+  await test('hasDangerousKey returns false for primitives', () => {
+    assert.strictEqual(shared.hasDangerousKey('string'), false);
+    assert.strictEqual(shared.hasDangerousKey(42), false);
+    assert.strictEqual(shared.hasDangerousKey(true), false);
+    assert.strictEqual(shared.hasDangerousKey(false), false);
+  });
+
+  await test('hasDangerousKey returns false for plain safe object', () => {
+    assert.strictEqual(shared.hasDangerousKey({ a: 1, b: 'two', c: [1, 2, 3], d: { nested: true } }), false);
+  });
+
+  await test('hasDangerousKey flags arrays with dangerous elements (top-level treatment)', () => {
+    const arr = [JSON.parse('{"__proto__":{"x":1}}')];
+    assert.strictEqual(shared.hasDangerousKey(arr), true);
+  });
+
+  await test('hasDangerousKey flags arrays containing objects with forbidden keys', () => {
+    assert.strictEqual(shared.hasDangerousKey([{ constructor: 1 }]), true);
+    assert.strictEqual(shared.hasDangerousKey([{ prototype: null }]), true);
+  });
+
+  await test('hasDangerousKey returns false for arrays of primitives', () => {
+    assert.strictEqual(shared.hasDangerousKey([1, 2, 3]), false);
+    assert.strictEqual(shared.hasDangerousKey(['a', 'b', 'c']), false);
+    assert.strictEqual(shared.hasDangerousKey([]), false);
+  });
+
+  await test('hasDangerousKey returns false for arrays of safe objects', () => {
+    assert.strictEqual(shared.hasDangerousKey([{ a: 1 }, { b: 2 }]), false);
+  });
+
+  await test('hasDangerousKey does NOT mutate input', () => {
+    const obj = JSON.parse('{"__proto__":{"polluted":true}}');
+    const before = JSON.stringify(obj);
+    shared.hasDangerousKey(obj);
+    assert.strictEqual(JSON.stringify(obj), before);
+  });
+}
+
 async function testParseStreamJsonOutput() {
   console.log('\n── shared.js — Claude Output Parsing ──');
 
@@ -11070,6 +11157,7 @@ async function main() {
     await testBranchSanitization();
     await testSanitizePath();
     await testValidatePid();
+    await testHasDangerousKey();
     await testParseStreamJsonOutput();
     await testClassifyInboxItem();
     await testSkillFrontmatter();


### PR DESCRIPTION
## Summary

Implements PRD item **P-e5b2a7d8-b** — a belt-and-braces guard that rejects HTTP POST bodies containing `__proto__`, `constructor`, or `prototype` keys before the parsed body is handed to any handler.

- New pure helper `hasDangerousKey(obj)` in `engine/shared.js`. Arrays are transparent (they don't consume a depth level); object nesting caps at 1.
- Wired into `dashboard.js` `readBody`: on trigger, rejects with `err.statusCode = 400` and the exact message from the spec.
- Updated `catch (e) { jsonReply(res, 500, ...) }` patterns to honour `e.statusCode || 500`, including the SSE stream handler's pre-`writeHead` error path — so the guard consistently surfaces 400 regardless of which handler catches.

### Why this matters

`JSON.parse` itself is safe — it installs `__proto__` as a plain own data property and does not mutate the prototype chain. The risk is *downstream* code that shallow-merges the payload into a target via `Object.assign`, spread, or deep-merge utilities. Any such site can elevate the payload into a prototype write. Rather than audit every call site, we reject poisoned bodies at the single entrypoint.

### Spec compliance (TDD)

Every row of the unit-test table from the PRD is covered in `test/unit.test.js`:

| Input | Expected | Test |
|---|---|---|
| `{__proto__: {}}` | true | flags top-level __proto__ |
| `{constructor: 1}` | true | flags top-level constructor |
| `{prototype: null}` | true | flags top-level prototype |
| `{foo: {__proto__: 1}}` | true | flags one-level-deep __proto__ |
| `{foo: {bar: {__proto__: 1}}}` | false | does NOT recurse beyond one level by design |
| `{}` | false | empty object |
| `null` / `undefined` / primitives | false | non-objects |
| arrays with dangerous elements | true | transparent iteration |
| arrays of primitives | false | safe |

Plus: input-non-mutation assertion, arrays-of-objects tests, clean-body pass-through.

Integration tests in `test/minions-tests.js`:
- `POST /api/command-center` with `{"message":"hi","__proto__":{"polluted":true}}` → **400** with the forbidden-key error.
- `POST /api/command-center` with `{"message":"hi","constructor":{...}}` → **400**.
- Clean body POST (against a fast endpoint that shares `readBody`) → **200** (guard doesn't over-trigger).
- Asserts `Object.prototype` was NOT mutated as a side effect.

## Test plan

- [x] `npm test` — 2463/2464 pass. The single failure is pre-existing (`Metrics JSON has valid structure` reads live `metrics.json` and is state-dependent; unrelated to this PR).
- [x] 17 new `hasDangerousKey` unit tests all pass.
- [x] Behavioural end-to-end check via a mock-`req` harness confirmed the guard rejects with `statusCode=400`, the clean-body path resolves normally, and `Object.prototype` stays unpolluted.
- [ ] Integration tests (`test/minions-tests.js`) will pass once the dashboard is restarted with this branch's code; they currently red against the running master dashboard by design.

## Files changed

- `engine/shared.js` — `hasDangerousKey` helper + export
- `dashboard.js` — `readBody` guard; `e.statusCode`-aware catch blocks; SSE handler pre-headers error path
- `test/unit.test.js` — `testHasDangerousKey` (17 cases) + registration
- `test/minions-tests.js` — 3 integration cases in `testApiEndpoints`

🤖 Generated with [Claude Code](https://claude.com/claude-code)