### PR TITLE
fix: Pinned context optimistic save (closes #1295)

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -381,10 +381,15 @@ function _mtimesChanged(prev, curr) {
   return false;
 }
 
-function invalidateStatusCache() {
+function invalidateStatusCache(opts) {
   _fastState = null;
   _fastStateTs = 0;
-  // Slow state continues on its own TTL — not invalidated by mutations
+  // Slow state continues on its own TTL by default — mutations of slow-state data
+  // (pinned.md, schedules, etc.) must opt in via { includeSlow: true } for immediate visibility.
+  if (opts && opts.includeSlow) {
+    _slowState = null;
+    _slowStateTs = 0;
+  }
   _statusCache = null;
   _statusCacheJson = null;
   _statusCacheGzip = null;
@@ -4726,7 +4731,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       const levelTag = level === 'critical' ? '🔴 ' : level === 'warning' ? '🟡 ' : '';
       const entry = '\n\n### ' + levelTag + title + '\n\n' + content + '\n\n*Pinned by human on ' + new Date().toISOString().slice(0, 10) + '*';
       safeWrite(pinnedPath, (existing || '# Pinned Context\n\nCritical notes visible to all agents.') + entry);
-      invalidateStatusCache();
+      // pinned.md is in slow-state cache — opt-in invalidation so the new entry is visible immediately (closes #1295)
+      invalidateStatusCache({ includeSlow: true });
       return jsonReply(res, 200, { ok: true });
     }},
     { method: 'POST', path: '/api/pinned/remove', desc: 'Remove a pinned note by title', params: 'title', handler: async (req, res) => {
@@ -4739,7 +4745,8 @@ What would you like to discuss or change? When you're happy, say "approve" and I
       const regex = new RegExp('\\n\\n###\\s*(?:🔴\\s*|🟡\\s*)?' + title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\n[\\s\\S]*?(?=\\n\\n###|$)', 'i');
       content = content.replace(regex, '');
       safeWrite(pinnedPath, content);
-      invalidateStatusCache();
+      // pinned.md is in slow-state cache — opt-in invalidation so the unpin is visible immediately
+      invalidateStatusCache({ includeSlow: true });
       return jsonReply(res, 200, { ok: true });
     }},
 

--- a/dashboard/js/render-pinned.js
+++ b/dashboard/js/render-pinned.js
@@ -42,11 +42,37 @@ async function submitPinnedNote(e) {
   const level = document.getElementById('pin-level').value;
   if (!title || !content) { if (btn) { btn.disabled = false; btn.textContent = 'Pin Note'; } alert('Title and content required'); return; }
   try { closeModal(); } catch { /* may not be open */ }
+
+  // Optimistic render: append the new entry to the pinned list and re-render immediately
+  // so it appears without waiting for the POST round-trip or the next status refresh (closes #1295).
+  // Snapshot prevEntries so we can revert on failure.
+  const prevEntries = Array.isArray(window._pinnedEntries) ? window._pinnedEntries.slice() : [];
+  const newEntry = { title, content, level: level || 'info' };
+  const nextEntries = prevEntries.concat([newEntry]);
+  window._pinnedEntries = nextEntries;
+  try { renderPinned(nextEntries); } catch { /* DOM may be missing — non-fatal */ }
   showToast('cmd-toast', 'Note pinned', true);
+
   try {
     const res = await fetch('/api/pinned', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ title, content, level }) });
-    if (res.ok) { refresh(); } else { const d = await res.json().catch(() => ({})); showToast('cmd-toast', 'Pin failed: ' + (d.error || 'unknown'), false); openPinNoteModal(); }
-  } catch (e) { showToast('cmd-toast', 'Error: ' + e.message, false); openPinNoteModal(); }
+    if (res.ok) {
+      // Reconcile with server state (captures the normalised entry shape from parsePinnedEntries).
+      refresh();
+    } else {
+      // Revert optimistic update and surface the error.
+      window._pinnedEntries = prevEntries;
+      try { renderPinned(prevEntries); } catch { /* ignore */ }
+      const d = await res.json().catch(() => ({}));
+      showToast('cmd-toast', 'Pin failed: ' + (d.error || 'unknown'), false);
+      openPinNoteModal();
+    }
+  } catch (err) {
+    // Network failure — revert optimistic update.
+    window._pinnedEntries = prevEntries;
+    try { renderPinned(prevEntries); } catch { /* ignore */ }
+    showToast('cmd-toast', 'Error: ' + err.message, false);
+    openPinNoteModal();
+  }
 }
 
 async function removePinnedNote(title) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14355,6 +14355,65 @@ async function testDashboardAuditXss() {
     assert.ok(src.includes('this.dataset.pinTitle'), 'should read from dataset');
   });
 
+  await test('submitPinnedNote optimistically renders new entry before awaiting fetch (closes #1295)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-pinned.js'), 'utf8');
+    // Extract submitPinnedNote body up to next function or end
+    const m = src.match(/async function submitPinnedNote[\s\S]*?(?=\n(?:async )?function |\nwindow\.MinionsPinned)/);
+    assert.ok(m, 'submitPinnedNote must exist');
+    const body = m[0];
+    const renderPos = body.indexOf('renderPinned(');
+    const fetchPos = body.indexOf('fetch(');
+    assert.ok(renderPos > 0, 'submitPinnedNote must call renderPinned for optimistic update');
+    assert.ok(fetchPos > 0, 'submitPinnedNote must call fetch to persist');
+    assert.ok(renderPos < fetchPos,
+      'renderPinned must fire BEFORE fetch — manual entry should appear in list immediately (optimistic)');
+    assert.ok(body.includes('window._pinnedEntries'),
+      'must update window._pinnedEntries with new entry optimistically so subsequent renders preserve it');
+  });
+
+  await test('submitPinnedNote reverts optimistic state when POST /api/pinned fails (closes #1295)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-pinned.js'), 'utf8');
+    const m = src.match(/async function submitPinnedNote[\s\S]*?(?=\n(?:async )?function |\nwindow\.MinionsPinned)/);
+    assert.ok(m, 'submitPinnedNote must exist');
+    const body = m[0];
+    // Must capture a snapshot of previous entries so we can revert on failure
+    assert.ok(/prevEntries|previousEntries|priorEntries/.test(body),
+      'must snapshot previous entries for revert on failure');
+    // Must re-render with the revert snapshot in at least one error branch
+    const renderCalls = (body.match(/renderPinned\(/g) || []).length;
+    assert.ok(renderCalls >= 2,
+      'must re-render at least twice: optimistic + revert on failure');
+  });
+
+  await test('POST /api/pinned invalidates slow-state cache so newly pinned entry appears on next status fetch (closes #1295)', () => {
+    // Pinned entries live in _slowState (60s TTL). Without invalidating slow state,
+    // the dashboard would show stale pinned data for up to 60 seconds after pinning.
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const addIdx = src.indexOf("'POST', path: '/api/pinned'");
+    assert.ok(addIdx > 0, 'POST /api/pinned handler must exist');
+    // Handler body runs to the next top-level route entry
+    const block = src.slice(addIdx, addIdx + 1000);
+    assert.ok(/invalidateStatusCache\s*\(\s*\{[^}]*includeSlow\s*:\s*true/.test(block),
+      'POST /api/pinned must call invalidateStatusCache({ includeSlow: true }) — pinned lives in slow state');
+
+    const remIdx = src.indexOf("'/api/pinned/remove'");
+    assert.ok(remIdx > 0, 'POST /api/pinned/remove handler must exist');
+    const remBlock = src.slice(remIdx, remIdx + 1000);
+    assert.ok(/invalidateStatusCache\s*\(\s*\{[^}]*includeSlow\s*:\s*true/.test(remBlock),
+      'POST /api/pinned/remove must call invalidateStatusCache({ includeSlow: true }) so unpin is immediate');
+  });
+
+  await test('invalidateStatusCache supports includeSlow option for user mutations of slow-state data', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard.js'), 'utf8');
+    const m = src.match(/function invalidateStatusCache\s*\([^)]*\)[\s\S]*?^}/m);
+    assert.ok(m, 'invalidateStatusCache function must exist');
+    const body = m[0];
+    assert.ok(/includeSlow/.test(body),
+      'invalidateStatusCache should accept an includeSlow option to clear _slowState for user-initiated mutations');
+    assert.ok(/_slowState\s*=\s*null/.test(body),
+      'invalidateStatusCache must be able to clear _slowState when includeSlow is set');
+  });
+
   await test('render-inbox.js uses data attributes for item name in onclick', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-inbox.js'), 'utf8');
     assert.ok(src.includes('data-inbox-name'), 'should use data-inbox-name attribute');
@@ -26580,12 +26639,18 @@ async function testStatusCacheTiers() {
 
   // ── invalidateStatusCache invalidates fast state only ──
 
-  await test('invalidateStatusCache nullifies _fastState but not _slowState', () => {
-    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+  await test('invalidateStatusCache nullifies _fastState unconditionally and _slowState only on opt-in', () => {
+    const fn = dashSrc.match(/function invalidateStatusCache\s*\([^)]*\)[\s\S]*?^}/m);
     assert.ok(fn, 'invalidateStatusCache must exist');
     const body = fn[0];
-    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState');
-    assert.ok(!body.includes('_slowState = null'), 'must NOT nullify _slowState — slow state stays on its own TTL');
+    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState unconditionally');
+    // _slowState = null (if present) must be gated behind includeSlow — default TTL behaviour preserved
+    const slowIdx = body.indexOf('_slowState = null');
+    if (slowIdx > 0) {
+      const before = body.slice(0, slowIdx);
+      assert.ok(/includeSlow/.test(before),
+        '_slowState = null must be inside an includeSlow branch — default must leave slow state on its TTL');
+    }
   });
 
   // ── mtime tracking applies to fast state only ──
@@ -26698,7 +26763,7 @@ async function testStatusGzipCache() {
   });
 
   await test('invalidateStatusCache clears _statusCacheGzip', () => {
-    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+    const fn = dashSrc.match(/function invalidateStatusCache\s*\([^)]*\)[\s\S]*?^}/m);
     assert.ok(fn, 'invalidateStatusCache must exist');
     assert.ok(fn[0].includes('_statusCacheGzip = null') || fn[0].includes('_statusCacheGzip=null'),
       'invalidateStatusCache must clear _statusCacheGzip');
@@ -27021,7 +27086,7 @@ async function testStatusGzipCache() {
   });
 
   await test('invalidateStatusCache clears _statusCacheGzip', () => {
-    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+    const fn = dashSrc.match(/function invalidateStatusCache\s*\([^)]*\)[\s\S]*?^}/m);
     assert.ok(fn, 'invalidateStatusCache must exist');
     assert.ok(fn[0].includes('_statusCacheGzip = null') || fn[0].includes('_statusCacheGzip=null'),
       'invalidateStatusCache must clear _statusCacheGzip');
@@ -27091,12 +27156,18 @@ async function testStatusCacheTiers() {
 
   // ── invalidateStatusCache invalidates fast state only ──
 
-  await test('invalidateStatusCache nullifies _fastState but not _slowState', () => {
-    const fn = dashSrc.match(/function invalidateStatusCache\(\)[\s\S]*?^}/m);
+  await test('invalidateStatusCache nullifies _fastState unconditionally and _slowState only on opt-in', () => {
+    const fn = dashSrc.match(/function invalidateStatusCache\s*\([^)]*\)[\s\S]*?^}/m);
     assert.ok(fn, 'invalidateStatusCache must exist');
     const body = fn[0];
-    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState');
-    assert.ok(!body.includes('_slowState = null'), 'must NOT nullify _slowState — slow state stays on its own TTL');
+    assert.ok(body.includes('_fastState = null'), 'must nullify _fastState unconditionally');
+    // _slowState = null (if present) must be gated behind includeSlow — default TTL behaviour preserved
+    const slowIdx = body.indexOf('_slowState = null');
+    if (slowIdx > 0) {
+      const before = body.slice(0, slowIdx);
+      assert.ok(/includeSlow/.test(before),
+        '_slowState = null must be inside an includeSlow branch — default must leave slow state on its TTL');
+    }
   });
 
   // ── mtime tracking applies to fast state only ──


### PR DESCRIPTION
Closes #1295.

## Summary

When a user pins a note, the entry now appears in the list **immediately** instead of waiting up to ~64 s for the next status refresh to bubble back the new state.

## Why it was slow

Two independent gaps compounded:

1. **Client:** `submitPinnedNote` awaited `fetch('/api/pinned')` before any UI change. The list only updated on the next 4 s `refresh()` tick.
2. **Server:** `pinned.md` is rebuilt into `_slowState` (60 s TTL). Even with a fast `refresh()`, the newly-persisted entry was invisible for up to a minute because `invalidateStatusCache()` only cleared fast state.

## Fix

### `dashboard/js/render-pinned.js`
- `submitPinnedNote` now snapshots `window._pinnedEntries`, appends the new entry, calls `renderPinned()` synchronously, and only then fires the POST.
- On non-2xx or network failure: revert to the snapshot, re-render, show the error toast, and re-open the modal so the user doesn't lose their input.

### `dashboard.js`
- `invalidateStatusCache(opts)` accepts an opt-in `{ includeSlow: true }` flag that clears `_slowState` alongside `_fastState`. Default callers (dispatch mutations, work-item updates, etc.) are unchanged — slow state continues to use its own 60 s TTL.
- `POST /api/pinned` and `POST /api/pinned/remove` both opt in, so a subsequent `/api/status` rebuild surfaces the new state on the next tick rather than waiting for TTL expiry.

## Tests

Four new tests in `test/unit.test.js` assert:
- `renderPinned` fires **before** `fetch` (optimistic ordering).
- A snapshot is captured and `renderPinned` is called a second time on the failure path (revert).
- Both `POST /api/pinned` and `POST /api/pinned/remove` call `invalidateStatusCache({ includeSlow: true })`.
- `invalidateStatusCache` still gates `_slowState = null` behind the `includeSlow` branch (existing tests updated to reflect the new signature).

All 2469 unit tests pass.

## Test plan
- [ ] Pin a note in the dashboard — verify it appears instantly in the list without any visible refresh pause.
- [ ] Unpin a note — verify removal is instant and that a fresh `/api/status` fetch doesn't resurrect it for up to 60 s.
- [ ] Force a server 500 on `POST /api/pinned` — verify the optimistically-added entry disappears, the modal re-opens with the typed values, and the failure toast shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)