### PR TITLE
fix: escape </script> literal in utils.js (closes #1746)

### DIFF
--- a/dashboard/js/utils.js
+++ b/dashboard/js/utils.js
@@ -98,9 +98,15 @@ function toggleModalPin() {
 
 // Canonical HTML-escape helper (SEC-03). Use this in all new code and for any user-controlled
 // field that reaches `.innerHTML` / a template literal. Escapes the 6 HTML metacharacters
-// (& < > " ' /) — the `/` escape closes the `</script>` break-out path that a 5-char escape
+// (& < > " ' /) — the `/` escape closes the `<\/script>` break-out path that a 5-char escape
 // leaves open. Returns '' for null/undefined so missing fields never render the literal strings
 // "null"/"undefined". Idempotent for non-metacharacter input (double-escaping only expands `&`).
+// NOTE: the `<\/script>` spelling above is deliberate. dashboard.js inlines every module in
+// dashboard/js/ into a single inline <script> block; a raw closing-script-tag literal in any
+// comment or string closes that block early and spills the rest as document text (issue #1746).
+// The HTML5 tokenizer's script-data end-tag match is byte-level and ignores JS comment/string
+// boundaries, so the only safe way to reference the token in-source is to break the match —
+// `<` followed by `\/` works because after `<` only `/` (not `\`) triggers end-tag-open state.
 function escapeHtml(str) {
   if (str === null || str === undefined) return '';
   return String(str)

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -18929,6 +18929,44 @@ async function testSec03EscapeHtml() {
     }
     assert.ok(total <= DYNAMIC_INNERHTML_BASELINE, `count=${total} <= baseline=${DYNAMIC_INNERHTML_BASELINE}`);
   });
+
+  // ── Regression gate for issue #1746 ─────────────────────────────────────
+  // dashboard.js inlines every dashboard/js/*.js module into a single
+  // `<script>/* __JS__ */</script>` block in layout.html. The HTML tokenizer
+  // scans script-data looking for the byte sequence `</script` followed by
+  // one of `\t \n \f \r ' ' '/' '>'`; comments and string literals don't
+  // matter — it's a raw-text scan. A stray literal `</script>` (even inside
+  // a JS comment) therefore terminates the inline block early and spills the
+  // remaining JS into the document body as visible text.
+  //
+  // Fix when a comment or string needs to reference the token: insert a
+  // backslash between `<` and `/` (`<\/script>`). After `<` the HTML parser
+  // transitions to script-data-less-than-sign state, which only recognizes
+  // `/` (end-tag-open) or `!` (escape-start); `\` is "anything else" and
+  // emits `<` back to script-data state, breaking the match.
+  await test('no dashboard/js/*.js file contains a literal </script> end-tag sequence (issue #1746)', () => {
+    const jsDir = path.join(MINIONS_DIR, 'dashboard', 'js');
+    // Match the HTML5 end-tag rule exactly: `</script` followed by whitespace,
+    // '/', or '>'. Using this (not a bare `</script>`) catches the full set
+    // of byte sequences that would actually close the inline block, including
+    // forms like `</script ` or `</script/>`.
+    const endTagRe = /<\/script[\t\n\f\r \/>]/;
+    const offenders = [];
+    for (const name of fs.readdirSync(jsDir)) {
+      if (!name.endsWith('.js')) continue;
+      const fp = path.join(jsDir, name);
+      const src = fs.readFileSync(fp, 'utf8');
+      if (endTagRe.test(src)) {
+        const lines = src.split('\n');
+        const lineNo = lines.findIndex(l => endTagRe.test(l)) + 1;
+        offenders.push(`${name}:${lineNo}`);
+      }
+    }
+    assert.strictEqual(offenders.length, 0,
+      `Literal </script> end-tag sequence found in: ${offenders.join(', ')}. ` +
+      `Escape it as <\\/script> in comments/strings — the inline dashboard ` +
+      `<script> block will otherwise be terminated early by the HTML parser.`);
+  });
 }
 
 // ─── Dashboard Audit: Medium Bugs ───────────────────────────────────────────


### PR DESCRIPTION
Closes #1746.

## The bug

`dashboard/js/utils.js:101` contained the token `</script>` verbatim inside a line comment (introduced by the SEC-03 Phase A escapeHtml work, PR #1323). `dashboard.js` inlines every `dashboard/js/*.js` module into a single `<script>/* __JS__ */</script>` block in `layout.html`. The HTML5 tokenizer's script-data end-tag scan is byte-level and does **not** honour JS comment or string boundaries — so that literal inside the comment terminated the inline `<script>` block early, and the remainder of the assembled dashboard JS spilled into the document as visible text, breaking the whole dashboard.

## The fix

Rewrite the offending comment (and the new NOTE added beside it) so the token is spelled `<\/script>` instead of `</script>`. After `<` the HTML parser enters *script-data-less-than-sign state*, which only recognises `/` (end-tag-open) or `!` (escape-start). `\` is "anything else" — it emits `<` back to script-data state, so the end-tag match never starts. The backslash is meaningless inside a JS line comment (just bytes), so there is no JS-side effect.

The original `escapeHtml` implementation itself was already correct — only the documentation comment was unsafe.

## Regression gate

Added a unit test in `test/unit.test.js` (inside `testSec03EscapeHtml`) that walks `dashboard/js/` and fails if any file contains the byte sequence `</script` followed by one of `\t \n \f \r ' ' '/' '>'` — the full HTML5 end-tag-close alphabet, not just `</script>` with a trailing `>`. This catches the same bug class in any future comment, string, or template literal, not just this one line.

**TDD confirmation:** the test fails on the pre-fix source (offender: `utils.js:101`) and passes after the fix.

## Test plan

- [x] Reproduced the bug by scanning `dashboard/js/*.js` — the pre-fix source shows `offenders: [ 'utils.js:101' ]`.
- [x] Applied the fix, re-ran the same scan — `offenders: []`.
- [x] Simulated the full inline-script concatenation from `dashboard.js`'s `jsFiles` list and confirmed zero premature `</script` tokens in the assembled body.
- [x] `npm test` — **2799 passed / 0 failed / 3 skipped**, including the new regression test and all existing SEC-03 escapeHtml tests.