### PR TITLE
[E2E] Security fixes — dashboard auth/CSRF, XSS helper, token scrubber, input validation

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1305,7 +1305,10 @@ function checkRateLimit(key, maxPerMinute) {
 
 function jsonReply(res, code, data, req) {
   res.setHeader('Content-Type', 'application/json');
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  // Access-Control-Allow-Origin is set ONCE by the server dispatcher prelude:
+  // `*` for GET/HEAD (read-only), never for mutating responses (Origin gate
+  // already blocked cross-origin POSTs). Setting it here would reopen the
+  // cross-origin write path.
   res.statusCode = code;
   const json = JSON.stringify(data);
   const ae = req && req.headers && req.headers['accept-encoding'] || '';
@@ -1425,15 +1428,93 @@ function restartEngine() {
 
 // -- Server --
 
+// Mutating HTTP methods that require Origin and Content-Type gating.
+// GET/HEAD/OPTIONS are treated as read-only/preflight and bypass these checks.
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
 const server = http.createServer(async (req, res) => {
-  // CORS preflight
+  // ── Security headers (applied to every response) ──────────────────────────
+  // Baseline CSP + clickjacking/mime/referrer protections. The dashboard HTML
+  // entry-point later overrides CSP for its inline <script>/<style> blocks;
+  // all API (JSON, text, SSE) responses inherit the strict CSP from here.
+  const _secHeaders = shared.buildSecurityHeaders();
+  for (const [k, v] of Object.entries(_secHeaders)) {
+    try { res.setHeader(k, v); } catch { /* headers may already be sent in rare error paths */ }
+  }
+
+  // ── Origin gate (mutating + OPTIONS preflight) ────────────────────────────
+  // Defense-in-depth against CSRF / DNS-rebinding: even though the dashboard
+  // binds to 127.0.0.1, a malicious page can coerce a user's browser to POST
+  // to localhost. We reject any mutating request whose Origin (or Referer, if
+  // Origin is absent) is not in the local allowlist. When both headers are
+  // absent (curl, CLI tooling, Node http.request without Origin) we allow the
+  // request to preserve existing local automation.
+  const _rawOrigin = req.headers['origin'];
+  const _rawReferer = req.headers['referer'];
+  const _isMutating = MUTATING_METHODS.has(req.method);
+
+  function _originGateReject(reason) {
+    console.warn(`[origin-gate] reject ${req.method} ${req.url} origin=${_rawOrigin || _rawReferer || '(none)'} reason=${reason}`);
+    res.statusCode = 403;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Origin not allowed' }));
+  }
+
+  // CORS preflight — echo validated origin; reject disallowed origins outright.
   if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    if (_rawOrigin) {
+      if (!shared.isAllowedOrigin(_rawOrigin)) { _originGateReject('preflight-origin'); return; }
+      res.setHeader('Access-Control-Allow-Origin', _rawOrigin);
+      res.setHeader('Vary', 'Origin');
+    }
+    // Note: when Origin is absent (non-browser preflight), no ACAO is echoed —
+    // that's fine, only browsers care about ACAO and they always send Origin.
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     res.statusCode = 204;
     res.end();
     return;
+  }
+
+  // Mutating requests: enforce Origin allowlist (Origin first, Referer fallback).
+  if (_isMutating) {
+    if (_rawOrigin) {
+      if (!shared.isAllowedOrigin(_rawOrigin)) { _originGateReject('origin'); return; }
+    } else if (_rawReferer) {
+      if (!shared.isAllowedOrigin(_rawReferer)) { _originGateReject('referer'); return; }
+    }
+    // Neither Origin nor Referer present → legacy tooling (curl, Node.js) is allowed.
+
+    // Content-Type enforcement: require application/json on mutating requests.
+    // readBody() always expects JSON. Rejecting anything other than
+    // application/json closes the entire CSRF "simple request" loophole
+    // (text/plain, application/x-www-form-urlencoded, multipart/form-data are
+    // all cross-origin-postable without a preflight). DELETE with an empty
+    // body (Content-Length: 0) is exempt — it carries no payload to parse.
+    const ct = String(req.headers['content-type'] || '').toLowerCase();
+    const clen = parseInt(req.headers['content-length'] || '0', 10) || 0;
+    const hasBody = clen > 0 || req.headers['transfer-encoding'];
+    if (hasBody && !ct.startsWith('application/json')) {
+      res.statusCode = 415;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Content-Type must be application/json' }));
+      return;
+    }
+    // Empty-body mutating request (e.g. DELETE /api/cc-sessions/:id) with
+    // no Content-Type is allowed — no body, no CSRF-friendly payload.
+    if (!hasBody && ct && !ct.startsWith('application/json')) {
+      res.statusCode = 415;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Content-Type must be application/json' }));
+      return;
+    }
+  }
+
+  // GET: permit cross-origin reads for external monitoring tools (curl, uptime
+  // checks). Mutating responses deliberately do NOT set ACAO — cross-origin
+  // browsers cannot use them anyway (Origin check blocks that path).
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
   }
 
   // ── Route Handler Functions ───────────────────────────────────────────────
@@ -2271,6 +2352,20 @@ const server = http.createServer(async (req, res) => {
   }
 
   async function handleAgentLiveStream(req, res, match) {
+    // SSE Origin gate — must run BEFORE res.writeHead(200, ...) so we can
+    // still return a 403 with a normal status line. Once we upgrade to SSE
+    // the client has no way to distinguish a rejection from a dropped stream.
+    // GETs normally skip the Origin check, but SSE streams are long-lived and
+    // warrant the same cross-origin guard as mutating endpoints.
+    const _origin = req.headers['origin'];
+    if (_origin && !shared.isAllowedOrigin(_origin)) {
+      console.warn(`[sse-origin-gate] reject GET ${req.url} origin=${_origin}`);
+      res.statusCode = 403;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Origin not allowed' }));
+      return;
+    }
+
     const agentId = match[1];
     const agentDir = path.join(MINIONS_DIR, 'agents', agentId);
     const liveLogPath = path.join(agentDir, 'live-output.log');
@@ -3944,6 +4039,18 @@ What would you like to discuss or change? When you're happy, say "approve" and I
   }
 
   async function handleCommandCenterStream(req, res) {
+    // SSE Origin gate (belt-and-suspenders: the top-level dispatcher has
+    // already rejected disallowed origins on POST, but validate again here
+    // before res.writeHead(200, text/event-stream) so any future refactor
+    // that moves the route can't accidentally bypass the check).
+    const _origin = req.headers['origin'];
+    if (_origin && !shared.isAllowedOrigin(_origin)) {
+      console.warn(`[sse-origin-gate] reject POST /api/command-center/stream origin=${_origin}`);
+      res.statusCode = 403;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Origin not allowed' }));
+      return;
+    }
     if (checkRateLimit('command-center', 10)) { res.statusCode = 429; res.end('Rate limited'); return; }
     let tabId;
     let _ccStreamAbort = null;
@@ -5277,6 +5384,20 @@ What would you like to discuss or change? When you're happy, say "approve" and I
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('ETag', HTML_ETAG);
   res.setHeader('Cache-Control', 'no-cache'); // revalidate each time, but use 304 if unchanged
+  // The SPA ships as a single self-contained HTML: inline <script> block,
+  // inline <style> block, and many inline onclick= handlers on page
+  // fragments. Strict `script-src 'self'` would break every button. We
+  // relax the default CSP ONLY for the dashboard HTML entry-point — the
+  // strict CSP still applies to all /api/* responses (verified by tests).
+  // data: in img-src permits the inline SVG favicon (<link rel="icon" href="data:...">).
+  res.setHeader(
+    'Content-Security-Policy',
+    "default-src 'self'; " +
+    "script-src 'self' 'unsafe-inline'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' data:; " +
+    "connect-src 'self'"
+  );
   if (req.headers['if-none-match'] === HTML_ETAG) {
     res.statusCode = 304;
     res.end();

--- a/dashboard/js/render-agents.js
+++ b/dashboard/js/render-agents.js
@@ -4,23 +4,23 @@ function renderAgents(agents) {
   agentData = agents;
   const grid = document.getElementById('agents-grid');
   grid.innerHTML = agents.map(a => `
-    <div class="agent-card ${statusColor(a.status)}" onclick="if(shouldIgnoreSelectionClick(event))return;openAgentDetail('${escHtml(a.id)}')">
+    <div class="agent-card ${statusColor(a.status)}" onclick="if(shouldIgnoreSelectionClick(event))return;openAgentDetail('${escapeHtml(a.id)}')">
       <div class="agent-card-header">
-        <span class="agent-name"><span class="agent-emoji">${escHtml(a.emoji)}</span>${escHtml(a.name)}</span>
-        <span class="status-badge ${escHtml(a.status)}">${escHtml(a.status)}</span>
+        <span class="agent-name"><span class="agent-emoji">${escapeHtml(a.emoji)}</span>${escapeHtml(a.name)}</span>
+        <span class="status-badge ${escapeHtml(a.status)}">${escapeHtml(a.status)}</span>
       </div>
-      <div class="agent-role">${escHtml(a.role)}</div>
-      <div class="agent-action" title="${escHtml(a.lastAction)}">${escHtml(a.lastAction)}</div>
+      <div class="agent-role">${escapeHtml(a.role)}</div>
+      <div class="agent-action" title="${escapeHtml(a.lastAction)}">${escapeHtml(a.lastAction)}</div>
       ${(function() {
         var s = a.started_at, c = a.completed_at;
         if (s && c) { var d = new Date(c) - new Date(s); if (d > 0) { var sec = Math.floor(d/1000)%60, min = Math.floor(d/60000)%60, hr = Math.floor(d/3600000); return '<div style="font-size:9px;color:var(--muted)">Last run: ' + (hr > 0 ? hr + 'h ' : '') + min + 'm ' + sec + 's</div>'; } }
         if (s && a.status === 'working') return '<div class="agent-runtime-tick" data-started="' + s + '" style="font-size:9px;color:var(--yellow)"></div>';
         return '';
       })()}
-      ${a._blockingToolCall ? `<div style="margin-top:4px;padding:4px 8px;background:rgba(130,160,210,0.13);border:1px solid rgba(130,160,210,0.3);border-radius:4px;font-size:10px;color:var(--muted)">&#x23F3; Blocking tool call (${escHtml(a._blockingToolCall.tool)}) &mdash; silent ${Math.round(a._blockingToolCall.silentMs/60000)}min, timeout in ${Math.round(a._blockingToolCall.remainingMs/60000)}min</div>` : ''}
-      ${a._warning ? `<div style="margin-top:4px;padding:4px 8px;background:rgba(210,153,34,0.15);border:1px solid rgba(210,153,34,0.3);border-radius:4px;font-size:10px;color:var(--yellow)">&#x26A0; ${escHtml(a._warning)}</div>` : ''}
-      ${a._permissionMode && a._permissionMode !== 'bypassPermissions' && !a._warning ? `<div style="margin-top:4px;font-size:9px;color:var(--muted)">Permission mode: ${escHtml(a._permissionMode)}</div>` : ''}
-      ${a.resultSummary ? `<div class="agent-result" title="${escHtml(a.resultSummary)}">${renderMd(a.resultSummary.slice(0, 200))}${a.resultSummary.length > 200 ? '...' : ''}</div>` : ''}
+      ${a._blockingToolCall ? `<div style="margin-top:4px;padding:4px 8px;background:rgba(130,160,210,0.13);border:1px solid rgba(130,160,210,0.3);border-radius:4px;font-size:10px;color:var(--muted)">&#x23F3; Blocking tool call (${escapeHtml(a._blockingToolCall.tool)}) &mdash; silent ${Math.round(a._blockingToolCall.silentMs/60000)}min, timeout in ${Math.round(a._blockingToolCall.remainingMs/60000)}min</div>` : ''}
+      ${a._warning ? `<div style="margin-top:4px;padding:4px 8px;background:rgba(210,153,34,0.15);border:1px solid rgba(210,153,34,0.3);border-radius:4px;font-size:10px;color:var(--yellow)">&#x26A0; ${escapeHtml(a._warning)}</div>` : ''}
+      ${a._permissionMode && a._permissionMode !== 'bypassPermissions' && !a._warning ? `<div style="margin-top:4px;font-size:9px;color:var(--muted)">Permission mode: ${escapeHtml(a._permissionMode)}</div>` : ''}
+      ${a.resultSummary ? `<div class="agent-result" title="${escapeHtml(a.resultSummary)}">${renderMd(a.resultSummary.slice(0, 200))}${a.resultSummary.length > 200 ? '...' : ''}</div>` : ''}
     </div>
   `).join('');
 }
@@ -31,14 +31,23 @@ async function openAgentDetail(id) {
   currentAgentId = id;
   currentTab = (agent.status === 'working') ? 'live' : 'thought-process';
 
-  document.getElementById('detail-agent-name').innerHTML =
-    '<span style="font-size:22px">' + escHtml(agent.emoji) + '</span> ' + escHtml(agent.name) + ' — ' + escHtml(agent.role);
+  // SEC-03 Phase A: Build the detail header via DOM + textContent instead of innerHTML.
+  // Emoji, name and role are all user-controlled fields; routing them through textContent
+  // guarantees no HTML interpretation even if the escape function were ever bypassed.
+  const nameEl = document.getElementById('detail-agent-name');
+  const emojiSpan = document.createElement('span');
+  emojiSpan.style.fontSize = '22px';
+  emojiSpan.textContent = agent.emoji || '';
+  nameEl.replaceChildren(
+    emojiSpan,
+    document.createTextNode(' ' + (agent.name || '') + ' \u2014 ' + (agent.role || ''))
+  );
 
   const badgeClass = agent.status;
   document.getElementById('detail-status-line').innerHTML =
     '<span class="status-badge ' + badgeClass + '">' + agent.status.toUpperCase() + '</span> ' +
-    '<span style="color:var(--muted)">' + escHtml(agent.lastAction) + '</span>' +
-    (agent._blockingToolCall ? '<div style="margin-top:4px;padding:4px 8px;background:rgba(130,160,210,0.13);border:1px solid rgba(130,160,210,0.3);border-radius:4px;font-size:11px;color:var(--muted)">&#x23F3; Blocking tool call (' + escHtml(agent._blockingToolCall.tool) + ') &mdash; silent ' + Math.round(agent._blockingToolCall.silentMs/60000) + 'min, timeout in ' + Math.round(agent._blockingToolCall.remainingMs/60000) + 'min</div>' : '') +
+    '<span style="color:var(--muted)">' + escapeHtml(agent.lastAction) + '</span>' +
+    (agent._blockingToolCall ? '<div style="margin-top:4px;padding:4px 8px;background:rgba(130,160,210,0.13);border:1px solid rgba(130,160,210,0.3);border-radius:4px;font-size:11px;color:var(--muted)">&#x23F3; Blocking tool call (' + escapeHtml(agent._blockingToolCall.tool) + ') &mdash; silent ' + Math.round(agent._blockingToolCall.silentMs/60000) + 'min, timeout in ' + Math.round(agent._blockingToolCall.remainingMs/60000) + 'min</div>' : '') +
     (agent.resultSummary ? '<div style="margin-top:4px;font-size:11px;color:var(--text);line-height:1.4">' + renderMd(agent.resultSummary.slice(0, 300)) + '</div>' : '');
 
   // Show panel immediately with loading state — don't wait for API
@@ -53,8 +62,8 @@ async function openAgentDetail(id) {
   } catch(e) {
     document.getElementById('detail-content').innerHTML =
       '<div style="padding:24px;text-align:center">' +
-        '<div style="color:var(--red);margin-bottom:12px">Error loading agent detail: ' + escHtml(e.message) + '</div>' +
-        '<button onclick="openAgentDetail(\'' + escHtml(id) + '\')" style="padding:6px 16px;background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-size:12px">Retry</button>' +
+        '<div style="color:var(--red);margin-bottom:12px">Error loading agent detail: ' + escapeHtml(e.message) + '</div>' +
+        '<button onclick="openAgentDetail(\'' + escapeHtml(id) + '\')" style="padding:6px 16px;background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-size:12px">Retry</button>' +
         ' <button onclick="closeDetail()" style="padding:6px 16px;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer;font-size:12px;color:var(--text)">Close</button>' +
       '</div>';
   }

--- a/dashboard/js/render-inbox.js
+++ b/dashboard/js/render-inbox.js
@@ -29,16 +29,16 @@ function renderInbox(inbox) {
     const idx = inboxStart + i;
     const pk = inboxPinKey(item.name);
     const pinned = isPinned(pk);
-    return `<div class="inbox-item${pinned ? ' item-pinned' : ''}" data-file="notes/inbox/${escHtml(item.name)}">
+    return `<div class="inbox-item${pinned ? ' item-pinned' : ''}" data-file="notes/inbox/${escapeHtml(item.name)}">
       <div class="inbox-name" onclick="openModal(${idx})" style="cursor:pointer">
-        <span>${escHtml(item.name)}</span><span>${escHtml(item.age || '')}</span>
+        <span>${escapeHtml(item.name)}</span><span>${escapeHtml(item.age || '')}</span>
       </div>
-      <div class="inbox-preview" onclick="openModal(${idx})" style="cursor:pointer">${escHtml(item.content.slice(0,200))}</div>
+      <div class="inbox-preview" onclick="openModal(${idx})" style="cursor:pointer">${escapeHtml(item.content.slice(0,200))}</div>
       <div style="display:flex;gap:6px;margin-top:6px;align-items:center">
-        <button class="pr-pager-btn pin-btn${pinned ? ' pinned' : ''}" style="font-size:9px;padding:2px 8px" data-pin-key="${escHtml(pk)}" onclick="event.stopPropagation();_togglePinAndRefresh(this.dataset.pinKey,'inbox')">${pinned ? 'Unpin' : 'Pin'}</button>
-        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px" data-inbox-name="${escHtml(item.name)}" onclick="event.stopPropagation();promoteToKB(this.dataset.inboxName)">Add to Knowledge Base</button>
-        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px" data-inbox-name="${escHtml(item.name)}" onclick="event.stopPropagation();openInboxInExplorer(this.dataset.inboxName)">Open in Explorer</button>
-        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--red)" data-inbox-name="${escHtml(item.name)}" onclick="event.stopPropagation();deleteInboxItem(this.dataset.inboxName)">Delete</button>
+        <button class="pr-pager-btn pin-btn${pinned ? ' pinned' : ''}" style="font-size:9px;padding:2px 8px" data-pin-key="${escapeHtml(pk)}" onclick="event.stopPropagation();_togglePinAndRefresh(this.dataset.pinKey,'inbox')">${pinned ? 'Unpin' : 'Pin'}</button>
+        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px" data-inbox-name="${escapeHtml(item.name)}" onclick="event.stopPropagation();promoteToKB(this.dataset.inboxName)">Add to Knowledge Base</button>
+        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px" data-inbox-name="${escapeHtml(item.name)}" onclick="event.stopPropagation();openInboxInExplorer(this.dataset.inboxName)">Open in Explorer</button>
+        <button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--red)" data-inbox-name="${escapeHtml(item.name)}" onclick="event.stopPropagation();deleteInboxItem(this.dataset.inboxName)">Delete</button>
       </div>
     </div>`;
   }).join('');
@@ -62,10 +62,10 @@ function promoteToKB(name) {
     { id: 'reviews', label: 'Reviews' },
   ];
   const picker = '<div style="padding:16px 20px">' +
-    '<p style="font-size:13px;color:var(--text);margin-bottom:12px">Choose a category for <strong>' + escHtml(name) + '</strong>:</p>' +
+    '<p style="font-size:13px;color:var(--text);margin-bottom:12px">Choose a category for <strong>' + escapeHtml(name) + '</strong>:</p>' +
     '<div style="display:flex;flex-direction:column;gap:8px">' +
     categories.map(c =>
-      '<button class="pr-pager-btn" style="font-size:12px;padding:8px 16px;text-align:left" onclick="doPromoteToKB(\'' + escHtml(name) + '\',\'' + c.id + '\')">' + c.label + '</button>'
+      '<button class="pr-pager-btn" style="font-size:12px;padding:8px 16px;text-align:left" onclick="doPromoteToKB(\'' + escapeHtml(name) + '\',\'' + c.id + '\')">' + c.label + '</button>'
     ).join('') +
     '</div></div>';
   document.getElementById('modal-title').textContent = 'Add to Knowledge Base';

--- a/dashboard/js/render-kb.js
+++ b/dashboard/js/render-kb.js
@@ -112,18 +112,18 @@ function renderKnowledgeBase() {
     const label = KB_CAT_LABELS[item.category] || item.category;
     var pinKey = kbPinKey(item.category, item.file);
     var pinned = isPinned(pinKey);
-    return '<div class="kb-item' + (pinned ? ' item-pinned' : '') + '" data-file="knowledge/' + escHtml(item.category) + '/' + escHtml(item.file) + '" onclick="kbOpenItem(\'' + escHtml(item.category) + '\', \'' + escHtml(item.file) + '\')">' +
+    return '<div class="kb-item' + (pinned ? ' item-pinned' : '') + '" data-file="knowledge/' + escapeHtml(item.category) + '/' + escapeHtml(item.file) + '" onclick="kbOpenItem(\'' + escapeHtml(item.category) + '\', \'' + escapeHtml(item.file) + '\')">' +
       '<div class="kb-item-body">' +
-        '<div class="kb-item-title">' + icon + ' ' + escHtml(item.title) +
-          ' <button class="pr-pager-btn pin-btn' + (pinned ? ' pinned' : '') + '" style="font-size:9px;padding:1px 6px;margin-left:6px;vertical-align:middle" data-pin-key="' + escHtml(pinKey) + '" onclick="event.stopPropagation();_togglePinAndRefresh(this.dataset.pinKey,\'kb\')">' + (pinned ? 'Unpin' : 'Pin') + '</button>' +
+        '<div class="kb-item-title">' + icon + ' ' + escapeHtml(item.title) +
+          ' <button class="pr-pager-btn pin-btn' + (pinned ? ' pinned' : '') + '" style="font-size:9px;padding:1px 6px;margin-left:6px;vertical-align:middle" data-pin-key="' + escapeHtml(pinKey) + '" onclick="event.stopPropagation();_togglePinAndRefresh(this.dataset.pinKey,\'kb\')">' + (pinned ? 'Unpin' : 'Pin') + '</button>' +
         '</div>' +
         '<div class="kb-item-meta">' +
           '<span>' + label + '</span>' +
-          (item.agent ? '<span>' + escHtml(item.agent) + '</span>' : '') +
+          (item.agent ? '<span>' + escapeHtml(item.agent) + '</span>' : '') +
           '<span>' + (item.date || '') + '</span>' +
           '<span>' + Math.round(item.size / 1024) + 'KB</span>' +
         '</div>' +
-        (item.preview ? '<div class="kb-item-preview">' + escHtml(item.preview) + '</div>' : '') +
+        (item.preview ? '<div class="kb-item-preview">' + escapeHtml(item.preview) + '</div>' : '') +
       '</div>' +
     '</div>';
   }).join('');

--- a/dashboard/js/render-plans.js
+++ b/dashboard/js/render-plans.js
@@ -8,7 +8,7 @@ function _plansNext() { _plansPage++; refresh(); }
 
 function openCreatePlanModal() {
   const projOpts = (typeof cmdProjects !== 'undefined' ? cmdProjects : []).map(p =>
-    '<option value="' + escHtml(p) + '">' + escHtml(p) + '</option>'
+    '<option value="' + escapeHtml(p) + '">' + escapeHtml(p) + '</option>'
   ).join('');
   const inputStyle = 'display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit';
 
@@ -218,23 +218,23 @@ function renderPlans(plans) {
       // For awaiting-approval: show Execute (re-generate PRD from updated plan) + Approve (use current PRD as-is)
       if (effectiveStatus === 'awaiting-approval' && isDraft && prdFile) {
         actions = '<div class="plan-card-actions" onclick="event.stopPropagation()">' +
-          '<button class="plan-btn approve" onclick="planApprove(\'' + escHtml(actionTarget) + '\')">Approve</button>' +
-          '<button class="plan-btn approve" style="opacity:0.7" onclick="planExecute(\'' + escHtml(p.file) + '\',\'' + escHtml(p.project || '') + '\',this)">Re-execute</button>' +
-          '<button class="plan-btn reject" onclick="planReject(\'' + escHtml(actionTarget) + '\')">Reject</button>' +
+          '<button class="plan-btn approve" onclick="planApprove(\'' + escapeHtml(actionTarget) + '\')">Approve</button>' +
+          '<button class="plan-btn approve" style="opacity:0.7" onclick="planExecute(\'' + escapeHtml(p.file) + '\',\'' + escapeHtml(p.project || '') + '\',this)">Re-execute</button>' +
+          '<button class="plan-btn reject" onclick="planReject(\'' + escapeHtml(actionTarget) + '\')">Reject</button>' +
         '</div>';
       } else {
         const actionLabel = effectiveStatus === 'paused' ? 'Resume' : 'Approve';
         actions = '<div class="plan-card-actions" onclick="event.stopPropagation()">' +
-          '<button class="plan-btn approve" onclick="planApprove(\'' + escHtml(actionTarget) + '\')">' + actionLabel + '</button>' +
-          '<button class="plan-btn reject" onclick="planReject(\'' + escHtml(actionTarget) + '\')">Reject</button>' +
+          '<button class="plan-btn approve" onclick="planApprove(\'' + escapeHtml(actionTarget) + '\')">' + actionLabel + '</button>' +
+          '<button class="plan-btn reject" onclick="planReject(\'' + escapeHtml(actionTarget) + '\')">Reject</button>' +
         '</div>';
       }
     } else if (isRevision) {
-      actions = '<div class="plan-card-meta" style="margin-top:6px;color:var(--purple,#a855f7)">Revision in progress: ' + escHtml((p.revisionFeedback || '').slice(0, 100)) + '</div>';
+      actions = '<div class="plan-card-meta" style="margin-top:6px;color:var(--purple,#a855f7)">Revision in progress: ' + escapeHtml((p.revisionFeedback || '').slice(0, 100)) + '</div>';
     }
 
     const executeBtn = isDraft && (effectiveStatus === 'active' || effectiveStatus === 'draft') && !isArchived && !prdFile ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--green);font-weight:600" ' +
-      'onclick="event.stopPropagation();planExecute(\'' + escHtml(p.file) + '\',\'' + escHtml(p.project) + '\',this)">Execute</button>' : '';
+      'onclick="event.stopPropagation();planExecute(\'' + escapeHtml(p.file) + '\',\'' + escapeHtml(p.project) + '\',this)">Execute</button>' : '';
     const showPause = effectiveStatus === 'dispatched' && prdFile && !isArchived;
     // Resume pill not needed — paused state is handled by the actions block above
     const showResume = false;
@@ -242,37 +242,37 @@ function renderPlans(plans) {
     const hasVerifyWi = !!verifyWi;
     const showVerify = effectiveStatus === 'completed' && prdFile && !isArchived && !hasVerifyWi;
     const pauseBtn = showPause ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--yellow)" ' +
-      'onclick="event.stopPropagation();planPause(\'' + escHtml(prdFile) + '\',this)">Pause</button>' : '';
+      'onclick="event.stopPropagation();planPause(\'' + escapeHtml(prdFile) + '\',this)">Pause</button>' : '';
     const resumeBtn = showResume
       ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--green)" ' +
-        'onclick="event.stopPropagation();planApprove(\'' + escHtml(prdFile) + '\',this)">Resume</button>'
+        'onclick="event.stopPropagation();planApprove(\'' + escapeHtml(prdFile) + '\',this)">Resume</button>'
       : '';
     const verifyBtn = showVerify ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--green)" ' +
-      'onclick="event.stopPropagation();triggerVerify(\'' + escHtml(prdFile) + '\',this)">Verify</button>' : '';
+      'onclick="event.stopPropagation();triggerVerify(\'' + escapeHtml(prdFile) + '\',this)">Verify</button>' : '';
     const showArchive = !isArchived;
     const archiveFile = prdFile || p.file;
     const archiveReady = p.archiveReady && !isArchived;
     const archiveBtn = showArchive ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px' +
       (archiveReady ? ';color:var(--green);font-weight:600;border:1px solid var(--green)' : '') + '" ' +
-      'onclick="event.stopPropagation();planArchive(\'' + escHtml(archiveFile) + '\',this)">' +
+      'onclick="event.stopPropagation();planArchive(\'' + escapeHtml(archiveFile) + '\',this)">' +
       (archiveReady ? '✓ Archive' : 'Archive') + '</button>' : '';
     const archiveReadyBadge = archiveReady ? '<span style="font-size:9px;font-weight:600;padding:1px 6px;border-radius:3px;background:rgba(63,185,80,0.15);color:var(--green);vertical-align:middle" title="Verification passed — ready to archive">Ready to archive</span>' : '';
     const deleteBtn = !isArchived ? '<button class="pr-pager-btn" style="font-size:9px;padding:2px 8px;color:var(--red)" ' +
-      'onclick="event.stopPropagation();planDelete(\'' + escHtml(p.file) + '\')">Delete</button>' : '';
+      'onclick="event.stopPropagation();planDelete(\'' + escapeHtml(p.file) + '\')">Delete</button>' : '';
 
     const versionBadge = p.version ? ' <span style="font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;background:rgba(56,139,253,0.15);color:var(--blue);vertical-align:middle">v' + p.version + '</span>' : '';
     const statusColors = { 'completed': 'var(--green)', 'dispatched': 'var(--blue)', 'converting': 'var(--yellow)', 'paused': 'var(--muted)', 'awaiting-approval': 'var(--yellow)', 'approved': 'var(--green)', 'rejected': 'var(--red)', 'has-failures': 'var(--red)', 'revision-requested': 'var(--purple,#a855f7)', 'active': 'var(--muted)' };
     const cardClass = effectiveStatus === 'dispatched' || effectiveStatus === 'converting' ? 'working' : effectiveStatus === 'awaiting-approval' || effectiveStatus === 'paused' ? 'awaiting' : effectiveStatus;
-    return '<div class="plan-card ' + cardClass + '" data-file="plans/' + escHtml(p.file) + '" style="cursor:pointer' + (isArchived ? ';opacity:0.7' : '') + '" onclick="if(shouldIgnoreSelectionClick(event))return;planView(\'' + escHtml(p.file) + '\')">' +
+    return '<div class="plan-card ' + cardClass + '" data-file="plans/' + escapeHtml(p.file) + '" style="cursor:pointer' + (isArchived ? ';opacity:0.7' : '') + '" onclick="if(shouldIgnoreSelectionClick(event))return;planView(\'' + escapeHtml(p.file) + '\')">' +
       '<div class="plan-card-header">' +
-        '<div><div class="plan-card-title">' + escHtml(p.summary || p.file) + versionBadge + '</div>' +
+        '<div><div class="plan-card-title">' + escapeHtml(p.summary || p.file) + versionBadge + '</div>' +
           '<div class="plan-card-meta">' +
             '<span style="font-weight:600;color:' + (statusColors[effectiveStatus] || 'var(--muted)') + '">' + label + '</span>' +
-            (p.project ? '<span>' + escHtml(p.project) + '</span>' : '') +
+            (p.project ? '<span>' + escapeHtml(p.project) + '</span>' : '') +
             '<span>' + p.itemCount + ' items</span>' +
             (p.updatedAt ? '<span title="Last updated: ' + p.updatedAt + '">Updated ' + timeAgo(p.updatedAt) + '</span>' : '') +
             (p.completedAt ? '<span>' + p.completedAt.slice(0, 10) + '</span>' : '') +
-            (p.generatedBy ? '<span>by ' + escHtml(p.generatedBy) + '</span>' : '') +
+            (p.generatedBy ? '<span>by ' + escapeHtml(p.generatedBy) + '</span>' : '') +
             executeBtn + pauseBtn + resumeBtn + verifyBtn + (hasVerifyWi ? _renderVerifyBadge(verifyWi) : '') + archiveReadyBadge + archiveBtn + deleteBtn +
           '</div>' +
         '</div>' +
@@ -323,15 +323,15 @@ function openArchivedPlansModal() {
   const html = plans.map(p => {
     const itemCount = p.itemCount || 0;
     const completed = p.completedAt ? p.completedAt.slice(0, 10) : '';
-    return '<div class="plan-card" data-file="plans/' + escHtml(p.file) + '" style="cursor:pointer;opacity:0.8" onclick="if(shouldIgnoreSelectionClick(event))return;planView(\'' + escHtml(p.file) + '\')">' +
+    return '<div class="plan-card" data-file="plans/' + escapeHtml(p.file) + '" style="cursor:pointer;opacity:0.8" onclick="if(shouldIgnoreSelectionClick(event))return;planView(\'' + escapeHtml(p.file) + '\')">' +
       '<div class="plan-card-header">' +
-        '<div><div class="plan-card-title" style="font-size:13px">' + escHtml(p.summary || p.file) + '</div>' +
+        '<div><div class="plan-card-title" style="font-size:13px">' + escapeHtml(p.summary || p.file) + '</div>' +
           '<div class="plan-card-meta">' +
             '<span style="color:var(--green);font-weight:600">Completed</span>' +
-            (p.project ? '<span>' + escHtml(p.project) + '</span>' : '') +
+            (p.project ? '<span>' + escapeHtml(p.project) + '</span>' : '') +
             '<span>' + itemCount + ' items</span>' +
             (completed ? '<span>' + completed + '</span>' : '') +
-            (p.generatedBy ? '<span>by ' + escHtml(p.generatedBy) + '</span>' : '') +
+            (p.generatedBy ? '<span>by ' + escapeHtml(p.generatedBy) + '</span>' : '') +
           '</div>' +
         '</div>' +
       '</div>' +
@@ -417,7 +417,7 @@ function _renderPlanModal(normalizedFile, raw, lastMod) {
   if (normalizedFile.endsWith('.json')) {
     let plan;
     try { plan = JSON.parse(raw); } catch (e) {
-      document.getElementById('modal-body').innerHTML = '<p style="color:var(--red)">Failed to parse plan JSON: ' + escHtml(e.message) + '</p><pre style="font-size:10px;max-height:200px;overflow:auto">' + escHtml((raw || '').slice(0, 500)) + '</pre>';
+      document.getElementById('modal-body').innerHTML = '<p style="color:var(--red)">Failed to parse plan JSON: ' + escapeHtml(e.message) + '</p><pre style="font-size:10px;max-height:200px;overflow:auto">' + escapeHtml((raw || '').slice(0, 500)) + '</pre>';
       return;
     }
     title = plan.plan_summary || normalizedFile;
@@ -466,20 +466,20 @@ function _renderPlanModal(normalizedFile, raw, lastMod) {
   if (isNeedsAction) {
     const target = prdFile || normalizedFile;
     const label = effectiveStatus === 'paused' ? 'Resume' : 'Approve';
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green)" onclick="planApprove(\'' + escHtml(target) + '\',this)">' + label + '</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green)" onclick="planApprove(\'' + escapeHtml(target) + '\',this)">' + label + '</button> ';
     // Re-execute: re-generate PRD from updated plan (only for .md plans with existing awaiting PRD)
     if (effectiveStatus === 'awaiting-approval' && isMdPlan && prdFile) {
-      modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green);opacity:0.7" onclick="planExecute(\'' + escHtml(normalizedFile) + '\',\'\',this)">Re-execute</button> ';
+      modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green);opacity:0.7" onclick="planExecute(\'' + escapeHtml(normalizedFile) + '\',\'\',this)">Re-execute</button> ';
     }
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--red)" onclick="planReject(\'' + escHtml(target) + '\')">Reject</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--red)" onclick="planReject(\'' + escapeHtml(target) + '\')">Reject</button> ';
   }
   // Execute (draft .md without PRD)
   if (isDraft && (effectiveStatus === 'active' || effectiveStatus === 'draft') && !isArchived) {
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green);font-weight:600" onclick="planExecute(\'' + escHtml(normalizedFile) + '\',\'\',this)">Execute</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green);font-weight:600" onclick="planExecute(\'' + escapeHtml(normalizedFile) + '\',\'\',this)">Execute</button> ';
   }
   // Pause (active PRD, not completed)
   if (effectiveStatus === 'dispatched' && prdFile && !isArchived) {
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--yellow)" onclick="planPause(\'' + escHtml(prdFile) + '\',this)">Pause</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--yellow)" onclick="planPause(\'' + escapeHtml(prdFile) + '\',this)">Pause</button> ';
   }
   // Completed label
   if (isCompleted && !isArchived) {
@@ -492,19 +492,19 @@ function _renderPlanModal(normalizedFile, raw, lastMod) {
   // Verify / Verified badge
   const modalVerifyWi = (window._lastWorkItems || []).find(w => w.itemType === 'verify' && w.sourcePlan === (prdFile || normalizedFile));
   if (effectiveStatus === 'completed' && prdFile && !isArchived && !modalVerifyWi) {
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green)" onclick="triggerVerify(\'' + escHtml(prdFile) + '\',this)">Verify</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--green)" onclick="triggerVerify(\'' + escapeHtml(prdFile) + '\',this)">Verify</button> ';
   }
   if (modalVerifyWi) modalActions += _renderVerifyBadge(modalVerifyWi);
   // Archive + Delete (always, unless archived)
   if (!isArchived) {
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--muted)" onclick="planArchive(\'' + escHtml(prdFile || normalizedFile) + '\')">Archive</button> ';
-    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--red)" onclick="planDelete(\'' + escHtml(normalizedFile) + '\')">Delete</button>';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--muted)" onclick="planArchive(\'' + escapeHtml(prdFile || normalizedFile) + '\')">Archive</button> ';
+    modalActions += '<button class="pr-pager-btn" style="' + bs + ';color:var(--red)" onclick="planDelete(\'' + escapeHtml(normalizedFile) + '\')">Delete</button>';
   }
 
   const lastModLabel = lastMod ? '<div style="font-size:10px;color:var(--muted);font-weight:400;margin-top:2px">Last updated: ' + new Date(lastMod).toLocaleString() + '</div>' : '';
   const actionBtns = '<div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px">' + modalActions + '</div>';
 
-  document.getElementById('modal-title').innerHTML = escHtml(title) + (versionLabel ? ' <span style="font-size:11px;font-weight:700;padding:1px 6px;border-radius:3px;background:rgba(56,139,253,0.15);color:var(--blue)">' + escHtml(versionLabel) + '</span>' : '') + lastModLabel + actionBtns;
+  document.getElementById('modal-title').innerHTML = escapeHtml(title) + (versionLabel ? ' <span style="font-size:11px;font-weight:700;padding:1px 6px;border-radius:3px;background:rgba(56,139,253,0.15);color:var(--blue)">' + escapeHtml(versionLabel) + '</span>' : '') + lastModLabel + actionBtns;
   const modalBody = document.getElementById('modal-body');
   const scrollTop = modalBody.scrollTop;
   if (normalizedFile.endsWith('.json')) {
@@ -742,11 +742,11 @@ function _renderVerifyBadge(verifyWi) {
   const planFile = verifyWi.sourcePlan || '';
   const planSlug = planFile.replace('.json', '');
   const verifyPr = allPrs.find(pr => (pr.prdItems || []).includes(verifyWi.id) || (pr.branch && pr.branch.includes(planSlug) && (pr.title || '').includes('[E2E]')));
-  const prLink = verifyPr?.url ? ' <a href="' + escHtml(verifyPr.url) + '" target="_blank" onclick="event.stopPropagation()" style="color:var(--blue);text-decoration:underline;font-size:9px">' + escHtml(verifyPr.id || 'E2E PR') + '</a>' : '';
+  const prLink = verifyPr?.url ? ' <a href="' + escapeHtml(verifyPr.url) + '" target="_blank" onclick="event.stopPropagation()" style="color:var(--blue);text-decoration:underline;font-size:9px">' + escapeHtml(verifyPr.id || 'E2E PR') + '</a>' : '';
   // Testing guide
   const guides = window._lastStatus?.verifyGuides || [];
   const guide = guides.find(g => g.planFile === planFile);
-  const guideLink = guide ? ' <span onclick="event.stopPropagation();openVerifyGuide(\'' + escHtml(guide.file) + '\')" style="color:var(--green);cursor:pointer;text-decoration:underline;font-size:9px">Testing Guide</span>' : '';
+  const guideLink = guide ? ' <span onclick="event.stopPropagation();openVerifyGuide(\'' + escapeHtml(guide.file) + '\')" style="color:var(--green);cursor:pointer;text-decoration:underline;font-size:9px">Testing Guide</span>' : '';
   return '<span style="font-size:9px;font-weight:600;color:' + color + ';padding:0 4px">' + label + '</span>' + prLink + guideLink;
 }
 

--- a/dashboard/js/render-prs.js
+++ b/dashboard/js/render-prs.js
@@ -19,16 +19,16 @@ function prRow(pr) {
   const url = pr.url || '#';
   const prId = pr.id || '—';
   return '<tr>' +
-    '<td><span class="pr-id">' + escHtml(String(prId)) + '</span></td>' +
-    '<td><a class="pr-title" href="' + escHtml(safeUrl(url)) + '" target="_blank" rel="noopener">' + escHtml(pr.title || 'Untitled') + '</a>' + (pr.description ? '<div class="pr-desc">' + escHtml(pr.description.length > 120 ? pr.description.slice(0, 120) + '...' : pr.description) + '</div>' : '') + '</td>' +
-    '<td><span class="pr-agent">' + escHtml(pr.agent || '—') + '</span></td>' +
-    '<td><span class="pr-branch">' + escHtml(pr.branch || '—') + '</span></td>' +
-    '<td><span class="pr-badge ' + reviewClass + '">' + escHtml(reviewLabel) + '</span></td>' +
-    '<td>' + (sq.reviewer && sq.status !== 'waiting' ? '<span class="pr-agent" title="' + escHtml(sq.note || '') + '">' + escHtml(sq.reviewer) + '</span>' : sq.reviewer && sq.status === 'waiting' ? '<span class="pr-agent" style="color:var(--muted)" title="Vote pending confirmation">' + escHtml(sq.reviewer) + '…</span>' : pr.reviewedBy && pr.reviewedBy.length ? '<span class="pr-agent">' + escHtml(pr.reviewedBy.join(', ')) + '</span>' : '<span style="color:var(--muted);font-size:11px">—</span>') + '</td>' +
-    '<td><span class="pr-badge ' + buildClass + '">' + escHtml(buildLabel) + '</span></td>' +
-    '<td><span class="pr-badge ' + statusClass + '">' + escHtml(statusLabel) + '</span></td>' +
-    '<td><span class="pr-date">' + escHtml((pr.created || '—').slice(0, 16).replace('T', ' ')) + '</span></td>' +
-    '<td><button class="pr-pager-btn" style="font-size:9px;padding:1px 5px;color:var(--red);border-color:var(--red)" data-pr-id="' + escHtml(String(prId)) + '" onclick="event.stopPropagation();unlinkPr(this.dataset.prId)" title="Remove from tracking">x</button></td>' +
+    '<td><span class="pr-id">' + escapeHtml(String(prId)) + '</span></td>' +
+    '<td><a class="pr-title" href="' + escapeHtml(safeUrl(url)) + '" target="_blank" rel="noopener">' + escapeHtml(pr.title || 'Untitled') + '</a>' + (pr.description ? '<div class="pr-desc">' + escapeHtml(pr.description.length > 120 ? pr.description.slice(0, 120) + '...' : pr.description) + '</div>' : '') + '</td>' +
+    '<td><span class="pr-agent">' + escapeHtml(pr.agent || '—') + '</span></td>' +
+    '<td><span class="pr-branch">' + escapeHtml(pr.branch || '—') + '</span></td>' +
+    '<td><span class="pr-badge ' + reviewClass + '">' + escapeHtml(reviewLabel) + '</span></td>' +
+    '<td>' + (sq.reviewer && sq.status !== 'waiting' ? '<span class="pr-agent" title="' + escapeHtml(sq.note || '') + '">' + escapeHtml(sq.reviewer) + '</span>' : sq.reviewer && sq.status === 'waiting' ? '<span class="pr-agent" style="color:var(--muted)" title="Vote pending confirmation">' + escapeHtml(sq.reviewer) + '…</span>' : pr.reviewedBy && pr.reviewedBy.length ? '<span class="pr-agent">' + escapeHtml(pr.reviewedBy.join(', ')) + '</span>' : '<span style="color:var(--muted);font-size:11px">—</span>') + '</td>' +
+    '<td><span class="pr-badge ' + buildClass + '">' + escapeHtml(buildLabel) + '</span></td>' +
+    '<td><span class="pr-badge ' + statusClass + '">' + escapeHtml(statusLabel) + '</span></td>' +
+    '<td><span class="pr-date">' + escapeHtml((pr.created || '—').slice(0, 16).replace('T', ' ')) + '</span></td>' +
+    '<td><button class="pr-pager-btn" style="font-size:9px;padding:1px 5px;color:var(--red);border-color:var(--red)" data-pr-id="' + escapeHtml(String(prId)) + '" onclick="event.stopPropagation();unlinkPr(this.dataset.prId)" title="Remove from tracking">x</button></td>' +
     '</tr>';
 }
 
@@ -93,7 +93,7 @@ function openModal(i) {
   if (!item) return;
   document.getElementById('modal-title').textContent = item.name;
   document.getElementById('modal-body').innerHTML =
-    '<div style="margin-bottom:12px"><button class="pr-pager-btn" style="font-size:10px;padding:3px 10px" onclick="promoteToKB(\'' + escHtml(item.name) + '\')">Add to Knowledge Base</button></div>' +
+    '<div style="margin-bottom:12px"><button class="pr-pager-btn" style="font-size:10px;padding:3px 10px" onclick="promoteToKB(\'' + escapeHtml(item.name) + '\')">Add to Knowledge Base</button></div>' +
     '<div style="font-size:12px;line-height:1.7;color:var(--muted)">' + renderMd(item.content) + '</div>';
   _modalDocContext = { title: item.name, content: item.content, selection: '' };
   _modalFilePath = 'notes/inbox/' + item.name; showModalQa();
@@ -106,7 +106,7 @@ function openModal(i) {
 function openAddPrModal() {
   const projOpts = (typeof cmdProjects !== 'undefined' ? cmdProjects : []).map(p => {
     const name = typeof p === 'object' ? p.name : p;
-    return '<option value="' + escHtml(name) + '">' + escHtml(name) + '</option>';
+    return '<option value="' + escapeHtml(name) + '">' + escapeHtml(name) + '</option>';
   }).join('');
   const inputStyle = 'display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit';
 

--- a/dashboard/js/render-work-items.js
+++ b/dashboard/js/render-work-items.js
@@ -23,55 +23,55 @@ function wiRetryBtn(item) {
     return '<span style="font-size:9px;padding:1px 6px;color:var(--green);border:1px solid rgba(63,185,80,0.35);background:rgba(63,185,80,0.1);border-radius:3px;margin-left:4px">Requeued</span>';
   }
   if (rs && rs.status === 'error') {
-    return '<span style="font-size:9px;padding:1px 6px;color:var(--red);border:1px solid rgba(248,81,73,0.35);background:rgba(248,81,73,0.1);border-radius:3px;margin-left:4px;cursor:pointer" title="' + escHtml(rs.message || 'Retry failed') + ' — click to try again" onclick="event.stopPropagation();retryWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')">Retry failed</span>';
+    return '<span style="font-size:9px;padding:1px 6px;color:var(--red);border:1px solid rgba(248,81,73,0.35);background:rgba(248,81,73,0.1);border-radius:3px;margin-left:4px;cursor:pointer" title="' + escapeHtml(rs.message || 'Retry failed') + ' — click to try again" onclick="event.stopPropagation();retryWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')">Retry failed</span>';
   }
-  return '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--yellow);border-color:var(--yellow);margin-left:4px" onclick="event.stopPropagation();retryWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')">Retry</button>';
+  return '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--yellow);border-color:var(--yellow);margin-left:4px" onclick="event.stopPropagation();retryWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')">Retry</button>';
 }
 
 function wiRow(item) {
   const statusBadge = (s) => {
     const cls = s === 'failed' ? 'rejected' : s === 'needs-human-review' ? 'needs-review' : s === 'dispatched' ? 'building' : s === 'pending' || s === 'queued' ? 'active' : s === 'done' ? 'approved' : s === 'decomposed' ? 'approved' : 'draft';
-    return '<span class="pr-badge ' + cls + '">' + escHtml(s) + '</span>';
+    return '<span class="pr-badge ' + cls + '">' + escapeHtml(s) + '</span>';
   };
-  const typeBadge = (t) => '<span class="dispatch-type ' + (t || 'implement') + '">' + escHtml(t || 'implement') + '</span>';
-  const priBadge = (p) => '<span class="prd-item-priority ' + (p || '') + '">' + escHtml(p || 'medium') + '</span>';
+  const typeBadge = (t) => '<span class="dispatch-type ' + (t || 'implement') + '">' + escapeHtml(t || 'implement') + '</span>';
+  const priBadge = (p) => '<span class="prd-item-priority ' + (p || '') + '">' + escapeHtml(p || 'medium') + '</span>';
   const prLink = item._pr
-    ? '<a class="pr-title" href="' + escHtml(item._prUrl || '#') + '" target="_blank" style="font-size:10px">' + escHtml(item._pr) + '</a>'
+    ? '<a class="pr-title" href="' + escapeHtml(item._prUrl || '#') + '" target="_blank" style="font-size:10px">' + escapeHtml(item._pr) + '</a>'
     : (item.branchStrategy === 'shared-branch' && item.status === 'done')
       ? '<span style="font-size:9px;color:var(--muted)" title="Part of shared branch — aggregate PR created at verify stage">shared branch</span>'
       : '<span style="color:var(--muted)">—</span>';
-  return '<tr style="cursor:pointer" onclick="if(shouldIgnoreSelectionClick(event))return;openWorkItemDetail(\'' + escHtml(item.id) + '\')">' +
-    '<td><span class="pr-id">' + escHtml(item.id || '') + '</span></td>' +
-    '<td style="max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + escHtml((item.title || '').slice(0, 200)) + '">' + escHtml(item.title || '') + '</td>' +
-    '<td><span style="font-size:10px;color:var(--muted)">' + escHtml(item._source || '') + '</span>' +
+  return '<tr style="cursor:pointer" onclick="if(shouldIgnoreSelectionClick(event))return;openWorkItemDetail(\'' + escapeHtml(item.id) + '\')">' +
+    '<td><span class="pr-id">' + escapeHtml(item.id || '') + '</span></td>' +
+    '<td style="max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + escapeHtml((item.title || '').slice(0, 200)) + '">' + escapeHtml(item.title || '') + '</td>' +
+    '<td><span style="font-size:10px;color:var(--muted)">' + escapeHtml(item._source || '') + '</span>' +
       (item.scope === 'fan-out' ? ' <span class="pr-badge ' + (item.status === 'done' || item.status === 'failed' ? 'draft' : 'building') + '" style="font-size:8px">fan-out</span>' : '') + '</td>' +
     '<td>' + typeBadge(item.type) + '</td>' +
     '<td>' + priBadge(item.priority) + '</td>' +
     '<td>' + statusBadge(item.status || 'pending') +
       (item._reopened ? ' <span style="font-size:9px;color:var(--purple);margin-left:4px" title="This item was reopened from a previously completed state">reopened</span>' : '') +
-      (item._pendingReason && item.status === 'pending' && item._pendingReason !== 'already_dispatched' ? ' <span style="font-size:9px;color:var(--muted);margin-left:4px" title="Pending reason: ' + escHtml(item._pendingReason) + '">' + escHtml(item._pendingReason.replace(/_/g, ' ')) + '</span>' : '') +
+      (item._pendingReason && item.status === 'pending' && item._pendingReason !== 'already_dispatched' ? ' <span style="font-size:9px;color:var(--muted);margin-left:4px" title="Pending reason: ' + escapeHtml(item._pendingReason) + '">' + escapeHtml(item._pendingReason.replace(/_/g, ' ')) + '</span>' : '') +
       (item._pendingReason === 'already_dispatched' && item.status === 'pending' ? ' <span style="font-size:9px;color:var(--blue);margin-left:4px" title="In dispatch queue, waiting to be assigned">queued</span>' : '') +
-      (item._skipReason && item.status === 'pending' ? ' <span style="font-size:9px;color:var(--yellow);margin-left:4px" title="Dispatch blocked: ' + escHtml(item._skipReason) + (item._blockedBy ? ' (by ' + escHtml(item._blockedBy) + ')' : '') + '">' + escHtml(item._skipReason.replace(/_/g, ' ')) + (item._blockedBy ? ' <span style="color:var(--muted)">(' + escHtml(item._blockedBy) + ')</span>' : '') + '</span>' : '') +
+      (item._skipReason && item.status === 'pending' ? ' <span style="font-size:9px;color:var(--yellow);margin-left:4px" title="Dispatch blocked: ' + escapeHtml(item._skipReason) + (item._blockedBy ? ' (by ' + escapeHtml(item._blockedBy) + ')' : '') + '">' + escapeHtml(item._skipReason.replace(/_/g, ' ')) + (item._blockedBy ? ' <span style="color:var(--muted)">(' + escapeHtml(item._blockedBy) + ')</span>' : '') + '</span>' : '') +
       (item.status === 'failed' ? ' ' + wiRetryBtn(item) : '') +
     '</td>' +
     '<td>' +
       (item.completedAgents && item.completedAgents.length > 0
-        ? '<span class="pr-agent">' + escHtml(item.completedAgents.join(', ')) + '</span>'
-        : '<span class="pr-agent">' + escHtml(item.dispatched_to || item.agent || '—') + '</span>') +
-      (item.failReason ? '<span style="display:block;font-size:9px;color:var(--red)" title="' + escHtml(item.failReason) + '">' + escHtml(item.failReason.slice(0, 30)) + '</span>' : '') +
+        ? '<span class="pr-agent">' + escapeHtml(item.completedAgents.join(', ')) + '</span>'
+        : '<span class="pr-agent">' + escapeHtml(item.dispatched_to || item.agent || '—') + '</span>') +
+      (item.failReason ? '<span style="display:block;font-size:9px;color:var(--red)" title="' + escapeHtml(item.failReason) + '">' + escapeHtml(item.failReason.slice(0, 30)) + '</span>' : '') +
     '</td>' +
     '<td>' + prLink + '</td>' +
-    '<td><span class="pr-date">' + escHtml((item.created || '').slice(0, 16).replace('T', ' ')) + '</span></td>' +
+    '<td><span class="pr-date">' + escapeHtml((item.created || '').slice(0, 16).replace('T', ' ')) + '</span></td>' +
     '<td style="white-space:nowrap;font-size:9px;color:var(--muted)">' +
       (item.references && item.references.length ? '<span title="' + item.references.length + ' reference(s)" style="margin-right:4px">&#x1F517;' + item.references.length + '</span>' : '') +
       (item.acceptanceCriteria && item.acceptanceCriteria.length ? '<span title="' + item.acceptanceCriteria.length + ' acceptance criteria">&#x2611;' + item.acceptanceCriteria.length + '</span>' : '') +
     '</td>' +
     '<td style="white-space:nowrap">' +
-      ((item.status === 'pending' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--blue);border-color:var(--blue);margin-right:4px" onclick="event.stopPropagation();editWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')" title="Edit work item">&#x270E;</button>' : '') +
-      ((item.status === 'done' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--muted);border-color:var(--border);margin-right:4px" onclick="event.stopPropagation();archiveWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')" title="Archive work item">&#x1F4E6;</button>' : '') +
-      ((item.status === 'done' || item.status === 'failed' || item.status === 'needs-human-review') && !item._humanFeedback ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--green);border-color:var(--green);margin-right:4px" onclick="event.stopPropagation();feedbackWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')" title="Give feedback">&#x1F44D;&#x1F44E;</button>' : (item._humanFeedback ? '<span style="font-size:9px" title="Feedback given">' + (item._humanFeedback.rating === 'up' ? '&#x1F44D;' : '&#x1F44E;') + '</span> ' : '')) +
-      ((item.status === 'pending' || item.status === 'dispatched' || item.status === 'queued' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--orange);border-color:var(--orange);margin-right:4px" onclick="event.stopPropagation();cancelWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')" title="Cancel work item and kill agent">&#x1F6AB;</button>' : '') +
-      '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--red);border-color:var(--red)" onclick="event.stopPropagation();deleteWorkItem(\'' + escHtml(item.id) + '\',\'' + escHtml(item._source || '') + '\')" title="Delete work item and kill agent">&#x2715;</button>' +
+      ((item.status === 'pending' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--blue);border-color:var(--blue);margin-right:4px" onclick="event.stopPropagation();editWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')" title="Edit work item">&#x270E;</button>' : '') +
+      ((item.status === 'done' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--muted);border-color:var(--border);margin-right:4px" onclick="event.stopPropagation();archiveWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')" title="Archive work item">&#x1F4E6;</button>' : '') +
+      ((item.status === 'done' || item.status === 'failed' || item.status === 'needs-human-review') && !item._humanFeedback ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--green);border-color:var(--green);margin-right:4px" onclick="event.stopPropagation();feedbackWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')" title="Give feedback">&#x1F44D;&#x1F44E;</button>' : (item._humanFeedback ? '<span style="font-size:9px" title="Feedback given">' + (item._humanFeedback.rating === 'up' ? '&#x1F44D;' : '&#x1F44E;') + '</span> ' : '')) +
+      ((item.status === 'pending' || item.status === 'dispatched' || item.status === 'queued' || item.status === 'failed' || item.status === 'needs-human-review') ? '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--orange);border-color:var(--orange);margin-right:4px" onclick="event.stopPropagation();cancelWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')" title="Cancel work item and kill agent">&#x1F6AB;</button>' : '') +
+      '<button class="pr-pager-btn" style="font-size:9px;padding:1px 6px;color:var(--red);border-color:var(--red)" onclick="event.stopPropagation();deleteWorkItem(\'' + escapeHtml(item.id) + '\',\'' + escapeHtml(item._source || '') + '\')" title="Delete work item and kill agent">&#x2715;</button>' +
     '</td>' +
   '</tr>';
 }
@@ -130,7 +130,7 @@ function editWorkItem(id, source) {
   if (!item) return;
   const types = ['implement', 'fix', 'review', 'plan', 'verify', 'decompose', 'meeting', 'investigate', 'refactor', 'test', 'explore', 'ask', 'docs'];
   const priorities = ['critical', 'high', 'medium', 'low'];
-  const agentOpts = (cmdAgents || []).map(a => '<option value="' + escHtml(a.id) + '"' + (item.agent === a.id ? ' selected' : '') + '>' + escHtml(a.name) + '</option>').join('');
+  const agentOpts = (cmdAgents || []).map(a => '<option value="' + escapeHtml(a.id) + '"' + (item.agent === a.id ? ' selected' : '') + '>' + escapeHtml(a.name) + '</option>').join('');
   const typeOpts = types.map(t => '<option value="' + t + '"' + ((item.type || 'implement') === t ? ' selected' : '') + '>' + t + '</option>').join('');
   const priOpts = priorities.map(p => '<option value="' + p + '"' + ((item.priority || 'medium') === p ? ' selected' : '') + '>' + p + '</option>').join('');
 
@@ -139,10 +139,10 @@ function editWorkItem(id, source) {
   document.getElementById('modal-body').innerHTML =
     '<div style="display:flex;flex-direction:column;gap:12px;font-family:inherit">' +
       '<label style="color:var(--text);font-size:var(--text-md)">Title' +
-        '<input id="wi-edit-title" value="' + escHtml(item.title || '') + '" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit">' +
+        '<input id="wi-edit-title" value="' + escapeHtml(item.title || '') + '" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit">' +
       '</label>' +
       '<label style="color:var(--text);font-size:var(--text-md)">Description' +
-        '<textarea id="wi-edit-desc" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escHtml(item.description || '') + '</textarea>' +
+        '<textarea id="wi-edit-desc" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escapeHtml(item.description || '') + '</textarea>' +
       '</label>' +
       '<div style="display:flex;gap:12px">' +
         '<label style="color:var(--text);font-size:var(--text-md);flex:1">Type' +
@@ -156,14 +156,14 @@ function editWorkItem(id, source) {
         '</label>' +
       '</div>' +
       '<label style="color:var(--text);font-size:var(--text-md)">References (one per line: url | title | type)' +
-        '<textarea id="wi-edit-refs" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escHtml((item.references || []).map(function(r) { return r.url + ' | ' + (r.title || '') + ' | ' + (r.type || 'link'); }).join('\n')) + '</textarea>' +
+        '<textarea id="wi-edit-refs" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escapeHtml((item.references || []).map(function(r) { return r.url + ' | ' + (r.title || '') + ' | ' + (r.type || 'link'); }).join('\n')) + '</textarea>' +
       '</label>' +
       '<label style="color:var(--text);font-size:var(--text-md)">Acceptance Criteria (one per line)' +
-        '<textarea id="wi-edit-ac" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escHtml((item.acceptanceCriteria || []).join('\n')) + '</textarea>' +
+        '<textarea id="wi-edit-ac" rows="3" style="display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit;resize:vertical">' + escapeHtml((item.acceptanceCriteria || []).join('\n')) + '</textarea>' +
       '</label>' +
       '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">' +
         '<button onclick="closeModal()" class="pr-pager-btn" style="padding:6px 16px;font-size:var(--text-md)">Cancel</button>' +
-        '<button onclick="submitWorkItemEdit(\'' + escHtml(id) + '\',\'' + escHtml(source || '') + '\',event)" style="padding:6px 16px;font-size:var(--text-md);background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Save</button>' +
+        '<button onclick="submitWorkItemEdit(\'' + escapeHtml(id) + '\',\'' + escapeHtml(source || '') + '\',event)" style="padding:6px 16px;font-size:var(--text-md);background:var(--blue);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer">Save</button>' +
       '</div>' +
     '</div>';
   document.getElementById('modal').classList.add('open');
@@ -253,11 +253,11 @@ async function toggleWorkItemArchive() {
       '<div class="pr-table-wrap"><table class="pr-table"><thead><tr><th>ID</th><th>Title</th><th>Type</th><th>Status</th><th>Agent</th><th>Archived</th></tr></thead><tbody>' +
       items.map(function(i) {
         return '<tr style="opacity:0.6">' +
-          '<td><span class="pr-id">' + escHtml(i.id || '') + '</span></td>' +
-          '<td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escHtml(i.title || '') + '</td>' +
-          '<td><span class="dispatch-type ' + (i.type || '') + '">' + escHtml(i.type || '') + '</span></td>' +
-          '<td style="color:' + (i.status === 'done' ? 'var(--green)' : 'var(--red)') + '">' + escHtml(i.status || '') + '</td>' +
-          '<td>' + escHtml(i.dispatched_to || '—') + '</td>' +
+          '<td><span class="pr-id">' + escapeHtml(i.id || '') + '</span></td>' +
+          '<td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + escapeHtml(i.title || '') + '</td>' +
+          '<td><span class="dispatch-type ' + (i.type || '') + '">' + escapeHtml(i.type || '') + '</span></td>' +
+          '<td style="color:' + (i.status === 'done' ? 'var(--green)' : 'var(--red)') + '">' + escapeHtml(i.status || '') + '</td>' +
+          '<td>' + escapeHtml(i.dispatched_to || '—') + '</td>' +
           '<td class="pr-date">' + shortTime(i.archivedAt) + '</td>' +
         '</tr>';
       }).join('') + '</tbody></table></div>';
@@ -309,7 +309,7 @@ function feedbackWorkItem(id, source) {
       '<textarea id="feedback-comment" rows="3" style="width:100%;padding:8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-family:inherit;resize:vertical" placeholder="What was good or needs improvement?"></textarea>' +
       '<div style="display:flex;justify-content:flex-end;gap:8px">' +
         '<button onclick="closeModal()" class="pr-pager-btn">Cancel</button>' +
-        '<button id="fb-send" onclick="submitFeedback(\'' + escHtml(id) + '\',\'' + escHtml(source) + '\')" style="padding:6px 16px;background:var(--surface2);color:var(--muted);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:not-allowed" disabled>Select rating first</button>' +
+        '<button id="fb-send" onclick="submitFeedback(\'' + escapeHtml(id) + '\',\'' + escapeHtml(source) + '\')" style="padding:6px 16px;background:var(--surface2);color:var(--muted);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:not-allowed" disabled>Select rating first</button>' +
       '</div>' +
     '</div>';
   document.getElementById('modal').classList.add('open');
@@ -352,10 +352,10 @@ function openCreateWorkItemModal() {
     '<option value="' + p + '"' + (p === 'medium' ? ' selected' : '') + '>' + p + '</option>'
   ).join('');
   const agentOpts = (typeof cmdAgents !== 'undefined' ? cmdAgents : []).map(a =>
-    '<option value="' + escHtml(a.id) + '">' + escHtml(a.name) + '</option>'
+    '<option value="' + escapeHtml(a.id) + '">' + escapeHtml(a.name) + '</option>'
   ).join('');
   const projOpts = (typeof cmdProjects !== 'undefined' ? cmdProjects : []).map(p =>
-    '<option value="' + escHtml(p) + '">' + escHtml(p) + '</option>'
+    '<option value="' + escapeHtml(p) + '">' + escapeHtml(p) + '</option>'
   ).join('');
   const inputStyle = 'display:block;width:100%;margin-top:4px;padding:6px 8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text);font-size:var(--text-md);font-family:inherit';
 
@@ -443,41 +443,41 @@ function openWorkItemDetail(id) {
   if (!item) return;
 
   const field = (label, value) => value ? '<div style="margin-bottom:8px"><span style="color:var(--muted);font-size:10px;text-transform:uppercase;letter-spacing:0.5px">' + label + '</span><div style="margin-top:2px">' + value + '</div></div>' : '';
-  const badge = (cls, text) => '<span class="pr-badge ' + cls + '">' + escHtml(text) + '</span>';
+  const badge = (cls, text) => '<span class="pr-badge ' + cls + '">' + escapeHtml(text) + '</span>';
   const statusCls = item.status === 'failed' ? 'rejected' : item.status === 'dispatched' ? 'building' : item.status === 'done' ? 'approved' : 'active';
 
   let html = '<div style="display:flex;flex-direction:column;gap:4px;font-size:13px">';
   html += '<div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">' +
     badge(statusCls, item.status || 'pending') +
     (item._reopened ? ' <span style="font-size:9px;color:var(--purple);margin-left:4px" title="This item was reopened from a previously completed state">reopened</span>' : '') + ' ' +
-    '<span class="dispatch-type ' + (item.type || 'implement') + '">' + escHtml(item.type || 'implement') + '</span>' +
-    '<span class="prd-item-priority ' + (item.priority || '') + '">' + escHtml(item.priority || 'medium') + '</span>' +
+    '<span class="dispatch-type ' + (item.type || 'implement') + '">' + escapeHtml(item.type || 'implement') + '</span>' +
+    '<span class="prd-item-priority ' + (item.priority || '') + '">' + escapeHtml(item.priority || 'medium') + '</span>' +
     '</div>';
   html += field('Description', '<div style="font-size:12px;max-height:320px;overflow-y:auto;padding:8px 10px;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-sm)">' + renderMd(item.description || item.title || '—') + '</div>');
-  html += field('Agent', escHtml(item.dispatched_to || item.agent || 'Auto'));
-  html += field('Source', escHtml(item._source || 'central'));
-  if (item.created) html += field('Created', escHtml(new Date(item.created).toLocaleString()));
-  if (item.dispatched_at) html += field('Dispatched', escHtml(new Date(item.dispatched_at).toLocaleString()) + ' to ' + escHtml(item.dispatched_to || '?'));
-  if (item.completedAt) html += field('Completed', escHtml(new Date(item.completedAt).toLocaleString()));
-  if (item.failReason) html += field('Failure Reason', '<span style="color:var(--red)">' + escHtml(item.failReason) + '</span>');
-  if (item._pendingReason && item.status === 'pending') html += field('Pending Reason', item._pendingReason === 'already_dispatched' ? 'Queued — waiting for available agent slot' : escHtml(item._pendingReason.replace(/_/g, ' ')));
-  if (item._skipReason && item.status === 'pending') html += field('Dispatch Blocked', '<span style="color:var(--yellow)">' + escHtml(item._skipReason.replace(/_/g, ' ')) + '</span>' + (item._blockedBy ? ' — blocked by <strong>' + escHtml(item._blockedBy) + '</strong>' : ''));
-  if (item.depends_on?.length) html += field('Depends On', item.depends_on.map(d => '<code>' + escHtml(d) + '</code>').join(', '));
-  if (item.acceptanceCriteria?.length) html += field('Acceptance Criteria', '<ul style="margin:0;padding-left:20px">' + item.acceptanceCriteria.map(c => '<li>' + escHtml(c) + '</li>').join('') + '</ul>');
-  if (item.references?.length) html += field('References', item.references.map(r => '<a href="' + escHtml(r.url) + '" target="_blank" style="color:var(--blue)">' + escHtml(r.title || r.url) + '</a>' + (r.type ? ' <span style="color:var(--muted);font-size:10px">(' + escHtml(r.type) + ')</span>' : '')).join('<br>'));
-  if (item._humanFeedback) html += field('Human Feedback', (item._humanFeedback.rating === 'up' ? '👍' : '👎') + (item._humanFeedback.comment ? ' — ' + escHtml(item._humanFeedback.comment) : ''));
-  if (item._pr) html += field('Pull Request', '<a href="' + escHtml(item._prUrl || '#') + '" target="_blank" style="color:var(--blue)">' + escHtml(item._pr) + '</a>');
+  html += field('Agent', escapeHtml(item.dispatched_to || item.agent || 'Auto'));
+  html += field('Source', escapeHtml(item._source || 'central'));
+  if (item.created) html += field('Created', escapeHtml(new Date(item.created).toLocaleString()));
+  if (item.dispatched_at) html += field('Dispatched', escapeHtml(new Date(item.dispatched_at).toLocaleString()) + ' to ' + escapeHtml(item.dispatched_to || '?'));
+  if (item.completedAt) html += field('Completed', escapeHtml(new Date(item.completedAt).toLocaleString()));
+  if (item.failReason) html += field('Failure Reason', '<span style="color:var(--red)">' + escapeHtml(item.failReason) + '</span>');
+  if (item._pendingReason && item.status === 'pending') html += field('Pending Reason', item._pendingReason === 'already_dispatched' ? 'Queued — waiting for available agent slot' : escapeHtml(item._pendingReason.replace(/_/g, ' ')));
+  if (item._skipReason && item.status === 'pending') html += field('Dispatch Blocked', '<span style="color:var(--yellow)">' + escapeHtml(item._skipReason.replace(/_/g, ' ')) + '</span>' + (item._blockedBy ? ' — blocked by <strong>' + escapeHtml(item._blockedBy) + '</strong>' : ''));
+  if (item.depends_on?.length) html += field('Depends On', item.depends_on.map(d => '<code>' + escapeHtml(d) + '</code>').join(', '));
+  if (item.acceptanceCriteria?.length) html += field('Acceptance Criteria', '<ul style="margin:0;padding-left:20px">' + item.acceptanceCriteria.map(c => '<li>' + escapeHtml(c) + '</li>').join('') + '</ul>');
+  if (item.references?.length) html += field('References', item.references.map(r => '<a href="' + escapeHtml(r.url) + '" target="_blank" style="color:var(--blue)">' + escapeHtml(r.title || r.url) + '</a>' + (r.type ? ' <span style="color:var(--muted);font-size:10px">(' + escapeHtml(r.type) + ')</span>' : '')).join('<br>'));
+  if (item._humanFeedback) html += field('Human Feedback', (item._humanFeedback.rating === 'up' ? '👍' : '👎') + (item._humanFeedback.comment ? ' — ' + escapeHtml(item._humanFeedback.comment) : ''));
+  if (item._pr) html += field('Pull Request', '<a href="' + escapeHtml(item._prUrl || '#') + '" target="_blank" style="color:var(--blue)">' + escapeHtml(item._pr) + '</a>');
 
   // Artifacts — output log, branch, skills, etc.
   var arts = item._artifacts || {};
   var artPills = '';
   var pillStyle = 'display:inline-flex;align-items:center;gap:3px;padding:2px 8px;border-radius:10px;font-size:10px;cursor:pointer;background:var(--surface2);border:1px solid var(--border);color:var(--text)';
   // Output log pill removed — raw stream-json output is not human-readable
-  var artBackFn = "pushModalBack(function(){openWorkItemDetail('" + escHtml(item.id) + "')});";
-  if (arts.branch) artPills += '<span style="' + pillStyle + ';cursor:default">🌿 ' + escHtml(arts.branch) + '</span> ';
-  if (arts.plan) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escHtml(arts.plan) + '\')" style="' + pillStyle + '">📋 Plan</span> ';
-  if (arts.prd) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escHtml(arts.prd) + '\')" style="' + pillStyle + '">📄 PRD</span> ';
-  if (arts.sourcePlan) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escHtml(arts.sourcePlan) + '\')" style="' + pillStyle + '">📋 Source Plan</span> ';
+  var artBackFn = "pushModalBack(function(){openWorkItemDetail('" + escapeHtml(item.id) + "')});";
+  if (arts.branch) artPills += '<span style="' + pillStyle + ';cursor:default">🌿 ' + escapeHtml(arts.branch) + '</span> ';
+  if (arts.plan) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escapeHtml(arts.plan) + '\')" style="' + pillStyle + '">📋 Plan</span> ';
+  if (arts.prd) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escapeHtml(arts.prd) + '\')" style="' + pillStyle + '">📄 PRD</span> ';
+  if (arts.sourcePlan) artPills += '<span onclick="' + artBackFn + 'planView(\'' + escapeHtml(arts.sourcePlan) + '\')" style="' + pillStyle + '">📋 Source Plan</span> ';
   if (arts.notes && arts.notes.length > 0) {
     arts.notes.forEach(function(n) {
       var noteFile = (n && typeof n === 'object') ? (n.file || n) : String(n || '');
@@ -486,17 +486,17 @@ function openWorkItemDetail(id) {
         var kbCat = kbParts[0];
         var kbFile = kbParts.slice(1).join('/');
         var kbLabel = kbFile.replace(/\.md$/, '').slice(0, 30);
-        artPills += '<span onclick="' + artBackFn + 'kbOpenItem(\'' + escHtml(kbCat) + '\',\'' + escHtml(kbFile) + '\')" style="' + pillStyle + '">📚 ' + escHtml(kbLabel) + '</span> ';
+        artPills += '<span onclick="' + artBackFn + 'kbOpenItem(\'' + escapeHtml(kbCat) + '\',\'' + escapeHtml(kbFile) + '\')" style="' + pillStyle + '">📚 ' + escapeHtml(kbLabel) + '</span> ';
       } else if (noteFile.startsWith('archive:')) {
         var archLabel = noteFile.slice(8).replace(/\.md$/, '').replace(/^\d{4}-\d{2}-\d{2}-/, '').slice(0, 30);
-        artPills += '<span onclick="' + artBackFn + 'openInboxNote(\'' + escHtml(noteFile.slice(8)) + '\')" style="' + pillStyle + ';opacity:0.7">📄 ' + escHtml(archLabel) + ' <span style="font-size:8px">(archived)</span></span> ';
+        artPills += '<span onclick="' + artBackFn + 'openInboxNote(\'' + escapeHtml(noteFile.slice(8)) + '\')" style="' + pillStyle + ';opacity:0.7">📄 ' + escapeHtml(archLabel) + ' <span style="font-size:8px">(archived)</span></span> ';
       } else {
         var noteLabel = noteFile.replace(/\.md$/, '').slice(0, 30);
-        artPills += '<span onclick="' + artBackFn + 'openInboxNote(\'' + escHtml(noteFile) + '\')" style="' + pillStyle + '">📝 ' + escHtml(noteLabel) + '</span> ';
+        artPills += '<span onclick="' + artBackFn + 'openInboxNote(\'' + escapeHtml(noteFile) + '\')" style="' + pillStyle + '">📝 ' + escapeHtml(noteLabel) + '</span> ';
       }
     });
   }
-  if (arts.skills && arts.skills.length > 0) arts.skills.forEach(function(s) { artPills += '<span onclick="openSkill(\'' + escHtml(s) + '\',\'minions\',\'\')" style="' + pillStyle + '">⚙ ' + escHtml(s) + '</span> '; });
+  if (arts.skills && arts.skills.length > 0) arts.skills.forEach(function(s) { artPills += '<span onclick="openSkill(\'' + escapeHtml(s) + '\',\'minions\',\'\')" style="' + pillStyle + '">⚙ ' + escapeHtml(s) + '</span> '; });
   if (artPills) html += field('Artifacts', '<div style="display:flex;flex-wrap:wrap;gap:4px">' + artPills + '</div>');
 
   if (item._totalCostUsd != null) html += field('Cumulative Cost', '$' + Number(item._totalCostUsd).toFixed(4));

--- a/dashboard/js/utils.js
+++ b/dashboard/js/utils.js
@@ -96,6 +96,25 @@ function toggleModalPin() {
   else if (_modalFilePath.startsWith('knowledge/')) renderKnowledgeBase();
 }
 
+// Canonical HTML-escape helper (SEC-03). Use this in all new code and for any user-controlled
+// field that reaches `.innerHTML` / a template literal. Escapes the 6 HTML metacharacters
+// (& < > " ' /) — the `/` escape closes the `</script>` break-out path that a 5-char escape
+// leaves open. Returns '' for null/undefined so missing fields never render the literal strings
+// "null"/"undefined". Idempotent for non-metacharacter input (double-escaping only expands `&`).
+function escapeHtml(str) {
+  if (str === null || str === undefined) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/\//g, '&#x2F;');
+}
+
+// Legacy 5-char escape. Kept as a backward-compat alias so files not yet migrated under
+// SEC-03 Phase A still compile. Prefer `escapeHtml` in new code — it adds the `/` escape
+// and null/undefined handling. Phase B will remove this once the remaining renderers move.
 function escHtml(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
@@ -482,4 +501,4 @@ async function submitBugReport() {
   }
 }
 
-window.MinionsUtils = { wakeEngine, escHtml, renderMd, normalizePlanFile, timeAgo, statusColor, shouldIgnoreSelectionClick, llmCopyBtn, copyLlmText, openBugReport, submitBugReport };
+window.MinionsUtils = { wakeEngine, escapeHtml, escHtml, renderMd, normalizePlanFile, timeAgo, statusColor, shouldIgnoreSelectionClick, llmCopyBtn, copyLlmText, openBugReport, submitBugReport };

--- a/engine/shared.js
+++ b/engine/shared.js
@@ -1029,6 +1029,56 @@ function sanitizeBranch(name) {
   return String(name).replace(/[^a-zA-Z0-9._\-\/]/g, '-').slice(0, 200);
 }
 
+// ── HTTP Origin Allowlist & Security Headers ─────────────────────────────────
+// Pure helpers used by dashboard.js to gate mutating requests against an
+// explicit allowlist of local origins and to attach uniform security response
+// headers. Extracted here so they're unit-testable without the HTTP server.
+
+// Allowed origin (scheme + host) — port-agnostic. Dashboard always binds to
+// 127.0.0.1:7331 locally; browser tabs may arrive as localhost, 127.0.0.1, or
+// IPv6 [::1] depending on how the user opened the page.
+// WHATWG URL keeps IPv6 brackets in `hostname`, so we compare against the
+// bracketed form `[::1]`. We also accept the bare form `::1` defensively.
+const _ALLOWED_ORIGIN_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const _ALLOWED_ORIGIN_SCHEMES = new Set(['http:']);
+
+/**
+ * Returns true if the origin-like header value (either an `Origin` header value
+ * such as `http://localhost:7331` or a full `Referer` URL) belongs to the local
+ * dashboard allowlist. Port-agnostic. Returns false for null/undefined/empty,
+ * the literal string `'null'` (sandboxed iframes, data: URIs), malformed URLs,
+ * non-http schemes, and any host not in the allowlist.
+ * @param {string|null|undefined} origin
+ * @returns {boolean}
+ */
+function isAllowedOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false;
+  const trimmed = origin.trim();
+  if (!trimmed || trimmed === 'null') return false;
+  let parsed;
+  try { parsed = new URL(trimmed); } catch { return false; }
+  if (!parsed.hostname) return false;
+  if (!_ALLOWED_ORIGIN_SCHEMES.has(parsed.protocol)) return false;
+  return _ALLOWED_ORIGIN_HOSTS.has(parsed.hostname);
+}
+
+/**
+ * Returns the baseline set of security response headers to apply on every HTTP
+ * response from the dashboard. Values match OWASP defaults for a same-origin
+ * SPA served from 127.0.0.1. The HTML entry-point response intentionally
+ * overrides CSP to allow its inline `<script>` / `<style>` blocks; API (JSON,
+ * SSE) responses inherit the strict CSP returned here.
+ * @returns {{[key:string]: string}}
+ */
+function buildSecurityHeaders() {
+  return {
+    'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'same-origin',
+  };
+}
+
 // ── Skill Frontmatter Parser ─────────────────────────────────────────────────
 
 function parseSkillFrontmatter(content, filename) {
@@ -1631,6 +1681,8 @@ module.exports = {
   getAdoOrgBase,
   sanitizePath,
   sanitizeBranch,
+  isAllowedOrigin,
+  buildSecurityHeaders,
   validatePid,
   parseSkillFrontmatter,
   sleepMs,

--- a/test/minions-tests.js
+++ b/test/minions-tests.js
@@ -13,23 +13,29 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 
-const BASE = 'http://localhost:7331';
+const BASE = process.env.MINIONS_TEST_BASE || 'http://localhost:7331';
 const MINIONS_DIR = path.resolve(__dirname, '..');
 const PLANS_DIR = path.join(MINIONS_DIR, 'plans');
 const ENGINE_DIR = path.join(MINIONS_DIR, 'engine');
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function httpReq(method, urlPath, body) {
+function httpReq(method, urlPath, body, opts = {}) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlPath, BASE);
-    const opts = { method, hostname: url.hostname, port: url.port, path: url.pathname, headers: {} };
-    if (body) {
-      const data = JSON.stringify(body);
-      opts.headers['Content-Type'] = 'application/json';
-      opts.headers['Content-Length'] = Buffer.byteLength(data);
+    const extraHeaders = opts.headers || {};
+    // opts.rawBody (string) takes precedence for Content-Type stress tests.
+    // opts.contentType overrides Content-Type (e.g. 'text/plain' to test 415).
+    const rawBody = opts.rawBody != null ? String(opts.rawBody) : (body ? JSON.stringify(body) : null);
+    const contentType = opts.contentType !== undefined ? opts.contentType : (body ? 'application/json' : null);
+    const reqOpts = { method, hostname: url.hostname, port: url.port, path: url.pathname + (url.search || ''), headers: { ...extraHeaders } };
+    if (rawBody != null) {
+      if (contentType !== null && contentType !== undefined && contentType !== '') {
+        reqOpts.headers['Content-Type'] = contentType;
+      }
+      reqOpts.headers['Content-Length'] = Buffer.byteLength(rawBody);
     }
-    const req = http.request(opts, res => {
+    const req = http.request(reqOpts, res => {
       let d = '';
       res.on('data', c => d += c);
       res.on('end', () => {
@@ -39,12 +45,12 @@ function httpReq(method, urlPath, body) {
     });
     req.on('error', reject);
     req.setTimeout(10000, () => { req.destroy(); reject(new Error('timeout')); });
-    if (body) req.write(JSON.stringify(body));
+    if (rawBody != null) req.write(rawBody);
     req.end();
   });
 }
-const GET = (p) => httpReq('GET', p);
-const POST = (p, b) => httpReq('POST', p, b);
+const GET = (p, opts) => httpReq('GET', p, null, opts);
+const POST = (p, b, opts) => httpReq('POST', p, b, opts);
 
 function readJson(fp) {
   try { return JSON.parse(fs.readFileSync(fp, 'utf8')); } catch { return null; }
@@ -472,6 +478,123 @@ async function testDataIntegrity() {
   });
 }
 
+async function testSecurityHeaders() {
+  console.log('\n── Security Headers & Origin Gate ──');
+
+  // 1. Security response headers on GET /api/status
+  await test('GET /api/status includes CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy', async () => {
+    const r = await GET('/api/status');
+    assert.strictEqual(r.status, 200);
+    const h = r.headers;
+    assert.ok(h['content-security-policy'], 'missing Content-Security-Policy');
+    assert.ok(h['content-security-policy'].includes("default-src 'self'"), 'CSP missing default-src');
+    assert.ok(h['content-security-policy'].includes("script-src 'self'"), 'CSP missing script-src');
+    // API responses must keep strict script-src (no 'unsafe-inline')
+    assert.ok(!/script-src[^;]*'unsafe-inline'/.test(h['content-security-policy']),
+      "API CSP must not allow 'unsafe-inline' scripts");
+    assert.strictEqual(h['x-frame-options'], 'DENY');
+    assert.strictEqual(h['x-content-type-options'], 'nosniff');
+    assert.strictEqual(h['referrer-policy'], 'same-origin');
+  });
+
+  // 2. POST with disallowed Origin → 403
+  await test('POST /api/command-center with Origin: https://evil.example returns 403', async () => {
+    const r = await POST('/api/command-center',
+      { message: 'hi', tabId: 'sec-test-bad-origin' },
+      { headers: { Origin: 'https://evil.example' } });
+    assert.strictEqual(r.status, 403, `expected 403, got ${r.status} body=${r.body}`);
+    assert.ok(r.json, 'response must be JSON');
+    assert.ok(/not allowed/i.test(r.json.error || ''), 'error must mention origin');
+  });
+
+  // 3. POST with valid localhost Origin → proceeds (not 403)
+  await test('POST /api/work-items with Origin: http://localhost:7331 succeeds (not blocked by origin gate)', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'Security test work item (safe to delete)', type: 'implement', priority: 'low' },
+      { headers: { Origin: 'http://localhost:7331' } });
+    assert.notStrictEqual(r.status, 403, 'valid localhost Origin must not be blocked');
+    assert.ok(r.status === 200 || r.status === 201, `unexpected status ${r.status} body=${r.body}`);
+    // Clean up the test item
+    if (r.json && r.json.id) {
+      try { await POST('/api/work-items/delete', { id: r.json.id }); } catch {}
+    }
+  });
+
+  // 4. Content-Type enforcement — text/plain on POST → 415
+  await test('POST /api/command-center with Content-Type: text/plain returns 415', async () => {
+    const r = await POST('/api/command-center',
+      null,
+      { rawBody: JSON.stringify({ message: 'hi', tabId: 'sec-test-bad-ct' }),
+        contentType: 'text/plain',
+        headers: { Origin: 'http://localhost:7331' } });
+    assert.strictEqual(r.status, 415, `expected 415, got ${r.status} body=${r.body}`);
+    assert.ok(r.json && /application\/json/i.test(r.json.error || ''),
+      'error must mention application/json');
+  });
+
+  // 5. Missing Content-Type on POST → 415
+  await test('POST /api/command-center with no Content-Type returns 415', async () => {
+    const r = await POST('/api/command-center',
+      null,
+      { rawBody: JSON.stringify({ message: 'hi', tabId: 'sec-test-no-ct' }),
+        contentType: '',
+        headers: { Origin: 'http://localhost:7331' } });
+    assert.strictEqual(r.status, 415, `expected 415, got ${r.status} body=${r.body}`);
+  });
+
+  // 6. Content-Type: application/json → allowed (not 415, gate not triggered)
+  await test('POST /api/command-center with application/json Content-Type is not blocked by 415 gate', async () => {
+    const r = await POST('/api/command-center',
+      { message: 'hi', tabId: 'sec-test-good-ct' },
+      { headers: { Origin: 'http://localhost:7331' } });
+    // Might be 200, 400 (empty CC response), 429 (rate limit), 500 (LLM) — just NOT 415
+    assert.notStrictEqual(r.status, 415, 'application/json must not trigger 415');
+    assert.notStrictEqual(r.status, 403, 'valid origin must not trigger 403');
+  });
+
+  // 7. Second mutating endpoint: POST /api/work-items with evil Origin → 403
+  await test('POST /api/work-items with cross-origin header returns 403', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'should never be created', type: 'implement' },
+      { headers: { Origin: 'https://attacker.example.com' } });
+    assert.strictEqual(r.status, 403, `expected 403, got ${r.status} body=${r.body}`);
+  });
+
+  // 8. SSE endpoint Origin rejection — must 403 before upgrade
+  await test('GET /api/agent/dallas/live-stream with cross-origin header returns 403 (not SSE upgrade)', async () => {
+    const r = await GET('/api/agent/dallas/live-stream',
+      { headers: { Origin: 'https://evil.example' } });
+    assert.strictEqual(r.status, 403, `SSE must reject before upgrade; got ${r.status}`);
+    assert.ok(r.headers['content-type'] && r.headers['content-type'].includes('application/json'),
+      'rejection must be JSON, not text/event-stream');
+  });
+
+  // 9. Same-origin GET without Origin header is allowed (legacy tooling, polling)
+  await test('GET /api/status without Origin header is allowed', async () => {
+    const r = await GET('/api/status');
+    assert.strictEqual(r.status, 200);
+  });
+
+  // 10. POST without Origin and without Referer is allowed (curl / legacy tooling)
+  await test('POST /api/work-items with no Origin and no Referer is allowed (legacy curl)', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'Legacy curl test item (safe to delete)', type: 'implement', priority: 'low' });
+    assert.notStrictEqual(r.status, 403, 'no-origin requests must not be blocked');
+    assert.ok(r.status === 200 || r.status === 201, `unexpected status ${r.status}`);
+    if (r.json && r.json.id) {
+      try { await POST('/api/work-items/delete', { id: r.json.id }); } catch {}
+    }
+  });
+
+  // 11. POST with disallowed Referer (no Origin) → 403
+  await test('POST /api/work-items with disallowed Referer (no Origin) returns 403', async () => {
+    const r = await POST('/api/work-items',
+      { title: 'should never be created', type: 'implement' },
+      { headers: { Referer: 'https://evil.example/attack.html' } });
+    assert.strictEqual(r.status, 403, `expected 403 on disallowed Referer, got ${r.status}`);
+  });
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -491,6 +614,7 @@ async function main() {
   }
 
   await testApiEndpoints();
+  await testSecurityHeaders();
   await testWorkItemCrud();
   await testPlanFlow();
   await testPrdFlow();

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -371,6 +371,134 @@ async function testBranchSanitization() {
   });
 }
 
+async function testIsAllowedOrigin() {
+  console.log('\n── shared.js — isAllowedOrigin (dashboard origin allowlist) ──');
+
+  // Allowed hosts — port-agnostic
+  await test('isAllowedOrigin accepts http://localhost without port', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://localhost:7331', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:7331'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://localhost:65535 (any port)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:65535'), true);
+  });
+
+  await test('isAllowedOrigin accepts http://127.0.0.1 and http://127.0.0.1:3000', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1:3000'), true);
+  });
+
+  await test('isAllowedOrigin accepts IPv6 http://[::1] and http://[::1]:7331', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://[::1]'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://[::1]:7331'), true);
+  });
+
+  await test('isAllowedOrigin accepts Referer-style full URL (path ignored)', () => {
+    // Referer headers include the full URL; helper must tolerate path/query
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost:7331/api/status'), true);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1:7331/dashboard?x=1'), true);
+  });
+
+  // Disallowed hosts
+  await test('isAllowedOrigin rejects arbitrary public origins', () => {
+    assert.strictEqual(shared.isAllowedOrigin('https://evil.example'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://evil.example:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://attacker.localhost.com'), false);
+  });
+
+  await test('isAllowedOrigin rejects private-network hosts not on allowlist', () => {
+    assert.strictEqual(shared.isAllowedOrigin('http://10.0.0.1'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://192.168.1.5:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://0.0.0.0'), false);
+  });
+
+  await test('isAllowedOrigin rejects https scheme (allowlist is http-only for local dev)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('https://localhost:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('https://127.0.0.1'), false);
+  });
+
+  await test('isAllowedOrigin rejects non-http schemes (file, data, ws, chrome-extension)', () => {
+    assert.strictEqual(shared.isAllowedOrigin('file:///etc/passwd'), false);
+    assert.strictEqual(shared.isAllowedOrigin('data:text/html,<script>1</script>'), false);
+    assert.strictEqual(shared.isAllowedOrigin('ws://localhost:7331'), false);
+    assert.strictEqual(shared.isAllowedOrigin('chrome-extension://abc'), false);
+  });
+
+  // Null / empty / malformed
+  await test('isAllowedOrigin rejects null, undefined, empty, and non-string inputs', () => {
+    assert.strictEqual(shared.isAllowedOrigin(null), false);
+    assert.strictEqual(shared.isAllowedOrigin(undefined), false);
+    assert.strictEqual(shared.isAllowedOrigin(''), false);
+    assert.strictEqual(shared.isAllowedOrigin('   '), false);
+    assert.strictEqual(shared.isAllowedOrigin(42), false);
+    assert.strictEqual(shared.isAllowedOrigin({}), false);
+  });
+
+  await test('isAllowedOrigin rejects literal "null" (sandboxed iframe / data URI origin)', () => {
+    // Browsers send `Origin: null` for sandboxed iframes, opaque origins, data: URIs
+    assert.strictEqual(shared.isAllowedOrigin('null'), false);
+  });
+
+  await test('isAllowedOrigin rejects malformed URLs', () => {
+    assert.strictEqual(shared.isAllowedOrigin('notaurl'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http:// localhost'), false);
+    assert.strictEqual(shared.isAllowedOrigin('javascript:alert(1)'), false);
+  });
+
+  await test('isAllowedOrigin rejects subdomain-spoof attempts', () => {
+    // Prevents attacker.localhost or 127.0.0.1.evil.com from sneaking through
+    assert.strictEqual(shared.isAllowedOrigin('http://localhost.evil.com'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://127.0.0.1.nip.io'), false);
+    assert.strictEqual(shared.isAllowedOrigin('http://not-localhost'), false);
+  });
+}
+
+async function testBuildSecurityHeaders() {
+  console.log('\n── shared.js — buildSecurityHeaders ──');
+
+  await test('buildSecurityHeaders returns exactly the four required headers', () => {
+    const h = shared.buildSecurityHeaders();
+    assert.ok(h && typeof h === 'object', 'must return an object');
+    const keys = Object.keys(h).sort();
+    assert.deepStrictEqual(keys, [
+      'Content-Security-Policy',
+      'Referrer-Policy',
+      'X-Content-Type-Options',
+      'X-Frame-Options',
+    ], 'must return exactly the four required keys');
+  });
+
+  await test('buildSecurityHeaders returns strict CSP (self-only scripts, inline styles permitted)', () => {
+    const h = shared.buildSecurityHeaders();
+    const csp = h['Content-Security-Policy'];
+    assert.ok(csp.includes("default-src 'self'"), 'CSP must include default-src self');
+    assert.ok(csp.includes("script-src 'self'"), 'CSP must include script-src self');
+    assert.ok(csp.includes("style-src 'self' 'unsafe-inline'"), 'CSP must allow inline styles');
+    // script-src must NOT include 'unsafe-inline' — that would defeat XSS protection
+    assert.ok(!/script-src[^;]*'unsafe-inline'/.test(csp), "script-src must not allow 'unsafe-inline'");
+  });
+
+  await test('buildSecurityHeaders sets X-Frame-Options: DENY and nosniff + same-origin referrer', () => {
+    const h = shared.buildSecurityHeaders();
+    assert.strictEqual(h['X-Frame-Options'], 'DENY');
+    assert.strictEqual(h['X-Content-Type-Options'], 'nosniff');
+    assert.strictEqual(h['Referrer-Policy'], 'same-origin');
+  });
+
+  await test('buildSecurityHeaders returns a fresh object each call (no shared mutation)', () => {
+    const a = shared.buildSecurityHeaders();
+    const b = shared.buildSecurityHeaders();
+    assert.notStrictEqual(a, b, 'each call must return a distinct object');
+    a['X-Frame-Options'] = 'TAMPERED';
+    assert.strictEqual(b['X-Frame-Options'], 'DENY', 'mutation of one result must not affect a later call');
+  });
+}
+
 async function testSanitizePath() {
   console.log('\n── shared.js — Path Sanitization ──');
 
@@ -11068,6 +11196,8 @@ async function main() {
     await testSharedUtilities();
     await testIdGeneration();
     await testBranchSanitization();
+    await testIsAllowedOrigin();
+    await testBuildSecurityHeaders();
     await testSanitizePath();
     await testValidatePid();
     await testParseStreamJsonOutput();

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14329,21 +14329,31 @@ async function testDashboardAuditXss() {
     const cardSection = src.match(/grid\.innerHTML = agents\.map[\s\S]*?\.join\(''\)/);
     assert.ok(cardSection, 'agent card template must exist');
     const card = cardSection[0];
-    // These fields must be escaped
-    assert.ok(card.includes('escHtml(a.id)'), 'a.id must be escaped in onclick');
-    assert.ok(card.includes('escHtml(a.name)'), 'a.name must be escaped');
-    assert.ok(card.includes('escHtml(a.emoji)'), 'a.emoji must be escaped');
-    assert.ok(card.includes('escHtml(a.status)'), 'a.status must be escaped');
-    assert.ok(card.includes('escHtml(a.role)'), 'a.role must be escaped');
+    // Post-SEC-03: hotspot renderers use the canonical escapeHtml helper (6-char, null-safe).
+    // These fields must be escaped via escapeHtml (or any *escape*Html helper).
+    const hasEscape = (s) => card.includes('escapeHtml(' + s + ')') || card.includes('escHtml(' + s + ')');
+    assert.ok(hasEscape('a.id'), 'a.id must be escaped in onclick');
+    assert.ok(hasEscape('a.name'), 'a.name must be escaped');
+    assert.ok(hasEscape('a.emoji'), 'a.emoji must be escaped');
+    assert.ok(hasEscape('a.status'), 'a.status must be escaped');
+    assert.ok(hasEscape('a.role'), 'a.role must be escaped');
   });
 
-  await test('render-agents.js detail header escapes agent fields', () => {
+  await test('render-agents.js detail header renders agent fields safely', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-agents.js'), 'utf8');
-    const headerLine = src.match(/detail-agent-name.*innerHTML[\s\S]*?;/);
-    assert.ok(headerLine, 'detail header line must exist');
-    assert.ok(headerLine[0].includes('escHtml(agent.emoji)'), 'emoji must be escaped in detail');
-    assert.ok(headerLine[0].includes('escHtml(agent.name)'), 'name must be escaped in detail');
-    assert.ok(headerLine[0].includes('escHtml(agent.role)'), 'role must be escaped in detail');
+    // Post-SEC-03: the detail-agent-name header is built via DOM (`replaceChildren` +
+    // `textContent`) rather than innerHTML. textContent inherently neutralises HTML, so
+    // agent.emoji / agent.name / agent.role can't be script-injected regardless of the
+    // escape helper. Assert we haven't regressed to an innerHTML pattern for this node.
+    const detailBlock = src.match(/detail-agent-name[\s\S]*?\)\);/);
+    assert.ok(detailBlock, 'detail-agent-name header block must exist');
+    const block = detailBlock[0];
+    assert.ok(!/detail-agent-name[^)]*\)\.innerHTML\s*=/.test(block),
+      'detail-agent-name must not be populated via innerHTML (use textContent / replaceChildren)');
+    assert.ok(block.includes('textContent'), 'emoji/name/role must be set via textContent');
+    assert.ok(block.includes('agent.emoji'), 'must read agent.emoji');
+    assert.ok(block.includes('agent.name'), 'must read agent.name');
+    assert.ok(block.includes('agent.role'), 'must read agent.role');
   });
 
   await test('render-pinned.js uses data attributes instead of JS string injection', () => {
@@ -14363,7 +14373,9 @@ async function testDashboardAuditXss() {
 
   await test('render-inbox.js escapes item.age', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-inbox.js'), 'utf8');
-    assert.ok(src.includes("escHtml(item.age") , 'item.age must be escaped');
+    // Post-SEC-03: render-inbox.js migrated from escHtml to canonical escapeHtml.
+    assert.ok(src.includes('escapeHtml(item.age') || src.includes('escHtml(item.age'),
+      'item.age must be escaped');
   });
 
   await test('utils.js has safeUrl function that blocks javascript: protocol', () => {
@@ -14386,6 +14398,184 @@ async function testDashboardAuditXss() {
     const tdMatch = rowFn ? (rowFn[0].match(/<td>/g) || []) : [];
     assert.strictEqual(thMatch.length, tdMatch.length,
       `PR table headers (${thMatch.length}) must match cell count (${tdMatch.length})`);
+  });
+
+  // ─── SEC-03 Phase A: escapeHtml helper + no-regression gate ───────────────
+  //
+  // Phase A landed three things:
+  //   1. A canonical `escapeHtml(str)` helper in dashboard/js/utils.js that escapes six
+  //      HTML metacharacters (& < > " ' /) and returns '' for null/undefined — null-safety
+  //      prevents the literal strings "null"/"undefined" from rendering where a field is
+  //      missing, and the `/` escape closes the `</script>` break-out route that the
+  //      legacy 5-char `escHtml` left open.
+  //   2. Migration of the top-priority renderers (work items, agents, PRs, KB entries,
+  //      plans, inbox) from `escHtml` → `escapeHtml` for every user-controlled field that
+  //      reaches `.innerHTML`.
+  //   3. This ratchet: count dynamic `.innerHTML =` / `.innerHTML +=` assignments across
+  //      dashboard/ and assert the count does not exceed a frozen baseline. New unsafe
+  //      innerHTML lines fail CI; converting an existing line to textContent /
+  //      insertAdjacentText is always allowed.
+  //
+  // ── How to update the baseline ──
+  //   When you migrate an `.innerHTML` assignment to a safer alternative (textContent,
+  //   insertAdjacentText, or a structured DOM build via document.createElement), rerun
+  //   the counter (see _countDynamicInnerHtml below) and lower DYNAMIC_INNERHTML_BASELINE
+  //   to match the new total. Never raise the baseline to make a failing test pass —
+  //   that defeats the ratchet. If a new renderer genuinely needs innerHTML for HTML
+  //   markup (e.g., returning from renderMd()), wrap user-controlled fields in
+  //   escapeHtml() and accept the baseline increment only with explicit review.
+  await testSec03EscapeHtml();
+}
+
+// A line's RHS is "static" (safe) iff it is a single pure string literal — no `${`,
+// no `+`, no bare identifier. The same predicate is used by the regression gate and
+// documented in the commit that introduced it.
+function _isStaticInnerHtmlRhs(rhs) {
+  const cleaned = rhs.replace(/;\s*$/, '').trim();
+  if (/^'[^']*'$/.test(cleaned)) return true;
+  if (/^"[^"]*"$/.test(cleaned)) return true;
+  if (/^`[^`$]*`$/.test(cleaned)) return true;
+  return false;
+}
+
+function _countDynamicInnerHtml(dir) {
+  const files = [];
+  (function walk(d) {
+    for (const name of fs.readdirSync(d)) {
+      const p = path.join(d, name);
+      const stat = fs.statSync(p);
+      if (stat.isDirectory()) walk(p);
+      else if (/\.(js|html)$/.test(name)) files.push(p);
+    }
+  })(dir);
+  let total = 0;
+  const perFile = {};
+  for (const f of files) {
+    const src = fs.readFileSync(f, 'utf8');
+    const lines = src.split('\n');
+    let n = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/\.innerHTML\s*\+?=\s*(.+)$/);
+      if (!m) continue;
+      if (_isStaticInnerHtmlRhs(m[1])) continue;
+      n++;
+    }
+    if (n > 0) { perFile[f] = n; total += n; }
+  }
+  return { total, perFile };
+}
+
+async function testSec03EscapeHtml() {
+  console.log('\n── SEC-03 Phase A: escapeHtml ──');
+
+  // Extract escapeHtml from source and eval it in a fresh scope (no deps).
+  const utilsSrc = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'utils.js'), 'utf8');
+  const escBody = utilsSrc.match(/function escapeHtml\([\s\S]*?^}/m);
+  if (!escBody) throw new Error('escapeHtml not found in dashboard/js/utils.js');
+  const escapeHtml = new Function(escBody[0] + '\nreturn escapeHtml;')();
+
+  await test('escapeHtml escapes all six HTML metacharacters', () => {
+    assert.strictEqual(escapeHtml('&'), '&amp;');
+    assert.strictEqual(escapeHtml('<'), '&lt;');
+    assert.strictEqual(escapeHtml('>'), '&gt;');
+    assert.strictEqual(escapeHtml('"'), '&quot;');
+    assert.strictEqual(escapeHtml("'"), '&#39;');
+    assert.strictEqual(escapeHtml('/'), '&#x2F;');
+  });
+
+  await test('escapeHtml escapes a realistic XSS payload', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const escaped = escapeHtml(payload);
+    assert.ok(!escaped.includes('<img'), 'raw <img must not survive');
+    assert.ok(escaped.includes('&lt;img'), '< must be encoded');
+    assert.ok(escaped.includes('&gt;'), '> must be encoded');
+  });
+
+  await test('escapeHtml escapes </script> break-out (the `/` escape matters)', () => {
+    // This is the tangible win over the 5-char legacy escHtml — `/` blocks
+    // `</script>` from closing an inline <script> tag when a field is accidentally
+    // interpolated into script context rather than body context.
+    const escaped = escapeHtml('</script>');
+    assert.ok(!escaped.includes('</'), 'raw </ must not survive');
+    assert.ok(escaped.includes('&#x2F;'), 'forward slash must be encoded as &#x2F;');
+  });
+
+  await test('escapeHtml returns empty string for null / undefined', () => {
+    // Legacy escHtml renders the literal strings "null" / "undefined" — a correctness
+    // bug (not a security bug) that escapeHtml fixes so missing fields don't leak.
+    assert.strictEqual(escapeHtml(null), '');
+    assert.strictEqual(escapeHtml(undefined), '');
+  });
+
+  await test('escapeHtml coerces non-string input to string', () => {
+    assert.strictEqual(escapeHtml(0), '0');
+    assert.strictEqual(escapeHtml(42), '42');
+    assert.strictEqual(escapeHtml(false), 'false');
+    assert.strictEqual(escapeHtml(true), 'true');
+  });
+
+  await test('escapeHtml is idempotent for non-metacharacter input', () => {
+    // The only metacharacter that expands on second pass is `&` (→ &amp; → &amp;amp;).
+    // Text without metacharacters is a fixed point — important so that template
+    // literals can safely wrap already-escaped callsites without double-encoding text.
+    const safe = 'Hello, world. 42 is the answer.';
+    assert.strictEqual(escapeHtml(escapeHtml(safe)), escapeHtml(safe));
+  });
+
+  await test('escapeHtml is exported via window.MinionsUtils', () => {
+    assert.ok(utilsSrc.includes('window.MinionsUtils'), 'MinionsUtils export must exist');
+    const exportLine = utilsSrc.match(/window\.MinionsUtils\s*=\s*\{[^}]*\}/)[0];
+    assert.ok(exportLine.includes('escapeHtml'), 'escapeHtml must be exported');
+  });
+
+  // Hotspot migration: the renderers listed in the task description must use the
+  // canonical escapeHtml helper for user-controlled fields that reach .innerHTML.
+  // Every field escape in these files should be escapeHtml (not the legacy escHtml)
+  // so future greps can distinguish migrated from unmigrated code.
+  const migratedFiles = [
+    'render-work-items.js', 'render-agents.js', 'render-prs.js',
+    'render-kb.js', 'render-plans.js', 'render-inbox.js',
+  ];
+  for (const f of migratedFiles) {
+    await test(`${f} uses escapeHtml (not legacy escHtml) after SEC-03 migration`, () => {
+      const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', f), 'utf8');
+      assert.ok(src.includes('escapeHtml('),
+        `${f} must use canonical escapeHtml helper`);
+      // Legacy escHtml must not appear — enforces clean migration.
+      // (A renamed identifier like `mapEscHtml` would match; we scope the regex to
+      // the exact call form so false positives are impossible.)
+      assert.ok(!/\bescHtml\s*\(/.test(src),
+        `${f} must not use legacy escHtml( — migrate to escapeHtml(`);
+    });
+  }
+
+  // ── Regression gate ─────────────────────────────────────────────────────
+  // Baseline was measured after Phase A migrations and frozen here. The counter
+  // treats a line as "dynamic" (potentially unsafe) when the RHS of `.innerHTML`
+  // is anything other than a single quoted/template string literal — i.e. it
+  // contains `${`, `+`, or a bare identifier. Static literal assignments
+  // (`el.innerHTML = '<p class="empty">...</p>'`) are exempt because they
+  // cannot carry user data.
+  const DYNAMIC_INNERHTML_BASELINE = 172;
+
+  await test(`dynamic innerHTML count does not exceed Phase A baseline (${DYNAMIC_INNERHTML_BASELINE})`, () => {
+    const dashboardDir = path.join(MINIONS_DIR, 'dashboard');
+    const { total, perFile } = _countDynamicInnerHtml(dashboardDir);
+    if (total > DYNAMIC_INNERHTML_BASELINE) {
+      // Surface the per-file breakdown so the reviewer can find the new offender(s).
+      const breakdown = Object.entries(perFile)
+        .sort((a, b) => b[1] - a[1])
+        .map(([f, n]) => `  ${n.toString().padStart(4)} ${path.relative(MINIONS_DIR, f)}`)
+        .join('\n');
+      assert.fail(
+        `Dynamic .innerHTML assignments in dashboard/ rose from baseline ${DYNAMIC_INNERHTML_BASELINE} to ${total}.\n` +
+        `Either wrap the new user-controlled field in escapeHtml() AND prefer textContent\n` +
+        `where the element holds only text, or — if this change is intentional progress in\n` +
+        `the other direction (a textContent conversion) — lower DYNAMIC_INNERHTML_BASELINE\n` +
+        `to ${total}.\n\nPer-file counts:\n${breakdown}`
+      );
+    }
+    assert.ok(total <= DYNAMIC_INNERHTML_BASELINE, `count=${total} <= baseline=${DYNAMIC_INNERHTML_BASELINE}`);
   });
 }
 
@@ -15130,8 +15320,9 @@ async function testEngineAuditMedium() {
 
   await test('render-kb.js escapes item.agent', () => {
     const src = fs.readFileSync(path.join(MINIONS_DIR, 'dashboard', 'js', 'render-kb.js'), 'utf8');
-    assert.ok(src.includes("escHtml(item.agent)"),
-      'item.agent must be escaped via escHtml to prevent XSS');
+    // Post-SEC-03: render-kb.js migrated from escHtml to canonical escapeHtml.
+    assert.ok(src.includes('escapeHtml(item.agent)') || src.includes('escHtml(item.agent)'),
+      'item.agent must be escaped via escapeHtml/escHtml to prevent XSS');
   });
 
   await test('_archiveMeeting clears markDeleted on API failure', () => {


### PR DESCRIPTION
## Summary

Aggregate E2E PR for plan `minions-2026-04-17.json` — Security fixes (dashboard auth/CSRF, XSS helper, token scrubber, input validation).

Base: `master` tip (`c276ed01`) which already contains merged items SEC-02 (#1296), SEC-04/05 (#1298), SEC-09 (#1297), SEC-13 (#1300). This E2E branch adds the remaining open PRs on top:

| PR | Item | Status |
|----|------|--------|
| [#1323](https://github.com/yemi33/minions/pull/1323) | SEC-03 Phase A — `escapeHtml` + hotspot XSS migration + innerHTML regression gate | approved, open |
| [#1327](https://github.com/yemi33/minions/pull/1327) | SEC-01/13/16 — Origin allowlist, Content-Type enforcement, security response headers | approved, open |
| [#1336](https://github.com/yemi33/minions/pull/1336) | Resolve `engine/shared.js` conflict between #1327 and master | approved, open |

`#1336` contains `#1327` as an ancestor — so this E2E branch merges `#1323` + `#1336` (which transitively brings in `#1327`) and then re-merges the latest `master` with a trivial conflict resolution on the `engine/shared.js` exports block (keep both `isAllowedOrigin/buildSecurityHeaders` and `hasDangerousKey`).

## Verification

- `npm test` → **2566 passed / 0 failed / 3 skipped** from the merged worktree.
- Smoke-tested the merged-code dashboard on `PORT=7332` — every security gate fires as specified:
  - CSP + `X-Frame-Options: DENY` + `X-Content-Type-Options: nosniff` + `Referrer-Policy: same-origin` on every response.
  - `POST` with `Origin: https://evil.example` → **403**.
  - `POST` with `Content-Type: text/plain` → **415**.
  - `POST` with top-level `__proto__` or `constructor` → **400**.
  - SSE `/api/agent/:id/live-stream` with disallowed `Origin` → **403**.
  - Legacy CLI (`curl` with no `Origin`) → accepted by the gate.
- `grep -n curl engine/ado.js` → single comment-only reference; no active shell-out.

## Known gap

SEC-01 session-cookie leg (SameSite=Strict HttpOnly cookie + 401 on missing cookie) is **not implemented** in any of the open PRs. Origin + Content-Type + proto-guard + security headers already close the CSRF hole without it, but the acceptance criteria named the cookie. Recommend a follow-up item — should not block this E2E.

## Test plan

- [ ] Merge to `master` (squash).
- [ ] Run `npm test` on master — expect 2566 pass / 0 fail / 3 skip.
- [ ] Restart prod dashboard on `:7331`, verify `curl -I http://localhost:7331/` includes all four security headers.
- [ ] Manual browser: create a work item titled `<img src=x onerror=alert(1)>`, confirm it renders as literal text with no script execution.
- [ ] Open a follow-up work item for SEC-01 session-cookie implementation.

## Links

- Testing guide: `prd/guides/verify-minions-2026-04-17.md`
- Source plan: `plans/meeting-follow-up-security-review-triage-and-agree-2026-04-17.md`
- PRD: `prd/minions-2026-04-17.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)