### PR TITLE
fix: ado merge-commit mismatch preserves prior buildStatus (closes #1233)

### DIFF
--- a/engine/ado.js
+++ b/engine/ado.js
@@ -449,7 +449,8 @@ async function pollPrStatus(config) {
         const mergeRef = encodeURIComponent(`refs/pull/${prNumber}/merge`);
         const buildsUrl = `${orgBase}/${project.adoProject}/_apis/build/builds?branchName=${mergeRef}&repositoryId=${project.repositoryId}&repositoryType=TfsGit&$top=25&api-version=7.1`;
         const buildsData = await adoFetch(buildsUrl, token);
-        const prBuilds = (buildsData?.value || []).filter(b => b.sourceVersion === mergeCommitId);
+        const allBuilds = buildsData?.value || [];
+        const prBuilds = allBuilds.filter(b => b.sourceVersion === mergeCommitId);
 
         if (prBuilds.length > 0) {
           buildStatus = classifyBuildStatus(prBuilds);
@@ -462,6 +463,17 @@ async function pollPrStatus(config) {
               _buildId: String(b.id),
             }));
           }
+        } else if (allBuilds.length > 0 && pr.buildStatus) {
+          // Stale merge-commit fallback — ADO returned builds for this PR's merge ref
+          // but none target the current `mergeCommitId`. Most likely the target branch
+          // moved, ADO recomputed the merge commit, but no new source-side changes
+          // triggered a rebuild. Preserve the previous `pr.buildStatus` so the tracker
+          // reflects the last known truth instead of flipping to a spurious 'none'.
+          // Also log a warn so stale states are detectable in engine logs. Issue #1233.
+          const sampleSv = (allBuilds[0]?.sourceVersion || '').slice(0, 8);
+          log('warn', `PR ${pr.id} build: merge-commit mismatch — ${allBuilds.length} build(s) on merge ref, none target current merge commit ${String(mergeCommitId).slice(0, 8)} (sample sourceVersion ${sampleSv}); preserving previous buildStatus '${pr.buildStatus}'`);
+          buildStatus = pr.buildStatus;
+          if (pr.buildFailReason) buildFailReason = pr.buildFailReason;
         }
       } catch (e) { log('warn', `ADO build query for ${pr.id}: ${e.message}`); }
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -19104,6 +19104,118 @@ async function testBuildErrorLogFeature() {
         `${label}: pr.lastBuildCheck = ts() must be followed by updated = true so the write is persisted`);
     }
   });
+
+  // ─── Stale merge-commit fallback #1233 (item 3) ────────────────────────────
+  //
+  // When a target-branch update causes ADO to recompute the PR's merge commit
+  // but no new CI builds are triggered (source-side unchanged), `buildsData`
+  // still returns recent builds for this PR — but none match the new
+  // `mergeCommitId`, so `prBuilds` is empty and `buildStatus` resets to 'none'.
+  // The dashboard then shows "none" even though the real-world state hasn't
+  // changed from failing/passing. Fix: detect this specific case (buildsData
+  // has entries but filter returns empty), log a warning, and preserve the
+  // previous `pr.buildStatus` so the tracker reflects the last known truth.
+
+  await test('ado.js detects stale merge-commit and preserves previous buildStatus (#1233)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    // Must check the mismatch condition: builds returned but none match
+    // sourceVersion. Accept either naming (`buildsData.value` directly or a
+    // renamed binding like `allBuilds`) and either condition ordering, but
+    // require the two facts to co-occur:
+    //   - the filtered prBuilds is empty
+    //   - the pre-filter list has entries (prevents firing the fallback when
+    //     there are simply no builds at all)
+    //   - the previous pr.buildStatus is consulted
+    const fallbackMismatchPattern = /(allBuilds|buildsData[?\s]*\.value)[^{;]{0,120}\.length\s*(>\s*0|>\s*=?\s*0)[\s\S]{0,120}pr\.buildStatus/;
+    const mismatchOrderFlipped = /prBuilds\.length\s*===\s*0[\s\S]{0,120}(allBuilds|buildsData[?\s]*\.value)[^{;]{0,120}\.length\s*>\s*0/;
+    assert.ok(fallbackMismatchPattern.test(src) || mismatchOrderFlipped.test(src),
+      'ado.js must detect the stale merge-commit case (builds list non-empty but prBuilds filter returns empty) AND consult pr.buildStatus');
+    // Must log a warn-level diagnostic so operators can spot stale states
+    const warnRegex = /log\(\s*['"]warn['"][^)]*(stale|mismatch|merge commit|merge-commit|no builds match)/i;
+    assert.ok(warnRegex.test(src),
+      'ado.js must log a warning when builds exist but none target the current merge commit');
+  });
+
+  await test('ado.js preserves pr.buildStatus on merge-commit mismatch instead of resetting to none (#1233)', () => {
+    const src = fs.readFileSync(path.join(MINIONS_DIR, 'engine', 'ado.js'), 'utf8');
+    // The fallback branch must assign the previous pr.buildStatus back to
+    // the local buildStatus variable so the subsequent transition guard
+    // does not fire a spurious 'failing → none' log and state change.
+    // Accept either `buildStatus = pr.buildStatus` or an equivalent early-return.
+    assert.ok(
+      /buildStatus\s*=\s*pr\.buildStatus/.test(src)
+      || /buildStatus\s*=\s*\(?\s*pr\.buildStatus\s*\|\|/.test(src),
+      'ado.js must reassign the local buildStatus to the previous pr.buildStatus when builds mismatch the current merge commit');
+  });
+
+  // Behavioral simulation — document the intended decision table.
+  //   buildsData.value | prBuilds (filtered) | prev pr.buildStatus | expected
+  //   empty            | empty               | failing             | 'none'         (no builds ever — honest)
+  //   1+ builds        | empty               | failing             | 'failing'      (preserve — stale merge commit)
+  //   1+ builds        | empty               | 'passing'           | 'passing'      (preserve)
+  //   1+ builds        | empty               | undefined           | 'none'         (no prior knowledge)
+  //   1+ builds        | 1+ matches          | failing             | classify matches
+  const applyBuildStatusResolution = (buildsValue, mergeCommitId, prevStatus) => {
+    let buildStatus = 'none';
+    const prBuilds = (buildsValue || []).filter(b => b.sourceVersion === mergeCommitId);
+    if (prBuilds.length > 0) {
+      // Classify deterministically for the test — mimic classifyBuildStatus roughly
+      const hasFailed = prBuilds.some(b => b.result === 'failed');
+      const allDone = prBuilds.every(b => b.status === 'completed');
+      if (hasFailed) buildStatus = 'failing';
+      else if (allDone) buildStatus = 'passing';
+      else buildStatus = 'running';
+    } else if ((buildsValue || []).length > 0 && prevStatus) {
+      // Stale merge-commit fallback
+      buildStatus = prevStatus;
+    }
+    return buildStatus;
+  };
+
+  await test('behavioral: buildsData empty + prev failing → none (no builds ever)', () => {
+    assert.strictEqual(
+      applyBuildStatusResolution([], 'abc123', 'failing'),
+      'none',
+      'When ADO has no builds at all, report none regardless of prior status');
+  });
+
+  await test('behavioral: builds exist but none match merge commit + prev failing → failing (#1233)', () => {
+    const builds = [
+      { sourceVersion: 'old-merge-hash-1', result: 'failed', status: 'completed' },
+      { sourceVersion: 'old-merge-hash-2', result: 'succeeded', status: 'completed' },
+    ];
+    assert.strictEqual(
+      applyBuildStatusResolution(builds, 'new-merge-hash', 'failing'),
+      'failing',
+      'Stale merge commit: preserve previous failing status so dashboard does not show spurious none');
+  });
+
+  await test('behavioral: builds exist but none match merge commit + prev passing → passing (#1233)', () => {
+    const builds = [{ sourceVersion: 'old', result: 'succeeded', status: 'completed' }];
+    assert.strictEqual(
+      applyBuildStatusResolution(builds, 'new', 'passing'),
+      'passing',
+      'Stale merge commit: preserve previous passing status');
+  });
+
+  await test('behavioral: builds exist but none match merge commit + no prior status → none (#1233)', () => {
+    const builds = [{ sourceVersion: 'old', result: 'succeeded', status: 'completed' }];
+    assert.strictEqual(
+      applyBuildStatusResolution(builds, 'new', undefined),
+      'none',
+      'First poll with mismatched builds and no prior status: stay at none (nothing to preserve)');
+  });
+
+  await test('behavioral: builds match current merge commit → classify matched builds, ignore previous (#1233)', () => {
+    const builds = [
+      { sourceVersion: 'current-merge', result: 'succeeded', status: 'completed' },
+      { sourceVersion: 'old-merge',     result: 'failed',    status: 'completed' },
+    ];
+    assert.strictEqual(
+      applyBuildStatusResolution(builds, 'current-merge', 'failing'),
+      'passing',
+      'When builds match the current merge commit, classify those builds — do not fall back to previous status');
+  });
 }
 
 // ─── spawnEngine state preservation (#564) ──────────────────────────────────


### PR DESCRIPTION
Closes #1233 — the remaining item 3 (stale-state detection) not addressed by PR #1273.

## Problem (item 3 of #1233)

`pollPrStatus` filters ADO builds by `sourceVersion === mergeCommitId`. When a target-branch (master) update causes ADO to recompute the merge commit but no new source-side changes trigger a rebuild, the filter returns empty → `buildStatus` reset to `none` → dashboard misrepresents the PR until new builds complete, even though the underlying state (failing/passing) is unchanged.

PR #1273 already handled:
1. Don't clear `buildErrorLog` on `none` transitions
2. Write `lastBuildCheck = ts()` on every poll

This PR addresses:
3. **Detect the merge-commit mismatch and preserve the previous `pr.buildStatus`** (plus log a warning so stale states are visible in engine logs).

## Change

`engine/ado.js` `pollPrStatus`:

- Extract the pre-filter builds list (`allBuilds`) so we can distinguish "no builds at all" from "builds exist but none match current merge commit".
- In the else-if branch (`prBuilds.length === 0 && allBuilds.length > 0 && pr.buildStatus`), log a warn-level diagnostic with the mismatch details and reassign local `buildStatus` to the previous `pr.buildStatus`.
- Existing transition guard (`if (pr.buildStatus !== buildStatus)`) does not fire, so no spurious `failing → none` transitions, no downstream state wipes.
- First-poll behavior preserved via the `pr.buildStatus` truthiness guard — with no prior status, the fallback is skipped.

`engine/github.js` is not affected: GitHub's `check-runs` API keys off `prData.head.sha` (source SHA), not a merge commit, so the same "merge commit recomputed" scenario doesn't apply.

## Tests (+7 under `testBuildErrorLogFeature`)

- **Source patterns**: mismatch detection, warn log, buildStatus preservation.
- **Behavioral decision table** (`applyBuildStatusResolution`):
  - Empty buildsData + prev failing → `none` (no builds ever)
  - Builds exist but none match + prev failing → `failing` (preserve)
  - Builds exist but none match + prev passing → `passing` (preserve)
  - Builds exist but none match + no prior status → `none` (nothing to preserve)
  - Builds match current merge commit → classify matches, ignore previous

## Test plan

- [x] `node test/unit.test.js` — 2506 passed, 1 pre-existing unrelated failure (metrics.json structure — same failure noted in PR #1273 test plan)
- [x] All 7 new tests pass
- [x] Diff reviewed: no magic strings, no downgrade of any approved review status, no nested locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)