### PR TITLE
Implement P-e5b2a7d8-a: Header gate — Origin allowlist, Content-Type enforcement, security response headers

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1305,7 +1305,10 @@ function checkRateLimit(key, maxPerMinute) {
 
 function jsonReply(res, code, data, req) {
   res.setHeader('Content-Type', 'application/json');
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  // Access-Control-Allow-Origin is set ONCE by the server dispatcher prelude:
+  // `*` for GET/HEAD (read-only), never for mutating responses (Origin gate
+  // already blocked cross-origin POSTs). Setting it here would reopen the
+  // cross-origin write path.
   res.statusCode = code;
   const json = JSON.stringify(data);
   const ae = req && req.headers && req.headers['accept-encoding'] || '';
@@ -1425,15 +1428,93 @@ function restartEngine() {
 
 // -- Server --
 
+// Mutating HTTP methods that require Origin and Content-Type gating.
+// GET/HEAD/OPTIONS are treated as read-only/preflight and bypass these checks.
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
 const server = http.createServer(async (req, res) => {
-  // CORS preflight
+  // ── Security headers (applied to every response) ──────────────────────────
+  // Baseline CSP + clickjacking/mime/referrer protections. The dashboard HTML
+  // entry-point later overrides CSP for its inline <script>/<style> blocks;
+  // all API (JSON, text, SSE) responses inherit the strict CSP from here.
+  const _secHeaders = shared.buildSecurityHeaders();
+  for (const [k, v] of Object.entries(_secHeaders)) {
+    try { res.setHeader(k, v); } catch { /* headers may already be sent in rare error paths */ }
+  }
+
+  // ── Origin gate (mutating + OPTIONS preflight) ────────────────────────────
+  // Defense-in-depth against CSRF / DNS-rebinding: even though the dashboard
+  // binds to 127.0.0.1, a malicious page can coerce a user's browser to POST
+  // to localhost. We reject any mutating request whose Origin (or Referer, if
+  // Origin is absent) is not in the local allowlist. When both headers are
+  // absent (curl, CLI tooling, Node http.request without Origin) we allow the
+  // request to preserve existing local automation.
+  const _rawOrigin = req.headers['origin'];
+  const _rawReferer = req.headers['referer'];
+  const _isMutating = MUTATING_METHODS.has(req.method);
+
+  function _originGateReject(reason) {
+    console.warn(`[origin-gate] reject ${req.method} ${req.url} origin=${_rawOrigin || _rawReferer || '(none)'} reason=${reason}`);
+    res.statusCode = 403;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Origin not allowed' }));
+  }
+
+  // CORS preflight — echo validated origin; reject disallowed origins outright.
   if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    if (_rawOrigin) {
+      if (!shared.isAllowedOrigin(_rawOrigin)) { _originGateReject('preflight-origin'); return; }
+      res.setHeader('Access-Control-Allow-Origin', _rawOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
+    // Note: when Origin is absent (non-browser preflight), no ACAO is echoed —
+    // that's fine, only browsers care about ACAO and they always send Origin.
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     res.statusCode = 204;
     res.end();
     return;
+  }
+
+  // Mutating requests: enforce Origin allowlist (Origin first, Referer fallback).
+  if (_isMutating) {
+    if (_rawOrigin) {
+      if (!shared.isAllowedOrigin(_rawOrigin)) { _originGateReject('origin'); return; }
+    } else if (_rawReferer) {
+      if (!shared.isAllowedOrigin(_rawReferer)) { _originGateReject('referer'); return; }
+    }
+    // Neither Origin nor Referer present → legacy tooling (curl, Node.js) is allowed.
+
+    // Content-Type enforcement: require application/json on mutating requests.
+    // readBody() always expects JSON. Rejecting anything other than
+    // application/json closes the entire CSRF "simple request" loophole
+    // (text/plain, application/x-www-form-urlencoded, multipart/form-data are
+    // all cross-origin-postable without a preflight). DELETE with an empty
+    // body (Content-Length: 0) is exempt — it carries no payload to parse.
+    const ct = String(req.headers['content-type'] || '').toLowerCase();
+    const clen = parseInt(req.headers['content-length'] || '0', 10) || 0;
+    const hasBody = clen > 0 || req.headers['transfer-encoding'];
+    if (hasBody && !ct.startsWith('application/json')) {
+      res.statusCode = 415;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Content-Type must be application/json' }));
+      return;
+    }
+    // Empty-body mutating request (e.g. DELETE /api/cc-sessions/:id) with
+    // no Content-Type is allowed — no body, no CSRF-friendly payload.
+    if (!hasBody && ct && !ct.startsWith('application/json')) {
+      res.statusCode = 415;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Content-Type must be application/json' }));
+      return;
+    }
+  }
+
+  // GET: permit cross-origin reads for external monitoring tools (curl, uptime
+  // checks). Mutating responses deliberately do NOT set ACAO — cross-origin
+  // browsers cannot use them anyway (Origin check blocks that path).
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
   }
 
   // ── Route Handler Functions ───────────────────────────────────────────────
@@ -2271,6 +2352,20 @@ const server = http.createServer(async (req, res) => {
   }
 
   async function handleAgentLiveStream(req, res, match) {
+    // SSE Origin gate — must run BEFORE res.writeHead(200, ...) so we can
+    // still return a 403 with a normal status line. Once we upgrade to SSE
+    // the client has no way to distinguish a rejection from a dropped stream.
+    // GETs normally skip the Origin check, but SSE streams are long-lived and
+    // warrant the same cross-origin guard as mutating endpoints.
+    const _origin = req.headers['origin'];
+    if (_origin && !shared.isAllowedOrigin(_origin)) {
+      console.warn(`[sse-origin-gate] reject GET ${req.url} origin=${_origin}`);
+      res.statusCode = 403;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Origin not allowed' }));
+      return;
+    }
+
     const agentId = match[1];
     const agentDir = path.join(MINIONS_DIR, 'agents', agentId);
     const liveLogPath = path.join(agentDir, 'live-output.log');
@@ -3944,6 +4039,18 @@ What would you like to discuss or change? When you're happy, say "approve" and I
   }
 
   async function handleCommandCenterStream(req, res) {
+    // SSE Origin gate (belt-and-suspenders: the top-level dispatcher has
+    // already rejected disallowed origins on POST, but validate again here
+    // before res.writeHead(200, text/event-stream) so any future refactor
+    // that moves the route can't accidentally bypass the check).
+    const _origin = req.headers['origin'];
+    if (_origin && !shared.isAllowedOrigin(_origin)) {
+      console.warn(`[sse-origin-gate] reject POST /api/command-center/stream origin=${_origin}`);
+      res.statusCode = 403;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Origin not allowed' }));
+      return;
+    }
     if (checkRateLimit('command-center', 10)) { res.statusCode = 429; res.end('Rate limited'); return; }
     let tabId;
     let _ccStreamAbort = null;
@@ -5277,6 +5384,20 @@ What would you like to discuss or change? When you're happy, say "approve" and I
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('ETag', HTML_ETAG);
   res.setHeader('Cache-Control', 'no-cache'); // revalidate each time, but use 304 if unchanged
+  // The SPA ships as a single self-contained HTML: inline <script> block,
+  // inline <style> block, and many inline onclick= handlers on page
+  // fragments. Strict `script-src 'self'` would break every button. We
+  // relax the default CSP ONLY for the dashboard HTML entry-point — the
+  // strict CSP still applies to all /api/* responses (verified by tests).
+  // data: in img-src permits the inline SVG favicon (<link rel="icon" href="data:...">).
+  res.setHeader(
+    'Content-Security-Policy',
+    "default-src 'self'; " +
+    "script-src 'self' 'unsafe-inline'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' data:; " +
+    "connect-src 'self'"
+  );
   if (req.headers['if-none-match'] === HTML_ETAG) {
     res.statusCode = 304;
     res.end();

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -1029,6 +1029,56 @@ function sanitizeBranch(name) {
   return String(name).replace(/[^a-zA-Z0-9._\-\/]/g, '-').slice(0, 200);
 }
 
+// ── HTTP Origin Allowlist & Security Headers ─────────────────────────────────
+// Pure helpers used by dashboard.js to gate mutating requests against an
+// explicit allowlist of local origins and to attach uniform security response
+// headers. Extracted here so they're unit-testable without the HTTP server.
+
+// Allowed origin (scheme + host) — port-agnostic. Dashboard always binds to
+// 127.0.0.1:7331 locally; browser tabs may arrive as localhost, 127.0.0.1, or
+// IPv6 [::1] depending on how the user opened the page.
+// WHATWG URL keeps IPv6 brackets in `hostname`, so we compare against the
+// bracketed form `[::1]`. We also accept the bare form `::1` defensively.
+const _ALLOWED_ORIGIN_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const _ALLOWED_ORIGIN_SCHEMES = new Set(['http:']);
+
+/**
+ * Returns true if the origin-like header value (either an `Origin` header value
+ * such as `http://localhost:7331` or a full `Referer` URL) belongs to the local
+ * dashboard allowlist. Port-agnostic. Returns false for null/undefined/empty,
+ * the literal string `'null'` (sandboxed iframes, data: URIs), malformed URLs,
+ * non-http schemes, and any host not in the allowlist.
+ * @param {string|null|undefined} origin
+ * @returns {boolean}
+ */
+function isAllowedOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false;
+  const trimmed = origin.trim();
+  if (!trimmed || trimmed === 'null') return false;
+  let parsed;
+  try { parsed = new URL(trimmed); } catch { return false; }
+  if (!parsed.hostname) return false;
+  if (!_ALLOWED_ORIGIN_SCHEMES.has(parsed.protocol)) return false;
+  return _ALLOWED_ORIGIN_HOSTS.has(parsed.hostname);
+}
+
+/**
+ * Returns the baseline set of security response headers to apply on every HTTP
+ * response from the dashboard. Values match OWASP defaults for a same-origin
+ * SPA served from 127.0.0.1. The HTML entry-point response intentionally
+ * overrides CSP to allow its inline `<script>` / `<style>` blocks; API (JSON,
+ * SSE) responses inherit the strict CSP returned here.
+ * @returns {{[key:string]: string}}
+ */
+function buildSecurityHeaders() {
+  return {
+    'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'same-origin',
+  };
+}
+
 // ── Skill Frontmatter Parser ─────────────────────────────────────────────────
 
 function parseSkillFrontmatter(content, filename) {
@@ -1631,6 +1681,8 @@ module.exports = {
   getAdoOrgBase,
   sanitizePath,
   sanitizeBranch,
+  isAllowedOrigin,
+  buildSecurityHeaders,
   validatePid,
   parseSkillFrontmatter,
   sleepMs,

--- a/test/minions-tests.js
+++ b/test/minions-tests.js
@@ -13,23 +13,29 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const BASE = 'http://localhost:7331';
+const BASE = process.env.MINIONS_TEST_BASE || 'http://localhost:7331';
 const MINIONS_DIR = path.resolve(__dirname, '..');
 const PLANS_DIR = path.join(MINIONS_DIR, 'plans');
 const ENGINE_DIR = path.join(MINIONS_DIR, 'engine');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function httpReq(method, urlPath, body) {
+function httpReq(method, urlPath, body, opts = {}) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlPath, BASE);
-    const opts = { method, hostname: url.hostname, port: url.port, path: url.pathname, headers: {} };
-    if (body) {
-      const data = JSON.stringify(body);
-      opts.headers['Content-Type'] = 'application/json';
-      opts.headers['Content-Length'] = Buffer.byteLength(data);
+    const extraHeaders = opts.headers || {};
+    // opts.rawBody (string) takes precedence for Content-Type stress tests.
+    // opts.contentType overrides Content-Type (e.g. 'text/plain' to test 415).
+    const rawBody = opts.rawBody != null ? String(opts.rawBody) : (body ? JSON.stringify(body) : null);
+    const contentType = opts.contentType !== undefined ? opts.contentType : (body ? 'application/json' : null);
+    const reqOpts = { method, hostname: url.hostname, port: url.port, path: url.pathname + (url.search || ''), headers: { ...extraHeaders } };
+    if (rawBody != null) {
+      if (contentType !== null && contentType !== undefined && contentType !== '') {
+        reqOpts.headers['Content-Type'] = contentType;
+      }
+      reqOpts.headers['Content-Length'] = Buffer.byteLength(rawBody);
     }
-    const req = http.request(opts, res => {
+    const req = http.request(reqOpts, res => {
       let d = '';
       res.on('data', c => d += c);
       res.on('end', () => {
@@ -39,12 +45,12 @@ function httpReq(method, urlPath, body) {
     });
     req.on('error', reject);
     req.setTimeout(10000, () => { req.destroy(); reject(new Error('timeout')); });
-    if (body) req.write(JSON.stringify(body));
+    if (rawBody != null) req.write(rawBody);
     req.end();
   });
 }
-const GET = (p) => httpReq('GET', p);
-const POST = (p, b) => httpReq('POST', p, b);
+const GET = (p, opts) => httpReq('GET', p, null, opts);
+const POST = (p, b, opts) => httpReq('POST', p, b, opts);
 
 function readJson(fp) {
   try { return JSON.parse(fs.readFileSync(fp, 'utf8')); } catch { return null; }
@@ -472,6 +478,123 @@ async function testDataIntegrity() {
   });
 }
 
+async function testSecurityHeaders() {
+  console.log('\n── Security Headers & Origin Gate ──');
+
+  // 1. Security response headers on GET /api/status
+  await test('GET /api/status includes CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy', async () => {
+    const r = await GET('/api/status');
+    assert.strictEqual(r.status, 200);
+    const h = r.headers;
+    assert.ok(h['content-security-policy'], 'missing Content-Security-Policy');
+    assert.ok(h['content-security-policy'].includes("default-src 'self'"), 'CSP missing default-src');
+    assert.ok(h['content-security-policy'].includes("script-src 'self'"), 'CSP missing script-src');
+    // API responses must keep strict script-src (no 'unsafe-inline')
+    assert.ok(!/script-src[^;]*'unsafe-inline'/.test(h['content-security-policy']),
+      "API CSP must not allow 'unsafe-inline' scripts");
+    assert.strictEqual(h['x-frame-options'], 'DENY');
+    assert.strictEqual(h['x-content-type-options'], 'nosniff');
+    assert.strictEqual(h['referrer-policy'], 'same-origin');
+  });
+
+  // 2. POST with disallowed Origin → 403
+  await test('POST /api/command-center with Origin: https://evil.example returns 403', async () => {
+    const r = await POST('/api/command-center',
+      { message: 'hi', tabId: 'sec-test-bad-origin' },
+      { headers: { Origin: 'https://evil.example' } });
+    assert.strictEqual(r.status, 403, `expected 403, got ${r.status} body=${r.body}`);
+    assert.ok(r.json, 'response must be JSON');
+    assert.ok(/not allowed/i.test(r.json.error || ''), 'error must mention origin');
+  });
+
+  // 3. POST with valid localhost Origin → proceeds (not 403)
+  await test('POST /api/work-items with Origin: http://localhost:7331 succeeds (not blocked by origin gate)', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'Security test work item (safe to delete)', type: 'implement', priority: 'low' },
+      { headers: { Origin: 'http://localhost:7331' } });
+    assert.notStrictEqual(r.status, 403, 'valid localhost Origin must not be blocked');
+    assert.ok(r.status === 200 || r.status === 201, `unexpected status ${r.status} body=${r.body}`);
+    // Clean up the test item
+    if (r.json && r.json.id) {
+      try { await POST('/api/work-items/delete', { id: r.json.id }); } catch {}
+    }
+  });
+
+  // 4. Content-Type enforcement — text/plain on POST → 415
+  await test('POST /api/command-center with Content-Type: text/plain returns 415', async () => {
+    const r = await POST('/api/command-center',
+      null,
+      { rawBody: JSON.stringify({ message: 'hi', tabId: 'sec-test-bad-ct' }),
+        contentType: 'text/plain',
+        headers: { Origin: 'http://localhost:7331' } });
+    assert.strictEqual(r.status, 415, `expected 415, got ${r.status} body=${r.body}`);
+    assert.ok(r.json && /application\/json/i.test(r.json.error || ''),
+      'error must mention application/json');
+  });
+
+  // 5. Missing Content-Type on POST → 415
+  await test('POST /api/command-center with no Content-Type returns 415', async () => {
+    const r = await POST('/api/command-center',
+      null,
+      { rawBody: JSON.stringify({ message: 'hi', tabId: 'sec-test-no-ct' }),
+        contentType: '',
+        headers: { Origin: 'http://localhost:7331' } });
+    assert.strictEqual(r.status, 415, `expected 415, got ${r.status} body=${r.body}`);
+  });
+
+  // 6. Content-Type: application/json → allowed (not 415, gate not triggered)
+  await test('POST /api/command-center with application/json Content-Type is not blocked by 415 gate', async () => {
+    const r = await POST('/api/command-center',
+      { message: 'hi', tabId: 'sec-test-good-ct' },
+      { headers: { Origin: 'http://localhost:7331' } });
+    // Might be 200, 400 (empty CC response), 429 (rate limit), 500 (LLM) — just NOT 415
+    assert.notStrictEqual(r.status, 415, 'application/json must not trigger 415');
+    assert.notStrictEqual(r.status, 403, 'valid origin must not trigger 403');
+  });
+
+  // 7. Second mutating endpoint: POST /api/work-items with evil Origin → 403
+  await test('POST /api/work-items with cross-origin header returns 403', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'should never be created', type: 'implement' },
+      { headers: { Origin: 'https://attacker.example.com' } });
+    assert.strictEqual(r.status, 403, `expected 403, got ${r.status} body=${r.body}`);
+  });
+
+  // 8. SSE endpoint Origin rejection — must 403 before upgrade
+  await test('GET /api/agent/dallas/live-stream with cross-origin header returns 403 (not SSE upgrade)', async () => {
+    const r = await GET('/api/agent/dallas/live-stream',
+      { headers: { Origin: 'https://evil.example' } });
+    assert.strictEqual(r.status, 403, `SSE must reject before upgrade; got ${r.status}`);
+    assert.ok(r.headers['content-type'] && r.headers['content-type'].includes('application/json'),
+      'rejection must be JSON, not text/event-stream');
+  });
+
+  // 9. Same-origin GET without Origin header is allowed (legacy tooling, polling)
+  await test('GET /api/status without Origin header is allowed', async () => {
+    const r = await GET('/api/status');
+    assert.strictEqual(r.status, 200);
+  });
+
+  // 10. POST without Origin and without Referer is allowed (curl / legacy tooling)
+  await test('POST /api/work-items with no Origin and no Referer is allowed (legacy curl)', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'Legacy curl test item (safe to delete)', type: 'implement', priority: 'low' });
+    assert.notStrictEqual(r.status, 403, 'no-origin requests must not be blocked');
+    assert.ok(r.status === 200 || r.status === 201, `unexpected status ${r.status}`);
+    if (r.json && r.json.id) {
+      try { await POST('/api/work-items/delete', { id: r.json.id }); } catch {}
+    }
+  });
+
+  // 11. POST with disallowed Referer (no Origin) → 403
+  await test('POST /api/work-items with disallowed Referer (no Origin) returns 403', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'should never be created', type: 'implement' },
+      { headers: { Referer: 'https://evil.example/attack.html' } });
+    assert.strictEqual(r.status, 403, `expected 403 on disallowed Referer, got ${r.status}`);
+  });
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -491,6 +614,7 @@ async function main() {
   }
 
   await testApiEndpoints();
+  await testSecurityHeaders();
   await testWorkItemCrud();
   await testPlanFlow();
   await testPrdFlow();

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -371,6 +371,134 @@ async function testBranchSanitization() {
   });
 }
 
+async function testIsAllowedOrigin() {
+  console.log('\n── shared.js — isAllowedOrigin (dashboard origin allowlist) ──');
+
+  // Allowed hosts — port-agnostic
+  await test('isAllowedOrigin accepts http://localhost without port', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://localhost:7331', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:7331'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://localhost:65535 (any port)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:65535'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://127.0.0.1 and http://127.0.0.1:3000', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1:3000'), true);
+  });
+
+  await test('isAllowedOrigin accepts IPv6 http://[::1] and http://[::1]:7331', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://[::1]'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://[::1]:7331'), true);
+  });
+
+  await test('isAllowedOrigin accepts Referer-style full URL (path ignored)', () => {
+    // Referer headers include the full URL; helper must tolerate path/query
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:7331/api/status'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1:7331/dashboard?x=1'), true);
+  });
+
+  // Disallowed hosts
+  await test('isAllowedOrigin rejects arbitrary public origins', () => {
+    assert.strictEqual(shared.isAllowedOrigin('https://evil.example'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://evil.example:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://attacker.localhost.com'), false);
+  });
+
+  await test('isAllowedOrigin rejects private-network hosts not on allowlist', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://10.0.0.1'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://192.168.1.5:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://0.0.0.0'), false);
+  });
+
+  await test('isAllowedOrigin rejects https scheme (allowlist is http-only for local dev)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('https://localhost:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('https://127.0.0.1'), false);
+  });
+
+  await test('isAllowedOrigin rejects non-http schemes (file, data, ws, chrome-extension)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('file:///etc/passwd'), false);
+    assert.strictEqual(shared.isAllowedOrigin('data:text/html,<script>1</script>'), false);
+    assert.strictEqual(shared.isAllowedOrigin('ws://localhost:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('chrome-extension://abc'), false);
+  });
+
+  // Null / empty / malformed
+  await test('isAllowedOrigin rejects null, undefined, empty, and non-string inputs', () => {
+    assert.strictEqual(shared.isAllowedOrigin(null), false);
+    assert.strictEqual(shared.isAllowedOrigin(undefined), false);
+    assert.strictEqual(shared.isAllowedOrigin(''), false);
+    assert.strictEqual(shared.isAllowedOrigin('   '), false);
+    assert.strictEqual(shared.isAllowedOrigin(42), false);
+    assert.strictEqual(shared.isAllowedOrigin({}), false);
+  });
+
+  await test('isAllowedOrigin rejects literal "null" (sandboxed iframe / data URI origin)', () => {
+    // Browsers send `Origin: null` for sandboxed iframes, opaque origins, data: URIs
+    assert.strictEqual(shared.isAllowedOrigin('null'), false);
+  });
+
+  await test('isAllowedOrigin rejects malformed URLs', () => {
+    assert.strictEqual(shared.isAllowedOrigin('notaurl'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http:// localhost'), false);
+    assert.strictEqual(shared.isAllowedOrigin('javascript:alert(1)'), false);
+  });
+
+  await test('isAllowedOrigin rejects subdomain-spoof attempts', () => {
+    // Prevents attacker.localhost or 127.0.0.1.evil.com from sneaking through
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost.evil.com'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1.nip.io'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://not-localhost'), false);
+  });
+}
+
+async function testBuildSecurityHeaders() {
+  console.log('\n── shared.js — buildSecurityHeaders ──');
+
+  await test('buildSecurityHeaders returns exactly the four required headers', () => {
+    const h = shared.buildSecurityHeaders();
+    assert.ok(h && typeof h === 'object', 'must return an object');
+    const keys = Object.keys(h).sort();
+    assert.deepStrictEqual(keys, [
+      'Content-Security-Policy',
+      'Referrer-Policy',
+      'X-Content-Type-Options',
+      'X-Frame-Options',
+    ], 'must return exactly the four required keys');
+  });
+
+  await test('buildSecurityHeaders returns strict CSP (self-only scripts, inline styles permitted)', () => {
+    const h = shared.buildSecurityHeaders();
+    const csp = h['Content-Security-Policy'];
+    assert.ok(csp.includes("default-src 'self'"), 'CSP must include default-src self');
+    assert.ok(csp.includes("script-src 'self'"), 'CSP must include script-src self');
+    assert.ok(csp.includes("style-src 'self' 'unsafe-inline'"), 'CSP must allow inline styles');
+    // script-src must NOT include 'unsafe-inline' — that would defeat XSS protection
+    assert.ok(!/script-src[^;]*'unsafe-inline'/.test(csp), "script-src must not allow 'unsafe-inline'");
+  });
+
+  await test('buildSecurityHeaders sets X-Frame-Options: DENY and nosniff + same-origin referrer', () => {
+    const h = shared.buildSecurityHeaders();
+    assert.strictEqual(h['X-Frame-Options'], 'DENY');
+    assert.strictEqual(h['X-Content-Type-Options'], 'nosniff');
+    assert.strictEqual(h['Referrer-Policy'], 'same-origin');
+  });
+
+  await test('buildSecurityHeaders returns a fresh object each call (no shared mutation)', () => {
+    const a = shared.buildSecurityHeaders();
+    const b = shared.buildSecurityHeaders();
+    assert.notStrictEqual(a, b, 'each call must return a distinct object');
+    a['X-Frame-Options'] = 'TAMPERED';
+    assert.strictEqual(b['X-Frame-Options'], 'DENY', 'mutation of one result must not affect a later call');
+  });
+}
+
 async function testSanitizePath() {
   console.log('\n── shared.js — Path Sanitization ──');
 
@@ -11068,6 +11196,8 @@ async function main() {
     await testSharedUtilities();
     await testIdGeneration();
     await testBranchSanitization();
+    await testIsAllowedOrigin();
+    await testBuildSecurityHeaders();
     await testSanitizePath();
     await testValidatePid();
     await testParseStreamJsonOutput();


### PR DESCRIPTION
## Summary

Closes browser-side CSRF / DNS-rebind attack paths on the dashboard HTTP server (`dashboard.js`).

- **Origin allowlist** on all mutating methods (POST/PUT/PATCH/DELETE). Cross-origin requests return 403 JSON. Referer fallback when Origin is absent. Legacy curl/tooling with neither header still passes (preserves local automation).
- **Content-Type enforcement**: mutating requests carrying a body must set `application/json`. Tightened past the spec's literal "absent or text/plain" rule to also block `x-www-form-urlencoded` / `multipart/form-data` — the full simple-request CSRF loophole. Bodyless DELETE (e.g. `/api/cc-sessions/:tabId`) is exempt.
- **Security response headers** set once at dispatcher entry — `Content-Security-Policy` (strict `script-src 'self'`), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: same-origin`. Dashboard HTML entry-point overrides CSP with inline-permissive values; all `/api/*` responses inherit the strict baseline (verified by integration test).
- **SSE Origin gate** in `handleAgentLiveStream` (GET) and `handleCommandCenterStream` (POST SSE) — validates Origin BEFORE `res.writeHead(200, text/event-stream)` so rejections are a normal 403 status line, not a dropped stream upgrade.
- `Access-Control-Allow-Origin: '*'` removed from `jsonReply` — set only on GET/HEAD responses by the dispatcher prelude. OPTIONS preflight echoes the validated Origin + `Vary: Origin` instead of `*`.
- **Pure helpers extracted** to `engine/shared.js`: `isAllowedOrigin(origin)` (port-agnostic WHATWG parse, IPv6-bracket aware, rejects literal `'null'`, subdomain-spoofs, non-http schemes) and `buildSecurityHeaders()` (fresh object per call).

## Test plan

- [x] Unit tests — `isAllowedOrigin` truth table (allowed, disallowed, null, IPv6 `[::1]`, malformed, subdomain spoofs, Referer-style URLs) + `buildSecurityHeaders` invariants (keys, strict script-src, fresh-object). `npm test` → 2464 passed / 1 pre-existing failure (unrelated metrics test).
- [x] Integration tests — 11 scenarios in `test/minions-tests.js`:
  - `POST /api/command-center` with `Origin: https://evil.example` → 403
  - `POST /api/work-items` with valid localhost Origin → 200
  - `POST /api/command-center` with `Content-Type: text/plain` → 415
  - `POST` with missing Content-Type (body present) → 415
  - `POST` with `application/json` → passes Origin + CT gates
  - `POST /api/work-items` with evil Origin → 403
  - `GET /api/agent/:id/live-stream` with cross-origin → 403 (JSON, not SSE)
  - `GET /api/status` includes all 4 security headers
  - `POST` with no Origin, no Referer → allowed (legacy curl)
  - `POST` with disallowed Referer (no Origin) → 403
- [x] Manual smoke against side-car dashboard on :7332 confirmed every gate. `BASE` in `test/minions-tests.js` now reads `MINIONS_TEST_BASE` env var so integration coverage can target a non-default port.

## Run instructions

```bash
# Unit tests
npm test

# Integration tests (needs dashboard running on 7331)
minions start
npm run test:all
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)