### PR TITLE
docs: weekly doc sweep — sync stale references with current source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ Zero dependencies beyond Node.js built-ins. No build step.
 
 ```
 checkTimeouts → consolidateInbox → cleanup (every 10 ticks) →
-pollPrStatus (every 6 ticks) → pollPrHumanComments (every 12 ticks) →
+pollPrStatus (every prPollStatusEvery ticks, default 12) →
+pollPrHumanComments (every prPollCommentsEvery ticks, default 12) →
 discoverWork → updateSnapshot → dispatch agents (up to maxConcurrent)
 ```
 
@@ -373,7 +374,7 @@ Context-only PRs: PRs with `_contextOnly: true` are polled (status, votes, build
 
 ## ADO Integration
 
-Token via `azureauth ado token --mode iwa --mode broker --output token --timeout 1`. Cached 30 min, 10-min backoff on failure. **All `azureauth` calls MUST include `--timeout 1`** — without it, the command can hang indefinitely waiting for interactive broker UI that never appears in headless agent sessions, causing agent orphans. PR status polled every ~3 min, human comments every ~6 min. PR → PRD item linking derived from `pull-requests.json` prdItems.
+Token via `azureauth ado token --mode iwa --mode broker --output token --timeout 1`. Cached 30 min, 10-min backoff on failure. **All `azureauth` calls MUST include `--timeout 1`** — without it, the command can hang indefinitely waiting for interactive broker UI that never appears in headless agent sessions, causing agent orphans. PR status and human comments are polled every `prPollStatusEvery` / `prPollCommentsEvery` ticks (default 12 each, ~12 min). PR → PRD item linking derived from `pull-requests.json` prdItems.
 
 **evalLoop and polling interaction:** `evalLoop` gates the entire review→fix cycle. `adoPollEnabled` (or `ghPollEnabled` for GitHub projects) gates whether PR status is polled at all. Review auto-dispatch requires *both* to be true — `reviewEnabled = evalLoopEnabled && pollEnabled`. After a fix agent completes, the PR's `reviewStatus` is reset to `'waiting'` and `minionsReview.fixedAt` is set, which triggers a second-pass re-review on the next discovery tick (also gated by `evalLoop`). The `autoReview` flag was removed and consolidated into `evalLoop`.
 
@@ -400,7 +401,7 @@ User types message → ccCall() → buildPrompt() → llm.callLLM({ direct: true
 
 **State preamble:** `buildCCStatePreamble()` — lightweight snapshot of agents, dispatch, PR/WI counts, project list, schedule/pipeline counts. Cached with 10s TTL. Skipped on session resume (session already has context).
 
-**Sessions:** Single global CC session (`ccSession`), persisted to `engine/cc-session.json`. No time-based expiry and no turn limit (`CC_SESSION_MAX_TURNS = Infinity`). Resume via `--resume` flag. The session is invalidated (forcing a fresh start) only when the system prompt changes — detected by hashing `CC_STATIC_SYSTEM_PROMPT` into `_ccPromptHash` and comparing on each call. Per-tab sessions (streaming path) don't mutate the global `ccSession`.
+**Sessions:** Single global CC session (`ccSession`), persisted to `engine/cc-session.json`. Bounded by `ENGINE_DEFAULTS.ccMaxTurns` (default 50 turns) and `ENGINE_DEFAULTS.ccSessionTtlMs` (default 2h — resumed sessions older than this are rotated to cap context growth). Resume via `--resume` flag. The session is also invalidated (forcing a fresh start) when the system prompt changes — detected by hashing `CC_STATIC_SYSTEM_PROMPT` into `_ccPromptHash` and comparing on each call. Per-tab sessions (streaming path) don't mutate the global `ccSession`.
 
 **Model/effort:** Configurable via `config.engine.ccModel` (sonnet/haiku/opus) and `config.engine.ccEffort` (null/low/medium/high). Applied to all CC and doc-chat calls.
 

--- a/docs/auto-discovery.md
+++ b/docs/auto-discovery.md
@@ -11,8 +11,8 @@ tick()
   1. checkTimeouts()            Kill stale/hung agents (>heartbeatTimeout)
   2. consolidateInbox()         Merge learnings into notes.md (Haiku-powered)
   2.5 runCleanup()              Periodic cleanup (every 10 ticks ≈ 10min)
-  2.6 pollPrStatus()            Poll ADO for build, review, merge status (every 6 ticks ≈ 6min)
-  2.7 pollPrHumanComments()     Poll PR threads for human @minions comments (every 12 ticks ≈ 12min)
+  2.6 pollPrStatus()            Poll ADO + GitHub for build, review, merge status (every prPollStatusEvery ticks, default 12 ≈ 12min)
+  2.7 pollPrHumanComments()     Poll PR threads for human @minions comments (every prPollCommentsEvery ticks, default 12 ≈ 12min)
   3. discoverWork()             Scan ALL linked projects for new tasks
   4. updateSnapshot()           Write identity/now.md
   5. dispatch                   Spawn agents for pending items (up to maxConcurrent)
@@ -118,11 +118,11 @@ priority: high
 
 Both write to `work-items.json` and are picked up by Source 3 on the same or next tick.
 
-## ADO PR Status Polling (`pollPrStatus`)
+## PR Status Polling (`pollPrStatus`)
 
-**Runs:** Every 6 ticks (≈ 6 minutes), independently of work discovery. Replaces the retired agent-based `pr-sync`.
+**Runs:** Every `prPollStatusEvery` ticks (default 12, ≈ 12 minutes), independently of work discovery. ADO polling lives in `engine/ado.js`; GitHub polling lives in `engine/github.js` — both run in parallel each cycle (`Promise.allSettled`) and write to the same per-project `pull-requests.json` schema. Replaces the retired agent-based `pr-sync`.
 
-The engine directly polls the Azure DevOps REST API for **all** PR metadata: build/CI status, human review votes, and completion state. Two API calls per PR — no agent dispatch needed.
+The engine directly polls the host REST API for **all** PR metadata: build/CI status, human review votes, and completion state. Two API calls per PR — no agent dispatch needed.
 
 **Per PR:**
 1. `GET pullrequests/{id}` → `status` (active/completed/abandoned), `mergeStatus`, `reviewers[].vote`
@@ -137,7 +137,7 @@ The engine directly polls the Azure DevOps REST API for **all** PR metadata: bui
 | `buildStatus` | PR statuses (codecoverage/deploy/build/ci contexts) | `passing` / `failing` / `running` / `none` |
 | `buildFailReason` | Failed status description | Set on failure, cleared otherwise |
 
-**Auth:** Bearer token via `azureauth ado token --output token --timeout 1` (cached 30 minutes). The `--timeout 1` flag is required — without it, azureauth can hang indefinitely in headless sessions.
+**Auth:** Bearer token via `azureauth ado token --mode iwa --mode broker --output token --timeout 1` (cached 30 minutes). The `--timeout 1` flag is required — without it, azureauth can hang indefinitely in headless sessions. (GitHub polling uses the ambient `gh` CLI credentials, not azureauth.)
 
 This feeds `discoverFromPrs` — when `buildStatus` flips to `"failing"`, the next discovery tick dispatches a fix agent. When `status` becomes `"merged"`, the PR drops out of active polling.
 
@@ -244,9 +244,12 @@ Combines:
 
 ### 5. Spawn Claude CLI
 ```bash
-claude -p <prompt-file> --system-prompt <sysprompt-file> \
-  --output-format json --max-turns 100 --verbose \
-  --allowedTools Edit,Write,Read,Bash,Glob,Grep,Agent,WebFetch,WebSearch
+claude -p --system-prompt-file <sysprompt-file> \
+  --output-format stream-json --max-turns 100 --verbose \
+  --permission-mode bypassPermissions
+# Prompt text is piped via stdin (not passed as an arg).
+# Agent dispatches route through engine/spawn-agent.js; CC / doc-chat use a direct
+# spawn path in engine/llm.js that bypasses spawn-agent.js entirely.
 ```
 
 - Process runs in the worktree directory (or rootDir for reviews)
@@ -325,8 +328,8 @@ docs/**/*.md (specs)┤  (each tick)      ┌──────────┐
   plans/*.md ─────┘       ▼                 │
                      addToDispatch()────────┘
                                             │
-ADO REST API ─── pollPrBuildStatus() ──► pull-requests.json
-(every 6min)      (buildStatus field)       │
+ADO + GitHub REST ── pollPrStatus() ──► pull-requests.json
+(every ~12min)       (buildStatus field)      │
                                        spawnAgent()
                                             │
                                ┌────────────┼────────────┐

--- a/docs/command-center.md
+++ b/docs/command-center.md
@@ -13,7 +13,7 @@ CC maintains a true multi-turn session using Claude CLI's `--resume` flag. Unlik
 **Session lifecycle:**
 - **Created** on first message (or after the system prompt changes, or when you click **New Session**)
 - **Resumed** on subsequent messages via `--resume <sessionId>`
-- **Invalidated** only when the CC system prompt changes — detected by hashing `CC_STATIC_SYSTEM_PROMPT` into `_ccPromptHash` and comparing on each call. There is no time-based expiry and no turn cap (`CC_SESSION_MAX_TURNS = Infinity`).
+- **Invalidated** when the CC system prompt changes — detected by hashing `CC_STATIC_SYSTEM_PROMPT` into `_ccPromptHash` and comparing on each call. Sessions are also bounded by `ENGINE_DEFAULTS.ccMaxTurns` (default 50 turns) and `ENGINE_DEFAULTS.ccSessionTtlMs` (default 2h — resumed sessions older than this get rotated).
 - **Persisted** to `engine/cc-session.json` — survives dashboard restarts
 - **Frontend messages** saved to `localStorage` — survive page refresh
 
@@ -117,9 +117,10 @@ POST /api/command-center  (or /api/doc-chat, /api/steer-document)
     │     timeout: 600s (CC) or 300s (doc-plan) or 60s (doc-other)
     │
     ▼
-spawn-agent.js
+engine/llm.js callLLM({ direct: true })  (bypasses engine/spawn-agent.js — CC + doc-chat only)
     │
-    ├── If --resume: skip system prompt file, pass -p --resume <id>
+    ├── Resolves claude CLI binary path from engine/claude-caps.json
+    ├── If --resume: pass -p --resume <id> (no system prompt file)
     ├── If new: pass -p --system-prompt-file <file>
     │
     ▼
@@ -143,8 +144,8 @@ Frontend
 
 | File | Role |
 |------|------|
-| `engine/llm.js` | `callLLM()` — single LLM function with optional `sessionId` for resume |
-| `engine/spawn-agent.js` | Spawns claude CLI; skips system prompt on `--resume` |
+| `engine/llm.js` | `callLLM()` / `callLLMStreaming()` — single LLM function with optional `sessionId` for resume; `direct: true` spawns claude CLI directly (used by CC + doc-chat) |
+| `engine/spawn-agent.js` | Agent dispatch wrapper — resolves claude CLI path and invokes it. **Not used by CC/doc-chat** (direct spawn path). |
 | `engine/shared.js` | `parseStreamJsonOutput()` extracts `sessionId` from result |
 | `engine/cc-session.json` | Persisted session state (sessionId, turnCount, timestamps) |
 | `dashboard.js` | CC endpoint, `buildCCStatePreamble()`, `ccDocCall()`, `parseCCActions()` |

--- a/docs/design-state-storage.md
+++ b/docs/design-state-storage.md
@@ -22,7 +22,7 @@ Minions persists all runtime state as flat JSON files guarded by file-lock-based
 | `engine/metrics.json` | 5 KB | Per-agent stats | R/W on PR approval/merge | Low | Low |
 | `engine/control.json` | 169 B | Single object | R/W on start/stop/heartbeat | Low | Low |
 | `projects/*/work-items.json` | 370 KB | 180 items | R/W every 1-2 ticks; dashboard reads on-demand | **High** — engine + lifecycle + dashboard | High |
-| `projects/*/pull-requests.json` | 241 KB | 128 PRs | R/W every 6 ticks (polling); lifecycle writes | Medium | Medium |
+| `projects/*/pull-requests.json` | 241 KB | 128 PRs | R/W every `prPollStatusEvery` ticks (default 12, polling); lifecycle writes | Medium | Medium |
 | `engine/pipeline-runs.json` | 36 KB | Pipeline state | R/W on pipeline execution | Low | Low |
 | `engine/schedule-runs.json` | 115 B | Last-run times | R every 10 ticks; W on schedule execution | Low | Low |
 
@@ -56,7 +56,7 @@ Key properties:
 | Engine tick cycle | ~15 | ~3 | Heavy read, selective write |
 | Dashboard (per page load) | ~8 | 0 | Read-only display |
 | Dashboard (user action) | ~2 | ~2 | Read-modify-write |
-| PR polling (every 6 ticks) | ~4 | ~2 | Batch read-modify-write |
+| PR polling (every `prPollStatusEvery` ticks, default 12) | ~4 | ~2 | Batch read-modify-write |
 | Consolidation (every 10 ticks) | ~3 | ~2 | Read inbox files, write notes.md |
 
 **Read:write ratio is approximately 8:1.** This strongly favors a system that can serve reads without locking (e.g., WAL mode).

--- a/docs/human-vs-automated.md
+++ b/docs/human-vs-automated.md
@@ -46,7 +46,7 @@ These run continuously without you:
 - **Work discovery** — engine scans all project queues every tick (~60s)
 - **Agent dispatch** — engine picks the right agent, builds the prompt, spawns Claude
 - **Worktree management** — create on dispatch, pull on shared-branch, clean after merge
-- **PR status polling** — checks ADO for build status, review votes, merge state every ~6 min
+- **PR status polling** — checks ADO + GitHub for build status, review votes, merge state every ~12 min
 - **Build failure detection** — auto-files fix tasks when CI fails
 - **Inbox consolidation** — LLM-powered dedup and categorization when inbox hits threshold
 - **Knowledge base classification** — auto-assigns category to consolidated notes

--- a/docs/pr-review-fix-loop.md
+++ b/docs/pr-review-fix-loop.md
@@ -52,7 +52,7 @@ How the engine manages the lifecycle of a PR from creation through review, fix, 
 
 ## 6. Re-review cycle
 
-- Poller (~3min): detects new commit (`head.sha` changed) → sets `lastPushedAt`
+- Poller (every `prPollStatusEvery` ticks, default ~12min): detects new commit (`head.sha` changed) → sets `lastPushedAt`
 - Platform review state drives next action:
   - Reviewer approves → `approved` → done
   - Reviewer re-requests changes → `changes-requested` → triggers another fix

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -158,7 +158,7 @@ Without this, review findings only exist in the inbox file under the reviewer's 
 
 ## 4. Human Feedback on PRs
 
-Humans can leave comments on ADO PRs containing `@minions` to trigger fix tasks. The engine polls PR threads every ~6 minutes and dispatches fixes to the PR's author agent.
+Humans can leave comments on ADO or GitHub PRs containing `@minions` to trigger fix tasks. The engine polls PR threads every ~12 minutes (see `prPollCommentsEvery` in `engine/shared.js`) and dispatches fixes to the PR's author agent.
 
 ### Flow
 

--- a/playbooks/shared-rules.md
+++ b/playbooks/shared-rules.md
@@ -52,7 +52,7 @@ Your context window may be compacted or summarized mid-task by Claude's automati
 
 When asked to check build status, CI results, or review state for a PR:
 
-**Preferred — read cached state (always fresh within ~3 min when engine is running):**
+**Preferred — read cached state (refreshed every `prPollStatusEvery` ticks, default ~12 min when engine is running):**
 Find the PR in `projects/<project-name>/pull-requests.json` by `prNumber`. Key fields:
 - `buildStatus` — `passing` | `failing` | `running` | `none`
 - `buildErrorLog` — compiler/pipeline errors when `buildStatus` is `failing`


### PR DESCRIPTION
## Summary

Weekly documentation sweep. Fixes documentation identifier claims that drifted from the source tree. No engine source touched.

Every fix is anchored to a source-of-truth file:line that contradicted the doc — the premise of the skill is **doc is stale if the cited identifier doesn't match source, period**.

## Stale Claims Fixed

### 1. PR polling cadence (6 ticks / ~6 min → 12)

Default changed from 6 to 12 when `adoPollStatusEvery` / `adoPollCommentsEvery` were renamed to `prPollStatusEvery` / `prPollCommentsEvery` (see `docs/deprecated.json`). 8 doc references never updated.

| Stale doc | Source of truth |
|-----------|-----------------|
| `CLAUDE.md:31` tick-cycle diagram | `engine/shared.js:772-773` — `prPollStatusEvery: 12` |
| `CLAUDE.md:376` "every ~3 min / every ~6 min" | `engine.js:3297,3338` |
| `docs/auto-discovery.md:14,123,328` | Same |
| `docs/human-vs-automated.md:49` "every ~6 min" | Same |
| `docs/self-improvement.md:161` "every ~6 minutes" | Same |
| `docs/pr-review-fix-loop.md:55` "Poller (~3min)" | Same |
| `docs/design-state-storage.md:25,59` "every 6 ticks" | Same |
| `playbooks/shared-rules.md:55` "always fresh within ~3 min" | Same |

### 2. CC session `CC_SESSION_MAX_TURNS = Infinity` — false

Both `CLAUDE.md:403` and `docs/command-center.md:16` claimed no turn cap and no TTL.

**Actual:**
- `dashboard.js:542` — `CC_SESSION_MAX_TURNS = shared.ENGINE_DEFAULTS.ccMaxTurns`
- `dashboard.js:543` — `CC_SESSION_TTL_MS = shared.ENGINE_DEFAULTS.ccSessionTtlMs`
- `engine/shared.js:785` — `ccMaxTurns: 50`
- `engine/shared.js:786` — `ccSessionTtlMs: 2h`

### 3. Claude CLI spawn chain misdocumented

- `docs/auto-discovery.md:248` showed `--output-format json`. Real value is `stream-json` (source: `engine.js:818,1065`; `engine/llm.js:69,118`). Example invocation also used a bash-style single-arg call that doesn't match the stdin-piped `--system-prompt-file` reality.
- `docs/command-center.md:120,147` routed CC/doc-chat through `spawn-agent.js`. They use the direct path in `engine/llm.js` (already correctly documented in `CLAUDE.md:48`). Updated both references.

### 4. `azureauth` command missing flags

`docs/auto-discovery.md:140` had `azureauth ado token --output token --timeout 1`. Actual (source: `engine/ado.js:88`): `azureauth ado token --mode iwa --mode broker --output token --timeout 1`. Added a note that GitHub polling uses `gh` CLI, not azureauth.

### 5. ADO-only framing where GitHub also applies

`docs/auto-discovery.md` had a section titled "## ADO PR Status Polling" and an ASCII node labeled "ADO REST API". GitHub polling is parallel via `engine/github.js` (imported in `engine.js:1505`), both running inside `Promise.allSettled` (`engine.js:3298-3305`) and writing the same per-project `pull-requests.json` schema. Renamed to "PR Status Polling" and "ADO + GitHub REST". Same fix in `docs/human-vs-automated.md:49` and `docs/self-improvement.md:161`.

## What Was NOT Changed

- `docs/blog-first-successful-dispatch.md` — historical blog post; its references to old spawn paths are intentional narrative.
- `README.md` — sidebar page list, CLI reference, config table all match source.
- Other `playbooks/*.md` — template variables verified against `engine/playbook.js`; all clean.
- `docs/deprecated.json` — entries within the 3-day retention window.
- `knowledge/` — per team rule, agents never write to `knowledge/`.

## Test plan

- [x] `npm test` — 2504 passed, 0 failed, 3 skipped
- [x] No `engine/*.js`, `dashboard.js`, or `engine.js` touched
- [x] Each fixed claim carries a source-of-truth file:line
- [x] Branch pushed, no merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)